### PR TITLE
fix: only regenerate slug if there is no default

### DIFF
--- a/apps/web/src/components/forms/status-page-form.tsx
+++ b/apps/web/src/components/forms/status-page-form.tsx
@@ -94,10 +94,10 @@ export function StatusPageForm({
   }, [checkUniqueSlug]);
 
   useEffect(() => {
-    if (!watchSlug) {
+    if (!defaultValues?.title) {
       form.setValue("slug", slugify(watchTitle));
     }
-  }, [watchTitle, form, watchSlug]);
+  }, [watchTitle, form, watchSlug, defaultValues?.title]);
 
   const onSubmit = async ({
     ...props

--- a/apps/web/src/components/forms/status-page-form.tsx
+++ b/apps/web/src/components/forms/status-page-form.tsx
@@ -97,7 +97,7 @@ export function StatusPageForm({
     if (!defaultValues?.title) {
       form.setValue("slug", slugify(watchTitle));
     }
-  }, [watchTitle, form, watchSlug, defaultValues?.title]);
+  }, [watchTitle, form, defaultValues?.title]);
 
   const onSubmit = async ({
     ...props

--- a/apps/web/src/components/forms/status-page-form.tsx
+++ b/apps/web/src/components/forms/status-page-form.tsx
@@ -64,6 +64,7 @@ export function StatusPageForm({
   const inputFileRef = useRef<HTMLInputElement>(null);
   const [isPending, startTransition] = useTransition();
   const watchSlug = form.watch("slug");
+  const watchTitle = form.watch("title");
   const debouncedSlug = useDebounce(watchSlug, 1000); // using debounce to not exhaust the server
   const { toast } = useToast();
   const checkUniqueSlug = useCallback(async () => {
@@ -92,12 +93,11 @@ export function StatusPageForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkUniqueSlug]);
 
-  // FIXME: 🐛 This is causing a bug
-  // useEffect(() => {
-  //   if (!watchSlug) {
-  //     form.setValue("slug", slugify(watchTitle));
-  //   }
-  // }, [watchTitle, form, watchSlug]);
+  useEffect(() => {
+    if (!watchSlug) {
+      form.setValue("slug", slugify(watchTitle));
+    }
+  }, [watchTitle, form, watchSlug]);
 
   const onSubmit = async ({
     ...props


### PR DESCRIPTION
Fixes #231 