### PR TITLE
feat: split create update delete actions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@openstatus/tinybird": "workspace:*",
     "@openstatus/upstash": "workspace:*",
     "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-alert-dialog": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.5",
     "@radix-ui/react-hover-card": "^1.0.6",

--- a/apps/web/src/app/_components/submit-button.tsx
+++ b/apps/web/src/app/_components/submit-button.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { experimental_useFormStatus as useFormStatus } from "react-dom";
+
+import { LoadingAnimation } from "@/components/loading-animation";
+import { Button } from "@/components/ui/button";
 
 export function SubmitButton() {
   const { pending } = useFormStatus();
@@ -11,16 +13,7 @@ export function SubmitButton() {
       disabled={pending}
       className="w-20 disabled:opacity-100"
     >
-      {pending ? (
-        // TODO: move into separate file `LoadingAnimation`
-        <div className="flex items-center justify-center gap-1">
-          <div className="direction-alternate bg-primary-foreground h-1 w-1 animate-pulse rounded-full duration-700" />
-          <div className="direction-alternate bg-primary-foreground h-1 w-1 animate-pulse rounded-full delay-150 duration-700" />
-          <div className="direction-alternate bg-primary-foreground h-1 w-1 animate-pulse rounded-full delay-300 duration-700" />
-        </div>
-      ) : (
-        "Join"
-      )}
+      {pending ? <LoadingAnimation /> : "Join"}
     </Button>
   );
 }

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/action-button.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/action-button.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { MoreVertical } from "lucide-react";
+import type * as z from "zod";
+
+import type { insertMonitorSchema } from "@openstatus/db/src/schema";
+
+import { MonitorForm } from "@/components/forms/montitor-form";
+import { LoadingAnimation } from "@/components/loading-animation";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { wait } from "@/lib/utils";
+
+type Schema = z.infer<typeof insertMonitorSchema>;
+
+interface Props {
+  // TODO: use type instead!
+  workspaceId: number;
+  id: number;
+  url: string;
+  name: string;
+  description: string;
+}
+
+// TODO: add correct types
+export function ActionButton({ workspaceId, ...props }: Props) {
+  const router = useRouter();
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [alertOpen, setAlertOpen] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+
+  async function onUpdate(values: Schema) {
+    setSaving(true);
+    await wait(1000); // TODO: update monitor
+    router.refresh();
+    setSaving(false);
+    setDialogOpen(false);
+  }
+
+  async function onDelete() {
+    setSaving(true);
+    await wait(1000); // TODO: delete monitor
+    setSaving(false);
+    setAlertOpen(false);
+  }
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={(value) => setDialogOpen(value)}>
+      <AlertDialog
+        open={alertOpen}
+        onOpenChange={(value) => setAlertOpen(value)}
+      >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              className="absolute right-6 top-6 h-8 w-8 p-0"
+            >
+              <span className="sr-only">Open menu</span>
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DialogTrigger asChild>
+              <DropdownMenuItem>Edit</DropdownMenuItem>
+            </DialogTrigger>
+            <AlertDialogTrigger asChild>
+              <DropdownMenuItem className="text-destructive focus:bg-destructive focus:text-background">
+                Delete
+              </DropdownMenuItem>
+            </AlertDialogTrigger>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete your
+              account and remove your data from our servers.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                onDelete();
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {!saving ? "Delete" : <LoadingAnimation />}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Monitor</DialogTitle>
+          <DialogDescription>Create a monitor</DialogDescription>
+        </DialogHeader>
+        <MonitorForm
+          id="monitor-update"
+          onSubmit={onUpdate}
+          defaultValues={props}
+        />
+        <DialogFooter>
+          <Button
+            type="submit"
+            form="monitor-update"
+            disabled={saving}
+            onSubmit={(e) => {
+              e.preventDefault();
+            }}
+          >
+            {!saving ? "Confirm" : <LoadingAnimation />}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/action-button.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/action-button.tsx
@@ -43,7 +43,6 @@ type Schema = z.infer<typeof insertMonitorSchema>;
 interface Props {
   // TODO: use type instead!
   workspaceId: number;
-  id: number;
   url: string;
   name: string;
   description: string;
@@ -113,6 +112,7 @@ export function ActionButton({ workspaceId, ...props }: Props) {
                 e.preventDefault();
                 onDelete();
               }}
+              disabled={saving}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {!saving ? "Delete" : <LoadingAnimation />}

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/action-button.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/action-button.tsx
@@ -101,8 +101,8 @@ export function ActionButton({ workspaceId, ...props }: Props) {
           <AlertDialogHeader>
             <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete your
-              account and remove your data from our servers.
+              This action cannot be undone. This will permanently delete the
+              monitor.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -122,8 +122,8 @@ export function ActionButton({ workspaceId, ...props }: Props) {
       </AlertDialog>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create Monitor</DialogTitle>
-          <DialogDescription>Create a monitor</DialogDescription>
+          <DialogTitle>Update Monitor</DialogTitle>
+          <DialogDescription>Change your settings.</DialogDescription>
         </DialogHeader>
         <MonitorForm
           id="monitor-update"

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/create-form.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/create-form.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import type * as z from "zod";
+
+import type { insertMonitorSchema } from "@openstatus/db/src/schema";
+
+import { MonitorForm } from "@/components/forms/montitor-form";
+import { LoadingAnimation } from "@/components/loading-animation";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { api } from "@/trpc/client";
+
+interface Props {
+  workspaceId: number;
+}
+
+export function CreateForm({ workspaceId }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+
+  async function onCreate(values: z.infer<typeof insertMonitorSchema>) {
+    setSaving(true);
+    // await api.monitor.getMonitorsByWorkspace.revalidate();
+    await api.monitor.createMonitor.mutate({ ...values, workspaceId });
+    router.refresh();
+    setSaving(false);
+    setOpen(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(value) => setOpen(value)}>
+      <DialogTrigger asChild>
+        <Button>Create</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Monitor</DialogTitle>
+          <DialogDescription>Create a monitor</DialogDescription>
+        </DialogHeader>
+        <MonitorForm id="monitor-create" onSubmit={onCreate} />
+        <DialogFooter>
+          <Button type="submit" form="monitor-create" disabled={saving}>
+            {!saving ? "Confirm" : <LoadingAnimation />}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/create-form.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/_components/create-form.tsx
@@ -46,7 +46,7 @@ export function CreateForm({ workspaceId }: Props) {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create Monitor</DialogTitle>
-          <DialogDescription>Create a monitor</DialogDescription>
+          <DialogDescription>Choose the settings.</DialogDescription>
         </DialogHeader>
         <MonitorForm id="monitor-create" onSubmit={onCreate} />
         <DialogFooter>

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/loading.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/loading.tsx
@@ -1,10 +1,15 @@
 import { Container } from "@/components/dashboard/container";
 import { Header } from "@/components/dashboard/header";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Loading() {
   return (
     <div className="grid gap-6 md:grid-cols-2 md:gap-8">
-      <Header.Skeleton />
+      <div className="col-span-full flex w-full justify-between">
+        <Header.Skeleton>
+          <Skeleton className="h-9 w-20" />
+        </Header.Skeleton>
+      </div>
       <Container.Skeleton />
       <Container.Skeleton />
       <Container.Skeleton />

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/page.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/monitors/page.tsx
@@ -2,29 +2,29 @@ import * as React from "react";
 
 import { Container } from "@/components/dashboard/container";
 import { Header } from "@/components/dashboard/header";
-import { MonitorCreateForm } from "@/components/forms/montitor-form";
 import { api } from "@/trpc/server";
+import { ActionButton } from "./_components/action-button";
+import { CreateForm } from "./_components/create-form";
 
 export default async function MonitorPage({
   params,
 }: {
   params: { workspaceId: string };
 }) {
+  const workspaceId = Number(params.workspaceId);
   const monitors = await api.monitor.getMonitorsByWorkspace.query({
-    workspaceId: Number(params.workspaceId),
+    workspaceId,
   });
-  // iterate over monitors
+
   return (
     <div className="grid gap-6 md:grid-cols-2 md:gap-8">
       <Header title="Monitors" description="Overview of all your monitors.">
-        <MonitorCreateForm />
+        <CreateForm {...{ workspaceId }} />
       </Header>
       {monitors.map((monitor, index) => (
-        <Container
-          key={index}
-          title={monitor.url}
-          description={monitor.name}
-        ></Container>
+        <Container key={index} title={monitor.name} description={monitor.url}>
+          <ActionButton {...{ ...monitor, workspaceId }} />
+        </Container>
       ))}
     </div>
   );

--- a/apps/web/src/app/app/(dashboard)/[workspaceId]/status-pages/loading.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceId]/status-pages/loading.tsx
@@ -1,10 +1,15 @@
 import { Container } from "@/components/dashboard/container";
 import { Header } from "@/components/dashboard/header";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Loading() {
   return (
     <div className="grid gap-6 md:grid-cols-2 md:gap-8">
-      <Header.Skeleton />
+      <div className="col-span-full flex w-full justify-between">
+        <Header.Skeleton>
+          <Skeleton className="h-9 w-20" />
+        </Header.Skeleton>
+      </div>
       <Container.Skeleton />
       <Container.Skeleton />
       <Container.Skeleton />

--- a/apps/web/src/app/discord/page.tsx
+++ b/apps/web/src/app/discord/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DiscordRedirect() {
+  return redirect("https://discord.gg/eGXPrdGe");
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,14 +1,26 @@
 import Link from "next/link";
 
+import { Header } from "@/components/dashboard/header";
+import { Shell } from "@/components/dashboard/shell";
+import { Button } from "@/components/ui/button";
+
 export default function NotFound() {
   return (
     <main className="flex min-h-screen w-full flex-col space-y-6 p-4 md:p-8">
       <div className="flex flex-1 flex-col items-center justify-center gap-8">
         <div className="mx-auto max-w-xl text-center">
-          <div className="border-border rounded-lg border p-8 backdrop-blur-[2px]">
-            <h2>Not Found 😭</h2>
-            <p>This page could not be found</p>
-          </div>
+          <Shell>
+            <div className="flex flex-col gap-4 p-12">
+              <Header
+                title="404"
+                description="Sorry, this page could not be found."
+              />
+              {/* could think of redirecting the user to somewhere else! */}
+              <Button variant="link" asChild>
+                <Link href="/">Homepage</Link>
+              </Button>
+            </div>
+          </Shell>
         </div>
       </div>
     </main>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -13,11 +13,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
     },
     {
-      url: addPathToBaseURL("/sign-in"),
+      url: addPathToBaseURL("/app/sign-in"),
       lastModified: new Date(),
     },
     {
-      url: addPathToBaseURL("/sign-up"),
+      url: addPathToBaseURL("/app/sign-up"),
       lastModified: new Date(),
     },
     {

--- a/apps/web/src/app/status-page/[domain]/layout.tsx
+++ b/apps/web/src/app/status-page/[domain]/layout.tsx
@@ -1,0 +1,13 @@
+export default function StatusPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="flex min-h-screen w-full flex-col space-y-6 p-4 md:p-8">
+      <div className="flex flex-1 flex-col items-center justify-center gap-8">
+        <div className="mx-auto max-w-xl text-center">{children}</div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/status-page/[domain]/page.tsx
+++ b/apps/web/src/app/status-page/[domain]/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 
+import { Header } from "@/components/dashboard/header";
+import { Shell } from "@/components/dashboard/shell";
 import { MonitorList } from "@/components/status-page/monitor-list";
 import { api } from "@/trpc/server";
 
@@ -13,20 +15,11 @@ export default async function Page({ params }: { params: { domain: string } }) {
   }
 
   return (
-    <main className="flex min-h-screen w-full flex-col space-y-6 p-4 md:p-8">
-      <div className="flex flex-1 flex-col items-center justify-center gap-8">
-        <div className="mx-auto max-w-xl text-center">
-          <div className="border-border rounded-lg border p-8 backdrop-blur-[2px]">
-            <h1 className="text-foreground font-cal mb-6 mt-2 text-3xl">
-              {page.title}
-            </h1>
-            <div>
-              <p className="text-muted-foreground">{page.description}</p>
-            </div>
-          </div>
-          <MonitorList monitors={page.monitors} />
-        </div>
+    <Shell>
+      <div className="grid gap-4">
+        <Header title={page.title} description={page.description} />
+        <MonitorList monitors={page.monitors} />
       </div>
-    </main>
+    </Shell>
   );
 }

--- a/apps/web/src/components/dashboard/container.tsx
+++ b/apps/web/src/components/dashboard/container.tsx
@@ -16,8 +16,10 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 function Container({ title, description, className, children }: CardProps) {
   return (
-    <Card className={cn("border-border/50 w-full shadow-none", className)}>
-      <CardHeader>
+    <Card
+      className={cn("border-border/50 relative w-full shadow-none", className)}
+    >
+      <CardHeader className="mr-12">
         <CardTitle className="text-lg font-medium tracking-normal">
           {title}
         </CardTitle>

--- a/apps/web/src/components/dashboard/header.tsx
+++ b/apps/web/src/components/dashboard/header.tsx
@@ -13,7 +13,7 @@ function Header({ title, description, className, children }: HeaderProps) {
   return (
     <div
       className={cn(
-        "col-span-full mr-12 flex w-full justify-between md:mr-0",
+        "col-span-full mr-12 flex justify-between md:mr-0",
         className,
       )}
     >

--- a/apps/web/src/components/forms/montitor-form.tsx
+++ b/apps/web/src/components/forms/montitor-form.tsx
@@ -32,11 +32,7 @@ type Schema = z.infer<typeof insertMonitorSchema>;
 
 interface Props {
   id: string;
-  defaultValues?: {
-    url: string;
-    name: string;
-    description: string;
-  };
+  defaultValues?: Schema;
   onSubmit: (values: Schema) => Promise<void>;
 }
 

--- a/apps/web/src/components/forms/montitor-form.tsx
+++ b/apps/web/src/components/forms/montitor-form.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { useParams, useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import type * as z from "zod";
 
@@ -12,16 +10,6 @@ import {
   periodicityEnum,
 } from "@openstatus/db/src/schema";
 
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 import {
   Form,
   FormControl,
@@ -32,7 +20,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { api } from "@/trpc/client";
 import {
   Select,
   SelectContent,
@@ -41,143 +28,118 @@ import {
   SelectValue,
 } from "../ui/select";
 
-// EXAMPLE
-export function MonitorCreateForm() {
-  const [saving, setSaving] = React.useState(false);
-  const [open, setOpen] = React.useState(false);
-  const params = useParams();
-  const router = useRouter();
+type Schema = z.infer<typeof insertMonitorSchema>;
 
-  const form = useForm<z.infer<typeof insertMonitorSchema>>({
-    resolver: zodResolver(insertMonitorSchema),
-    defaultValues: {
-      name: "",
-      url: "",
-      description: "",
-      workspaceId: Number(params.workspaceId),
-    },
+interface Props {
+  id: string;
+  defaultValues?: {
+    url: string;
+    name: string;
+    description: string;
+  };
+  onSubmit: (values: Schema) => Promise<void>;
+}
+
+export function MonitorForm({ id, defaultValues, onSubmit }: Props) {
+  const form = useForm<Schema>({
+    resolver: zodResolver(insertMonitorSchema), // too much - we should only validate the values we ask inside of the form!
+    defaultValues,
   });
 
-  // either like that or with a user action
-  async function onSubmit(values: z.infer<typeof insertMonitorSchema>) {
-    setSaving(true);
-    // await api.monitor.getMonitorsByWorkspace.revalidate();
-    await api.monitor.createMonitor.mutate(values);
-    router.refresh();
-    setOpen(false);
-    setSaving(false);
-  }
-
   return (
-    <Dialog open={open} onOpenChange={(value) => setOpen(value)}>
-      <DialogTrigger asChild>
-        <Button>Create</Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Create Monitor</DialogTitle>
-          <DialogDescription>Create a monitor</DialogDescription>
-        </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} id="monitor">
-            <div className="grid w-full items-center  space-y-6">
-              <FormField
-                control={form.control}
-                name="url"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>URL</FormLabel>
-                    <FormControl>
-                      <Input placeholder="" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      This is url you want to monitor.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Name</FormLabel>
-                    <FormControl>
-                      <Input placeholder="" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      The name of the monitor that will be displayed.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="description"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Description</FormLabel>
-                    <FormControl>
-                      <Input placeholder="" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Give your user some information about it.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="periodicity"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <Select
-                      onValueChange={(value) =>
-                        field.onChange(periodicityEnum.parse(value))
-                      }
-                      defaultValue={field.value}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="How often it should check" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="1m" disabled>
-                          1 minute
-                        </SelectItem>
-                        <SelectItem value="5m" disabled>
-                          5 minutes
-                        </SelectItem>
-                        <SelectItem value="10m">10 minutes</SelectItem>
-                        <SelectItem value="30m" disabled>
-                          30 minutes
-                        </SelectItem>
-                        <SelectItem value="1h" disabled>
-                          1 hour
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormDescription>
-                      You can manage email addresses in your{" "}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          </form>
-        </Form>
-        <DialogFooter>
-          <Button type="submit" form="monitor" disabled={saving}>
-            {!saving ? "Confirm" : <Loader2 className="h-4 w-4 animate-spin" />}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} id={id}>
+        <div className="grid w-full items-center space-y-6">
+          <FormField
+            control={form.control}
+            name="url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>URL</FormLabel>
+                <FormControl>
+                  <Input placeholder="" {...field} />
+                </FormControl>
+                <FormDescription>
+                  This is url you want to monitor.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="" {...field} />
+                </FormControl>
+                <FormDescription>
+                  The name of the monitor that will be displayed.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Input placeholder="" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Give your user some information about it.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="periodicity"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <Select
+                  onValueChange={(value) =>
+                    field.onChange(periodicityEnum.parse(value))
+                  }
+                  defaultValue={field.value}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="How often it should check" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="1m" disabled>
+                      1 minute
+                    </SelectItem>
+                    <SelectItem value="5m" disabled>
+                      5 minutes
+                    </SelectItem>
+                    <SelectItem value="10m">10 minutes</SelectItem>
+                    <SelectItem value="30m" disabled>
+                      30 minutes
+                    </SelectItem>
+                    <SelectItem value="1h" disabled>
+                      1 hour
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  You can manage email addresses in your{" "}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </form>
+    </Form>
   );
 }

--- a/apps/web/src/components/forms/montitor-form.tsx
+++ b/apps/web/src/components/forms/montitor-form.tsx
@@ -43,7 +43,11 @@ interface Props {
 export function MonitorForm({ id, defaultValues, onSubmit }: Props) {
   const form = useForm<Schema>({
     resolver: zodResolver(insertMonitorSchema), // too much - we should only validate the values we ask inside of the form!
-    defaultValues,
+    defaultValues: {
+      url: defaultValues?.url || "",
+      name: defaultValues?.name || "",
+      description: defaultValues?.description || "",
+    },
   });
 
   return (

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -1,16 +1,27 @@
+"use client";
+
 import Link from "next/link";
-import { UserButton } from "@clerk/nextjs";
+import { UserButton, useUser } from "@clerk/nextjs";
+
+import { Skeleton } from "../ui/skeleton";
 
 export function AppHeader() {
+  const { isLoaded, isSignedIn } = useUser();
+
   return (
-    <header className="z-10 flex w-full items-center justify-between">
+    // use `h-8` to avoid header layout shift on load
+    <header className="z-10 flex h-8 w-full items-center justify-between">
       <Link
         href="/"
         className="font-cal text-muted-foreground hover:text-foreground text-lg"
       >
         openstatus
       </Link>
-      <UserButton />
+      {!isLoaded && !isSignedIn ? (
+        <Skeleton className="h-8 w-8 rounded-full" />
+      ) : (
+        <UserButton />
+      )}
     </header>
   );
 }

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -12,9 +12,9 @@ export function AppSidebar() {
   const params = useParams();
   return (
     <ul className="grid gap-1">
-      {pagesConfig.map(({ title, href, icon }) => {
+      {pagesConfig.map(({ title, href, icon, disabled }) => {
         const Icon = Icons[icon];
-        const link = `/app/${params.workspaceId}${href}`; // TODO: add
+        const link = `/app/${params.workspaceId}${href}`;
         return (
           <li key={title} className="w-full">
             <Link
@@ -23,6 +23,7 @@ export function AppSidebar() {
                 "hover:bg-muted/50 hover:text-foreground text-muted-foreground group flex w-full min-w-[200px] items-center rounded-md border border-transparent px-3 py-1",
                 pathname === link &&
                   "bg-muted/50 border-border text-foreground",
+                disabled && "pointer-events-none opacity-60",
               )}
             >
               <Icon className={cn("mr-2 h-4 w-4")} />

--- a/apps/web/src/components/loading-animation.tsx
+++ b/apps/web/src/components/loading-animation.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+
+type Props = React.HTMLAttributes<HTMLDivElement>;
+
+export function LoadingAnimation({ className, ...props }: Props) {
+  return (
+    <div
+      className={cn("flex items-center justify-center gap-1", className)}
+      {...props}
+    >
+      <div className="direction-alternate bg-primary-foreground h-1 w-1 animate-pulse rounded-full duration-700" />
+      <div className="direction-alternate bg-primary-foreground h-1 w-1 animate-pulse rounded-full delay-150 duration-700" />
+      <div className="direction-alternate bg-primary-foreground h-1 w-1 animate-pulse rounded-full delay-300 duration-700" />
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = ({
+  className,
+  ...props
+}: AlertDialogPrimitive.AlertDialogPortalProps) => (
+  <AlertDialogPrimitive.Portal className={cn(className)} {...props} />
+)
+AlertDialogPortal.displayName = AlertDialogPrimitive.Portal.displayName
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, children, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/apps/web/src/config/pages.ts
+++ b/apps/web/src/config/pages.ts
@@ -8,7 +8,7 @@ type Page = {
   disabled?: boolean;
 };
 
-export const pagesConfig = [
+export const pagesConfig: Page[] = [
   {
     title: "Dashboard",
     description: "Get an overview of what's hot.",
@@ -35,4 +35,4 @@ export const pagesConfig = [
     icon: "siren",
   },
   // ...
-] satisfies Page[];
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@radix-ui/react-accordion':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.0.4
+        version: 1.0.4(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-dialog':
         specifier: ^1.0.4
         version: 1.0.4(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
@@ -2048,6 +2051,32 @@ packages:
       '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@types/react': 18.2.12
+      '@types/react-dom': 18.2.5
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-alert-dialog@1.0.4(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-jbfBCRlKYlhbitueOAv7z74PXYeIQmWpKwm3jllsdkw7fGWNkxqP3v0nY9WmOzcPqpQuoorNtvViBgL46n5gVg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.5
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@radix-ui/react-dialog': 1.0.4(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.12)(react@18.2.0)
       '@types/react': 18.2.12
       '@types/react-dom': 18.2.5
       react: 18.2.0


### PR DESCRIPTION
Removed the `Dialog` from the form to be able to nest it inside of Dropdown (see [shadcn doc](https://ui.shadcn.com/docs/components/dialog#notes)).

Updated the `MonitorForm` to allow `defaultValues` for the "Update" action. Same behaviour of `Dialog` opening. Also included the "Delete" action with a `AlertDialog`.

Only issue is, the on save behaviour for the "Update" dialog seems to be broken. Need to check.

Otherwise small visual fixes here and there!

No real database action connected to the clicks yet!
