### PR TITLE
feat: regex custom domain and input with addons

### DIFF
--- a/apps/web/src/components/forms/custom-domain-form.tsx
+++ b/apps/web/src/components/forms/custom-domain-form.tsx
@@ -18,12 +18,12 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
 import { useDomainStatus } from "@/hooks/use-domain-status";
 import { api } from "@/trpc/client";
 import DomainConfiguration from "../domains/domain-configuration";
 import DomainStatusIcon from "../domains/domain-status-icon";
 import { LoadingAnimation } from "../loading-animation";
+import { InputWithAddons } from "../ui/input-with-addons";
 
 const customDomain = insertPageSchemaWithMonitors.pick({
   customDomain: true,
@@ -89,7 +89,11 @@ export function CustomDomainForm({ defaultValues }: { defaultValues: Schema }) {
               <FormLabel>Custom Domain</FormLabel>
               <FormControl>
                 <div className="flex items-center space-x-3">
-                  <Input placeholder="acme.com" {...field} />
+                  <InputWithAddons
+                    placeholder="acme.com"
+                    leading="https://"
+                    {...field}
+                  />
                   <div className="h-full w-7">
                     {/* TODO: add loading state */}
                     {status ? <DomainStatusIcon status={status} /> : null}

--- a/apps/web/src/components/forms/status-page-form.tsx
+++ b/apps/web/src/components/forms/status-page-form.tsx
@@ -24,6 +24,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { InputWithAddons } from "@/components/ui/input-with-addons";
 import { useToast } from "@/components/ui/use-toast";
 import { useDebounce } from "@/hooks/use-debounce";
 import { slugify } from "@/lib/utils";
@@ -195,7 +196,7 @@ export function StatusPageForm({
             <FormItem className="sm:col-span-3">
               <FormLabel>Slug</FormLabel>
               <FormControl>
-                <Input placeholder="" {...field} />
+                <InputWithAddons {...field} trailing={".openstatus.dev"} />
               </FormControl>
               <FormDescription>
                 The subdomain for your status page. At least 3 chars.

--- a/apps/web/src/components/ui/input-with-addons.tsx
+++ b/apps/web/src/components/ui/input-with-addons.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface InputWithAddonsProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  leading?: React.ReactNode;
+  trailing?: React.ReactNode;
+}
+
+const InputWithAddons = React.forwardRef<
+  HTMLInputElement,
+  InputWithAddonsProps
+>(({ leading, trailing, className, ...props }, ref) => {
+  return (
+    <div className="border-input ring-offset-background focus-within:ring-ring group flex h-10 w-full rounded-md border bg-transparent text-sm focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2">
+      {leading ? (
+        <div className="border-input bg-muted border-r px-3 py-2">
+          {leading}
+        </div>
+      ) : null}
+      <input
+        className={cn(
+          "placeholder:text-muted-foreground w-full rounded-md px-3 py-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+      {trailing ? (
+        <div className="border-input bg-muted border-l px-3 py-2">
+          {trailing}
+        </div>
+      ) : null}
+    </div>
+  );
+});
+InputWithAddons.displayName = "InputWithAddons";
+
+export { InputWithAddons };

--- a/packages/db/src/schema/page.ts
+++ b/packages/db/src/schema/page.ts
@@ -50,15 +50,22 @@ const slugSchema = z
   .min(3)
   .toLowerCase();
 
+const customDomainSchema = z
+  .string()
+  .regex(
+    new RegExp("^(?!https?://|www.)([a-zA-Z0-9]+(.[a-zA-Z0-9]+)+.*)$"),
+    "Should not start with http://, https:// or www.",
+  );
+
 // Schema for inserting a Page - can be used to validate API requests
 export const insertPageSchema = createInsertSchema(page, {
-  customDomain: z.string().optional(),
+  customDomain: customDomainSchema.optional(),
   icon: z.string().optional(),
   slug: slugSchema,
 });
 
 export const insertPageSchemaWithMonitors = insertPageSchema.extend({
-  customDomain: z.string().optional().default(""),
+  customDomain: customDomainSchema.optional().default(""),
   monitors: z.array(z.number()).optional(),
   workspaceSlug: z.string().optional(),
   slug: slugSchema,


### PR DESCRIPTION
Regex to ensure that the input does **not** start with `https://`, `http://` or `www`. Update includes a new `InputWithAddons` component for `trailing` and `leading` text/icon/...

<img width="854" alt="CleanShot 2023-08-23 at 22 03 38@2x" src="https://github.com/openstatusHQ/openstatus/assets/56969857/570c3fcb-6612-4841-b4af-3bbdda8b686c">

<img width="656" alt="CleanShot 2023-08-23 at 22 03 17@2x" src="https://github.com/openstatusHQ/openstatus/assets/56969857/5ac0fb01-4b46-41c7-aa83-e3f368c07267">
