### PR TITLE
Fix: eslint import warning on `packages\ui\turbo\generators\config.ts`

### DIFF
--- a/packages/ui/turbo/generators/config.ts
+++ b/packages/ui/turbo/generators/config.ts
@@ -1,4 +1,4 @@
-import { PlopTypes } from "@turbo/gen";
+import type { PlopTypes } from "@turbo/gen";
 
 // Learn more about Turborepo Generators at https://turbo.build/repo/docs/core-concepts/monorepos/code-generation
 


### PR DESCRIPTION
Fix eslint type import warning: _All imports in the declaration are only used as types. Use `import type`._

![image](https://github.com/openstatusHQ/openstatus/assets/75097898/855e9692-31ec-43a1-9f56-46b0d0a8c279)
