### PR TITLE
chore: better toast, tracker fix and more

### DIFF
--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/incidents/_components/action-button.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/incidents/_components/action-button.tsx
@@ -30,6 +30,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useToastAction } from "@/hooks/use-toast-action";
 import { api } from "@/trpc/client";
 
 const temporary = insertIncidentSchema.pick({ id: true, workspaceSlug: true });
@@ -38,15 +39,21 @@ type Schema = z.infer<typeof temporary>;
 
 export function ActionButton(props: Schema) {
   const router = useRouter();
+  const { toast } = useToastAction();
   const [alertOpen, setAlertOpen] = React.useState(false);
   const [isPending, startTransition] = React.useTransition();
 
   async function deleteIncident() {
     startTransition(async () => {
-      if (!props.id) return;
-      await api.incident.deleteIncident.mutate({ id: props.id });
-      router.refresh();
-      setAlertOpen(false);
+      try {
+        if (!props.id) return;
+        await api.incident.deleteIncident.mutate({ id: props.id });
+        toast("deleted");
+        router.refresh();
+        setAlertOpen(false);
+      } catch {
+        toast("error");
+      }
     });
   }
 

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/incidents/_components/delete-incident-update.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/incidents/_components/delete-incident-update.tsx
@@ -17,18 +17,25 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { useToastAction } from "@/hooks/use-toast-action";
 import { api } from "@/trpc/client";
 
 export function DeleteIncidentUpdateButtonIcon({ id }: { id: number }) {
   const router = useRouter();
+  const { toast } = useToastAction();
   const [alertOpen, setAlertOpen] = React.useState(false);
   const [isPending, startTransition] = React.useTransition();
 
   async function onDelete() {
     startTransition(async () => {
-      await api.incident.deleteIncidentUpdate.mutate({ id });
-      router.refresh();
-      setAlertOpen(false);
+      try {
+        await api.incident.deleteIncidentUpdate.mutate({ id });
+        toast("deleted");
+        router.refresh();
+        setAlertOpen(false);
+      } catch {
+        toast("error");
+      }
     });
   }
 

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/monitors/_components/action-button.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/monitors/_components/action-button.tsx
@@ -27,21 +27,28 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useToastAction } from "@/hooks/use-toast-action";
 import { api } from "@/trpc/client";
 
 type Schema = z.infer<typeof insertMonitorSchema>;
 
 export function ActionButton(props: Schema & { workspaceSlug: string }) {
   const router = useRouter();
+  const { toast } = useToastAction();
   const [alertOpen, setAlertOpen] = React.useState(false);
   const [isPending, startTransition] = React.useTransition();
 
   async function onDelete() {
     startTransition(async () => {
-      if (!props.id) return;
-      await api.monitor.deleteMonitor.mutate({ id: props.id });
-      router.refresh();
-      setAlertOpen(false);
+      try {
+        if (!props.id) return;
+        await api.monitor.deleteMonitor.mutate({ id: props.id });
+        toast("deleted");
+        router.refresh();
+        setAlertOpen(false);
+      } catch {
+        toast("error");
+      }
     });
   }
 

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/_components/action-button.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/_components/action-button.tsx
@@ -27,6 +27,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useToastAction } from "@/hooks/use-toast-action";
 import { api } from "@/trpc/client";
 
 type PageSchema = z.infer<typeof insertPageSchemaWithMonitors>;
@@ -37,15 +38,21 @@ interface ActionButtonProps {
 
 export function ActionButton({ page }: ActionButtonProps) {
   const router = useRouter();
+  const { toast } = useToastAction();
   const [alertOpen, setAlertOpen] = React.useState(false);
   const [isPending, startTransition] = React.useTransition();
 
   async function onDelete() {
     startTransition(async () => {
-      if (!page.id) return;
-      await api.page.deletePage.mutate({ id: page.id });
-      router.refresh();
-      setAlertOpen(false);
+      try {
+        if (!page.id) return;
+        await api.page.deletePage.mutate({ id: page.id });
+        toast("deleted");
+        router.refresh();
+        setAlertOpen(false);
+      } catch {
+        toast("error");
+      }
     });
   }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -50,14 +50,16 @@ export default async function Page() {
           <Button asChild variant="outline" className="rounded-full">
             <Link href="/play">Playground</Link>
           </Button>
-          {data && (
-            <Tracker
-              data={data}
-              id="openstatusPing"
-              name="Ping"
-              url="https://www.openstatus.dev/api/ping"
-            />
-          )}
+          <div className="mx-auto max-w-md">
+            {data && (
+              <Tracker
+                data={data}
+                id="openstatusPing"
+                name="Ping"
+                url="https://www.openstatus.dev/api/ping"
+              />
+            )}
+          </div>
         </Shell>
         <Cards />
         <Plans />

--- a/apps/web/src/app/play/page.tsx
+++ b/apps/web/src/app/play/page.tsx
@@ -34,14 +34,16 @@ export default async function PlayPage({
       <p className="text-muted-foreground text-lg font-light">
         Build your own within seconds.
       </p>
-      {data && (
-        <Tracker
-          data={data}
-          id="openstatusPing"
-          name="Ping"
-          url="https://www.openstatus.dev/api/ping"
-        />
-      )}
+      <div className="mx-auto w-full max-w-md">
+        {data && (
+          <Tracker
+            data={data}
+            id="openstatusPing"
+            name="Ping"
+            url="https://www.openstatus.dev/api/ping"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/forms/incident-form.tsx
+++ b/apps/web/src/components/forms/incident-form.tsx
@@ -32,8 +32,8 @@ import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { useToast } from "@/components/ui/use-toast";
 import { statusDict } from "@/data/incidents-dictionary";
+import { useToastAction } from "@/hooks/use-toast-action";
 import { api } from "@/trpc/client";
 
 // include update on creation
@@ -71,7 +71,7 @@ export function IncidentForm({
   });
   const router = useRouter();
   const [isPending, startTransition] = React.useTransition();
-  const { toast } = useToast();
+  const { toast } = useToastAction();
 
   const onSubmit = ({ ...props }: IncidentProps) => {
     startTransition(async () => {
@@ -97,13 +97,10 @@ export function IncidentForm({
             });
           }
         }
-        router.push("./");
+        toast("saved");
         router.refresh();
       } catch {
-        toast({
-          title: "Something went wrong.",
-          description: "Please try again.",
-        });
+        toast("error");
       }
     });
   };

--- a/apps/web/src/components/forms/incident-update-form.tsx
+++ b/apps/web/src/components/forms/incident-update-form.tsx
@@ -29,8 +29,8 @@ import {
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { useToast } from "@/components/ui/use-toast";
 import { statusDict } from "@/data/incidents-dictionary";
+import { useToastAction } from "@/hooks/use-toast-action";
 import { api } from "@/trpc/client";
 
 // TODO: for UX, using the form inside of a Dialog feels more suitable
@@ -61,7 +61,7 @@ export function IncidentUpdateForm({
   });
   const router = useRouter();
   const [isPending, startTransition] = React.useTransition();
-  const { toast } = useToast();
+  const { toast } = useToastAction();
 
   const onSubmit = ({ ...props }: IncidentUpdateProps) => {
     startTransition(async () => {
@@ -71,13 +71,10 @@ export function IncidentUpdateForm({
         } else {
           await api.incident.createIncidentUpdate.mutate({ ...props });
         }
-        router.push("../");
+        toast("saved");
         router.refresh();
       } catch {
-        toast({
-          title: "Something went wrong.",
-          description: "Please try again.",
-        });
+        toast("error");
       }
     });
   };

--- a/apps/web/src/components/forms/montitor-form.tsx
+++ b/apps/web/src/components/forms/montitor-form.tsx
@@ -45,10 +45,10 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { regionsDict } from "@/data/regions-dictionary";
+import { useToastAction } from "@/hooks/use-toast-action";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/client";
 import { LoadingAnimation } from "../loading-animation";
-import { useToast } from "../ui/use-toast";
 
 const cronJobs = [
   { value: "1m", label: "1 minute" },
@@ -85,7 +85,7 @@ export function MonitorForm({
   });
   const router = useRouter();
   const [isPending, startTransition] = React.useTransition();
-  const { toast } = useToast();
+  const { toast } = useToastAction();
 
   const onSubmit = ({ ...props }: MonitorProps) => {
     startTransition(async () => {
@@ -94,18 +94,16 @@ export function MonitorForm({
         if (defaultValues) {
           await api.monitor.updateMonitor.mutate(props);
         } else {
-          await api.monitor.createMonitor.mutate({
+          const monitor = await api.monitor.createMonitor.mutate({
             data: props,
             workspaceSlug,
           });
+          router.replace(`./edit?id=${monitor?.id}`); // to stay on same page and enable 'Advanced' tab
         }
-        router.push("./");
         router.refresh();
+        toast("saved");
       } catch {
-        toast({
-          title: "Something went wrong.",
-          description: "If you are in the limits, please try again.",
-        });
+        toast("error");
       }
     });
   };
@@ -125,7 +123,7 @@ export function MonitorForm({
             <FormItem className="sm:col-span-3">
               <FormLabel>Name</FormLabel>
               <FormControl>
-                <Input placeholder="" {...field} />
+                <Input placeholder="Documenso" {...field} />
               </FormControl>
               <FormDescription>
                 The name of the monitor displayed on the status page.
@@ -141,7 +139,11 @@ export function MonitorForm({
             <FormItem className="sm:col-span-4">
               <FormLabel>URL</FormLabel>
               <FormControl>
-                <Input placeholder="" {...field} />
+                {/* Should we use `InputWithAddons here? */}
+                <Input
+                  placeholder="https://documenso.com/api/health"
+                  {...field}
+                />
               </FormControl>
               <FormDescription>
                 Here is the URL you want to monitor.{" "}
@@ -157,7 +159,10 @@ export function MonitorForm({
             <FormItem className="sm:col-span-5">
               <FormLabel>Description</FormLabel>
               <FormControl>
-                <Input placeholder="" {...field} />
+                <Input
+                  placeholder="Determines the api health of our services."
+                  {...field}
+                />
               </FormControl>
               <FormDescription>
                 Provide your users with information about it.{" "}

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -9,6 +9,14 @@ import { Icons } from "../icons";
 import { Button } from "../ui/button";
 import { Skeleton } from "../ui/skeleton";
 
+/**
+ * TODO: work on a better breadcrumb navigation like Vercel
+ * [workspace/project/deploymenents/deployment]
+ * This will allow us to 'only' save, and not redirect the user to the other pages
+ * and therefore, can after saving the monitor/page go to the next tab!
+ * Probably, we will need to use useSegements() from vercel, but once done properly, it could be really nice to share
+ */
+
 export function AppHeader() {
   const { isLoaded, isSignedIn } = useUser();
 

--- a/apps/web/src/components/layout/skeleton-tabs.tsx
+++ b/apps/web/src/components/layout/skeleton-tabs.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface SkeletonTabsProps {
+  children?: React.ReactNode;
+}
+
+export function SkeletonTabs({ children }: SkeletonTabsProps) {
+  return (
+    <div className="w-full">
+      <div className="flex items-center border-b">
+        <Skeleton className="h-9 w-16 px-3 py-1.5" />
+        <Skeleton className="h-9 w-16 px-3 py-1.5" />
+      </div>
+      {/* tbd: if children is empty, we could render a skeleton container */}
+      <div className="mt-3">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/status-page/monitor.tsx
+++ b/apps/web/src/components/status-page/monitor.tsx
@@ -23,7 +23,6 @@ export const Monitor = async ({
       url={monitor.url}
       description={monitor.description}
       context="status-page"
-      maxSize={40}
     />
   );
 };

--- a/apps/web/src/components/tracker.tsx
+++ b/apps/web/src/components/tracker.tsx
@@ -20,9 +20,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import useWindowSize from "@/hooks/use-window-size";
 
 // What would be cool is tracker that turn from green to red  depending on the number of errors
-const tracker = cva("h-10 w-1.5 sm:w-2 rounded-full md:w-2.5", {
+const tracker = cva("h-10 rounded-full flex-1", {
   variants: {
     variant: {
       up: "bg-green-500 data-[state=open]:bg-green-600",
@@ -42,10 +43,6 @@ interface TrackerProps {
   id: string | number;
   name: string;
   description?: string;
-  /**
-   * Maximium length of the data array
-   */
-  maxSize?: number;
   context?: "play" | "status-page"; // TODO: we might need to extract those two different use cases - for now it's ok I'd say.
 }
 
@@ -54,10 +51,11 @@ export function Tracker({
   url,
   id,
   name,
-  maxSize = 35,
   context = "play",
   description,
 }: TrackerProps) {
+  const { isMobile } = useWindowSize();
+  const maxSize = React.useMemo(() => (isMobile ? 35 : 45), [isMobile]); // TODO: it is better than how it is currently, but creates a small content shift on first render
   const slicedData = data.slice(0, maxSize).reverse();
   const placeholderData: null[] = Array(maxSize).fill(null);
 
@@ -79,8 +77,8 @@ export function Tracker({
       : "";
 
   return (
-    <div className="mx-auto max-w-max">
-      <div className="mb-1 flex justify-between text-sm sm:mb-2">
+    <div className="flex flex-col">
+      <div className="mb-2 flex justify-between text-sm">
         <div className="flex items-center gap-2">
           <p className="text-foreground font-semibold">{name}</p>
           {description ? (
@@ -89,13 +87,14 @@ export function Tracker({
         </div>
         <p className="text-muted-foreground font-light">{uptime}</p>
       </div>
-      <div className="relative">
-        <div className="z-[-1] flex gap-0.5">
-          {placeholderData.map((_, i) => {
-            return <div key={i} className={tracker({ variant: "empty" })} />;
-          })}
-        </div>
-        <div className="absolute right-0 top-0 flex gap-0.5">
+      <div className="relative h-full w-full">
+        <div className="flex gap-0.5">
+          {Array(placeholderData.length - slicedData.length)
+            .fill(null)
+            .map((_, i) => {
+              // TODO: use `Bar` component and `HoverCard` with empty state
+              return <div key={i} className={tracker({ variant: "empty" })} />;
+            })}
           {slicedData.map((props) => {
             return (
               <Bar key={props.cronTimestamp} context={context} {...props} />

--- a/apps/web/src/components/ui/use-toast.ts
+++ b/apps/web/src/components/ui/use-toast.ts
@@ -135,7 +135,7 @@ function dispatch(action: Action) {
   });
 }
 
-type Toast = Omit<ToasterToast, "id">;
+export type Toast = Omit<ToasterToast, "id">;
 
 function toast({ ...props }: Toast) {
   const id = genId();

--- a/apps/web/src/hooks/use-toast-action.tsx
+++ b/apps/web/src/hooks/use-toast-action.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import type { Toast } from "@/components/ui/use-toast";
+
+const config = {
+  error: {
+    title: "Something went wrong.",
+    description: "Please try again.",
+    variant: "destructive",
+    action: (
+      <Button variant="outline" asChild className="text-foreground">
+        <a href="/discord" target="_blank" rel="noreferrer">
+          Discord
+        </a>
+      </Button>
+    ),
+  },
+  "unique-slug": {
+    title: "Slug is already taken.",
+    description: "Please select another slug. Every slug is unique.",
+  },
+  success: { title: "Success" },
+  deleted: { title: "Deleted successfully." }, // TODO: we are not informing the user besides the visual changes when an entry has been deleted
+  saved: { title: "Saved successfully." },
+} as const satisfies Record<string, Toast>;
+
+type ToastAction = keyof typeof config;
+
+export function useToastAction() {
+  const { toast: defaultToast } = useToast();
+
+  function toast(action: ToastAction) {
+    return defaultToast(config[action]);
+  }
+
+  return { toast };
+}

--- a/apps/web/src/hooks/use-window-size.ts
+++ b/apps/web/src/hooks/use-window-size.ts
@@ -1,0 +1,43 @@
+// CREDITS: https://github.com/steven-tey/precedent/blob/main/lib/hooks/use-window-size.ts
+import { useEffect, useState } from "react";
+
+export default function useWindowSize() {
+  const [windowSize, setWindowSize] = useState<{
+    width: number | undefined;
+    height: number | undefined;
+  }>({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    // Handler to call on window resize
+    function handleResize() {
+      // Set window width/height to state
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    // Add event listener
+    window.addEventListener("resize", handleResize);
+
+    // Call handler right away so state gets updated with initial window size
+    handleResize();
+
+    // Remove event listener on cleanup
+    return () => window.removeEventListener("resize", handleResize);
+  }, []); // Empty array ensures that effect is only run on mount
+
+  return {
+    windowSize,
+    isMobile: typeof windowSize?.width === "number" && windowSize?.width < 640,
+    isTablet:
+      typeof windowSize?.width === "number" &&
+      windowSize?.width >= 640 &&
+      windowSize?.width < 1024,
+    isDesktop:
+      typeof windowSize?.width === "number" && windowSize?.width >= 1024,
+  };
+}

--- a/packages/api/src/router/monitor.ts
+++ b/packages/api/src/router/monitor.ts
@@ -70,6 +70,7 @@ export const monitorRouter = createTRPCRouter({
         .returning()
         .get();
 
+      // TODO: check, do we have to await for the two calls? Will slow down user response for our analytics
       await analytics.identify(result.user.id, {
         userId: result.user.id,
       });
@@ -78,6 +79,7 @@ export const monitorRouter = createTRPCRouter({
         url: newMonitor.url,
         periodicity: newMonitor.periodicity,
       });
+      return newMonitor;
     }),
 
   getMonitorByID: protectedProcedure

--- a/packages/api/src/router/page.ts
+++ b/packages/api/src/router/page.ts
@@ -68,6 +68,7 @@ export const pageRouter = createTRPCRouter({
         await opts.ctx.db.insert(monitorsToPages).values(values).run();
       }
 
+      // TODO: check, do we have to await for the two calls? Will slow down user response for our analytics
       await analytics.identify(data.user.id, {
         userId: data.user.id,
       });
@@ -75,6 +76,7 @@ export const pageRouter = createTRPCRouter({
         event: "Page Created",
         slug: newPage.slug,
       });
+      return newPage;
     }),
 
   getPageByID: protectedProcedure


### PR DESCRIPTION
lots of small toast improvements incl. error message with discord support button and extracting in separate component
<img width="943" alt="CleanShot 2023-08-26 at 20 54 45@2x" src="https://github.com/openstatusHQ/openstatus/assets/56969857/be17a639-b0cb-405d-9d06-65d57fc80a67">

fixing ui bug
<img width="354" alt="CleanShot 2023-08-27 at 00 00 25@2x" src="https://github.com/openstatusHQ/openstatus/assets/56969857/712ff15a-eb90-4a68-9e71-45621bcecaee">

fixing empty headers on advanced monitor settings: until now, we would have saved and send the empty header to the endpoint. now checking if the `"key"` is not an empty string.

replace placeholder to "Documenso"

removing redirect to overview page after save
> This needs to discuss. But as we are getting more and more tabs, we should update the way we are navigating! @thibaultleouay