### PR TITLE
fix: update docsRepositoryBase url

### DIFF
--- a/apps/docs/theme.config.tsx
+++ b/apps/docs/theme.config.tsx
@@ -8,7 +8,7 @@ const config: DocsThemeConfig = {
   chat: {
     link: "https://discord.com/invite/dHD4JtSfsn",
   },
-  docsRepositoryBase: "https://github.com/openstatusHQ/openstatus/apps/docs",
+  docsRepositoryBase: "https://github.com/openstatusHQ/openstatus/tree/main/apps/docs",
   footer: {
     text: "OpenStatus Documentation",
   },


### PR DESCRIPTION
This PR fixes the "Edit this page" and "Question? Give us feedback →" link on the documentation.

By changing the `docsRepositoryBase` we not impacting the github link on the navbar, this link is set with the `project.link` property.