### PR TITLE
fix: og monitor id

### DIFF
--- a/apps/web/src/app/status-page/[domain]/page.tsx
+++ b/apps/web/src/app/status-page/[domain]/page.tsx
@@ -35,19 +35,20 @@ export default async function Page({ params }: Props) {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const page = await api.page.getPageBySlug.query({ slug: params.domain });
+  const firstMonitor = page?.monitors?.[0]; // temporary solution
 
   return {
     title: page?.title,
     description: page?.description,
     twitter: {
-      images: [`/api/og?monitorId=${page?.id}`],
+      images: [`/api/og?monitorId=${firstMonitor?.id}`],
       card: "summary_large_image",
       title: page?.title,
       description: page?.description,
     },
     openGraph: {
       type: "website",
-      images: [`/api/og?monitorId=${page?.id}`],
+      images: [`/api/og?monitorId=${firstMonitor?.id}`],
       title: page?.title,
       description: page?.description,
     },

--- a/apps/web/src/lib/tb.ts
+++ b/apps/web/src/lib/tb.ts
@@ -15,10 +15,7 @@ const tb = new Tinybird({ token: env.TINY_BIRD_API_KEY });
 // TODO: add security layer
 export async function getResponseListData(
   props: Partial<
-    Pick<
-      ResponseListParams,
-      "siteId" | "region" | "cronTimestamp" | "limit" | "monitorId"
-    >
+    Pick<ResponseListParams, "region" | "cronTimestamp" | "limit" | "monitorId">
   >,
 ) {
   try {

--- a/packages/tinybird/src/validation.ts
+++ b/packages/tinybird/src/validation.ts
@@ -65,7 +65,6 @@ export const tbBuildResponseList = z.object({
  * Params for pipe response_list__v1
  */
 export const tbParameterResponseList = z.object({
-  siteId: z.string().optional().default(""), // REMINDER: remove default once alpha
   monitorId: z.string().default(""), // REMINDER: remove default once alpha
   fromDate: z.number().int().default(0), // always start from a date
   toDate: z.number().int().optional(),


### PR DESCRIPTION
fixes the og for the subdomains. We take the first monitor that we get. No filter, no sorting. This is a temporary fix.