### PR TITLE
fix: pattern not repeating & screen overflow due to mouse effect

### DIFF
--- a/apps/web/src/app/_components/background.tsx
+++ b/apps/web/src/app/_components/background.tsx
@@ -13,7 +13,7 @@ export default function Background({
   useMouseMove();
   return (
     <>
-      <div className="fixed -z-50 h-full w-full">
+      <div className="absolute -z-50 h-full w-full">
         <div className="bg-muted-foreground/20 absolute inset-0 z-[-1]" />
         <div className="bg-gradient-radial from-muted-foreground/80 absolute left-[--x] top-[--y] z-[-1] h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full from-0% to-transparent to-90% blur-md" />
         <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">

--- a/apps/web/src/app/_components/background.tsx
+++ b/apps/web/src/app/_components/background.tsx
@@ -14,7 +14,7 @@ export default function Background({
   return (
     <>
       <div className="fixed top-0 left-0 -z-50">
-        <div className="sticky top-0 left-0 -z-50 h-screen w-screen overflow-hidden">
+        <div className="sticky top-0 left-0 h-screen w-screen overflow-hidden">
           <div className="bg-muted-foreground/20 absolute inset-0 z-[-1]" />
           <div className="bg-gradient-radial from-muted-foreground/80 absolute left-[--x] top-[--y] z-[-1] h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full from-0% to-transparent to-90% blur-md" />
           <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">

--- a/apps/web/src/app/_components/background.tsx
+++ b/apps/web/src/app/_components/background.tsx
@@ -13,32 +13,35 @@ export default function Background({
   useMouseMove();
   return (
     <>
-      <div className="sticky top-0 left-0 -z-50 h-screen w-screen overflow-hidden">
-        <div className="bg-muted-foreground/20 absolute inset-0 z-[-1]" />
-        <div className="bg-gradient-radial from-muted-foreground/80 absolute left-[--x] top-[--y] z-[-1] h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full from-0% to-transparent to-90% blur-md" />
-        <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
-          <defs>
-            <pattern
-              id="dotted-pattern"
-              width="16"
-              height="16"
-              patternUnits="userSpaceOnUse"
-            >
-              <circle cx="2" cy="2" r="1" fill="black" />
-            </pattern>
-            <mask id="dots-mask">
-              <rect width="100%" height="100%" fill="white" />
-              <rect width="100%" height="100%" fill="url(#dotted-pattern)" />
-            </mask>
-          </defs>
-          <rect
-            width="100%"
-            height="100%"
-            fill="hsl(var(--background))"
-            mask="url(#dots-mask)"
-          />
-        </svg>
+      <div className="fixed top-0 left-0 -z-50">
+        <div className="sticky top-0 left-0 -z-50 h-screen w-screen overflow-hidden">
+          <div className="bg-muted-foreground/20 absolute inset-0 z-[-1]" />
+          <div className="bg-gradient-radial from-muted-foreground/80 absolute left-[--x] top-[--y] z-[-1] h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full from-0% to-transparent to-90% blur-md" />
+          <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
+            <defs>
+              <pattern
+                id="dotted-pattern"
+                width="16"
+                height="16"
+                patternUnits="userSpaceOnUse"
+              >
+                <circle cx="2" cy="2" r="1" fill="black" />
+              </pattern>
+              <mask id="dots-mask">
+                <rect width="100%" height="100%" fill="white" />
+                <rect width="100%" height="100%" fill="url(#dotted-pattern)" />
+              </mask>
+            </defs>
+            <rect
+              width="100%"
+              height="100%"
+              fill="hsl(var(--background))"
+              mask="url(#dots-mask)"
+            />
+          </svg>
+        </div>
       </div>
+
       {children}
     </>
   );

--- a/apps/web/src/app/_components/background.tsx
+++ b/apps/web/src/app/_components/background.tsx
@@ -13,7 +13,7 @@ export default function Background({
   useMouseMove();
   return (
     <>
-      <div className="absolute -z-50 h-full w-full">
+      <div className="sticky top-0 left-0 -z-50 h-screen w-screen overflow-hidden">
         <div className="bg-muted-foreground/20 absolute inset-0 z-[-1]" />
         <div className="bg-gradient-radial from-muted-foreground/80 absolute left-[--x] top-[--y] z-[-1] h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full from-0% to-transparent to-90% blur-md" />
         <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">


### PR DESCRIPTION
### **Issues:**  continue #112 

1. With previous PR merged pattern scrolls with the page due to absolute behaviour.
2. Screen overflows because of the mouse effect and it creates a major UI issue on mobile devices.

**Previous:**
```html
<div className="absolute -z-50 h-full w-full">
```

**Current:**
```html
<div className="sticky top-0 left-0 -z-50 h-screen w-screen overflow-hidden">
```
`sticky top-0 left-0` - fixes (1.) issue by behaving as fixed while sticking to top-0
`w-screen h-screen overflow-hidden` - fixes (2.) issue by avoiding overflow of the parent element

**Issues resolved: 2/2**

### Reference
[issue-2] -- red arrow is the mouse position
<img width="960" alt="image" src="https://github.com/openstatusHQ/openstatus/assets/88406357/123e121b-5082-4d94-a5e3-a79f48b8bdd1">
