### PR TITLE
fix: tb homepage cache

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,12 +9,12 @@ import { Plans } from "@/components/marketing/plans";
 import { Tracker } from "@/components/tracker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { getMonitorListData } from "@/lib/tb";
+import { getHomeMonitorListData } from "@/lib/tb";
 
 export const revalidate = 600;
 
 export default async function Page() {
-  const data = await getMonitorListData({ monitorId: "openstatusPing" });
+  const data = await getHomeMonitorListData();
 
   return (
     <MarketingLayout>

--- a/apps/web/src/lib/tb.ts
+++ b/apps/web/src/lib/tb.ts
@@ -3,6 +3,7 @@ import type {
   ResponseListParams,
 } from "@openstatus/tinybird";
 import {
+  getHomeMonitorList,
   getMonitorList,
   getResponseList,
   Tinybird,
@@ -30,6 +31,16 @@ export async function getResponseListData(
 export async function getMonitorListData(props: Partial<MonitorListParams>) {
   try {
     const res = await getMonitorList(tb)(props);
+    return res.data;
+  } catch (e) {
+    console.error(e);
+  }
+  return;
+}
+
+export async function getHomeMonitorListData() {
+  try {
+    const res = await getHomeMonitorList(tb)({ monitorId: "openstatusPing" });
     return res.data;
   } catch (e) {
     console.error(e);

--- a/packages/tinybird/src/client.ts
+++ b/packages/tinybird/src/client.ts
@@ -39,3 +39,19 @@ export function getMonitorList(tb: Tinybird) {
     },
   });
 }
+
+/**
+ * That pipe is used in the homepage to show the status while having cached data
+ * FYI We had 3TB of processed data during August. We will be able to reduce it signifcantly.
+ * The cache is only applied on the homepage.
+ */
+export function getHomeMonitorList(tb: Tinybird) {
+  return tb.buildPipe({
+    pipe: "monitor_list__v0",
+    parameters: tbParameterMonitorList,
+    data: tbBuildMonitorList,
+    opts: {
+      revalidate: 600, // 10 minutes cache
+    },
+  });
+}


### PR DESCRIPTION
We are able to "HIT" the cache (`revalidate: 600` 10 minutes) for the homepage monitor.

<img width="857" alt="CleanShot 2023-09-02 at 18 22 12@2x" src="https://github.com/openstatusHQ/openstatus/assets/56969857/2c822f01-1ade-4fcf-b11d-ed71c840b3a3">
