### PR TITLE
Move user to monitor edit from status page.

### DIFF
--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
@@ -76,15 +76,17 @@ export default async function Page({
                 <dd className="flex flex-wrap justify-end gap-2">
                   {page.monitorsToPages.map(
                     ({ monitor: { id, name, active } }) => (
-                      <Badge key={id} variant={active ? "default" : "outline"}>
-                        {name}
-                        <span
-                          className={cn(
-                            "ml-1 inline-block h-1.5 w-1.5 rounded-full",
-                            active ? "bg-green-500" : "bg-red-500",
-                          )}
-                        />
-                      </Badge>
+                      <Link key={id} href={`./monitors/edit?id=${id}`}>
+                        <Badge variant={active ? "default" : "outline"}>
+                          {name}
+                          <span
+                            className={cn(
+                              "ml-1 inline-block h-1.5 w-1.5 rounded-full",
+                              active ? "bg-green-500" : "bg-red-500",
+                            )}
+                          />
+                        </Badge>
+                      </Link>
                     ),
                   )}
                 </dd>

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
@@ -42,7 +42,7 @@ export default async function Page({
     <div className="grid gap-6 md:grid-cols-2 md:gap-8">
       <Header
         title="Status Page"
-        description="Overview of all your status page."
+        description="Overview of all your status pages."
       >
         <Button asChild={!disableButton} disabled={disableButton}>
           <Link href="./status-pages/edit">Create</Link>


### PR DESCRIPTION
When a user clicks on the monitor from the status page, let's redirect them to the edit page of that particular monitor so they can transition between pages swiftly.

So once `my website` in the image below is clicked, we move them to the monitor edit page of that particular monitor.
<img width="454" alt="image" src="https://github.com/openstatusHQ/openstatus/assets/97001695/a8a2ee1a-a3a4-46ed-972d-6cd71c2de451">
