### PR TITLE
feat(sitemaps): add sitemaps config

### DIFF
--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://www.openstatus.dev/sitemap.xml",
+  };
+}

--- a/apps/web/src/public/robots.txt
+++ b/apps/web/src/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.openstatus.dev/sitemap.xml

--- a/apps/web/src/public/robots.txt
+++ b/apps/web/src/public/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://www.openstatus.dev/sitemap.xml

--- a/apps/web/src/sitemap.ts
+++ b/apps/web/src/sitemap.ts
@@ -21,14 +21,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
     },
     {
-      url: addPathToBaseURL("/sign-in"),
-      lastModified: new Date(),
-    },
-    {
-      url: addPathToBaseURL("/sign-up"),
-      lastModified: new Date(),
-    },
-    {
       url: addPathToBaseURL("/monitor/openstatus"),
       lastModified: new Date(),
     },

--- a/apps/web/src/sitemap.ts
+++ b/apps/web/src/sitemap.ts
@@ -29,11 +29,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
     },
     {
-      url: addPathToBaseURL("/monitor"),
-      lastModified: new Date(),
-    },
-    {
-      url: addPathToBaseURL("/incident"),
+      url: addPathToBaseURL("/monitor/openstatus"),
       lastModified: new Date(),
     },
   ];

--- a/apps/web/src/sitemap.ts
+++ b/apps/web/src/sitemap.ts
@@ -1,0 +1,40 @@
+import type { MetadataRoute } from "next";
+
+const addPathToBaseURL = (path: string) => `https://openstatus.dev${path}`;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: addPathToBaseURL("/"),
+      lastModified: new Date(),
+    },
+    {
+      url: addPathToBaseURL("/play"),
+      lastModified: new Date(),
+    },
+    {
+      url: addPathToBaseURL("/sign-in"),
+      lastModified: new Date(),
+    },
+    {
+      url: addPathToBaseURL("/sign-up"),
+      lastModified: new Date(),
+    },
+    {
+      url: addPathToBaseURL("/sign-in"),
+      lastModified: new Date(),
+    },
+    {
+      url: addPathToBaseURL("/sign-up"),
+      lastModified: new Date(),
+    },
+    {
+      url: addPathToBaseURL("/monitor"),
+      lastModified: new Date(),
+    },
+    {
+      url: addPathToBaseURL("/incident"),
+      lastModified: new Date(),
+    },
+  ];
+}


### PR DESCRIPTION
After building, this was the results, which can be seen at the endpoint `http://localhost:3000/sitemap.xml`

Here is the current output. Please let me know what you think.

```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<url>
<loc>https://openstatus.dev/</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
<url>
<loc>https://openstatus.dev/play</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
<url>
<loc>https://openstatus.dev/sign-in</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
<url>
<loc>https://openstatus.dev/sign-up</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
<url>
<loc>https://openstatus.dev/sign-in</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
<url>
<loc>https://openstatus.dev/sign-up</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
<url>
<loc>https://openstatus.dev/monitor</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
<url>
<loc>https://openstatus.dev/incident</loc>
<lastmod>2023-07-12T12:20:26.901Z</lastmod>
</url>
</urlset>
```