### PR TITLE
Show tooltip for disabled button

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ ngrok http 3000
 
 Videos to better understand the OpenStatus codebase:
 
-* [The code behind OpenStatus and how it uses Turbopack](https://youtube.com/watch?v=PYfSJATE8v8).
+- [The code behind OpenStatus and how it uses Turbopack](https://youtube.com/watch?v=PYfSJATE8v8).
 
 ## Roadmap
 

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/monitors/page.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/monitors/page.tsx
@@ -7,7 +7,7 @@ import { Container } from "@/components/dashboard/container";
 import { Header } from "@/components/dashboard/header";
 import { Limit } from "@/components/dashboard/limit";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { ButtonWithDisableTooltip } from "@/components/ui/button-with-disable-tooltip";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
 import { ActionButton } from "./_components/action-button";
@@ -32,13 +32,13 @@ export default async function MonitorPage({
   return (
     <div className="grid gap-6 md:grid-cols-2 md:gap-8">
       <Header title="Monitors" description="Overview of all your monitors.">
-        <Button
+        <ButtonWithDisableTooltip
+          tooltip="You reached the limits"
           asChild={!isLimit}
           disabled={isLimit}
-          tooltipContent="You reached your limit"
         >
           <Link href="./monitors/edit">Create</Link>
-        </Button>
+        </ButtonWithDisableTooltip>
       </Header>
       {Boolean(monitors?.length) ? (
         monitors?.map((monitor, index) => (

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/monitors/page.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/monitors/page.tsx
@@ -32,7 +32,11 @@ export default async function MonitorPage({
   return (
     <div className="grid gap-6 md:grid-cols-2 md:gap-8">
       <Header title="Monitors" description="Overview of all your monitors.">
-        <Button asChild={!isLimit} disabled={isLimit}>
+        <Button
+          asChild={!isLimit}
+          disabled={isLimit}
+          tooltipContent="You reached your limit"
+        >
           <Link href="./monitors/edit">Create</Link>
         </Button>
       </Header>

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
@@ -44,7 +44,11 @@ export default async function Page({
         title="Status Page"
         description="Overview of all your status pages."
       >
-        <Button asChild={!disableButton} disabled={disableButton}>
+        <Button
+          asChild={!disableButton}
+          disabled={disableButton}
+          tooltipContent="You reached the limits"
+        >
           <Link href="./status-pages/edit">Create</Link>
         </Button>
       </Header>

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/page.tsx
@@ -8,6 +8,7 @@ import { Header } from "@/components/dashboard/header";
 import { Limit } from "@/components/dashboard/limit";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ButtonWithDisableTooltip } from "@/components/ui/button-with-disable-tooltip";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
 import { ActionButton } from "./_components/action-button";
@@ -44,13 +45,13 @@ export default async function Page({
         title="Status Page"
         description="Overview of all your status pages."
       >
-        <Button
+        <ButtonWithDisableTooltip
+          tooltip="You reached the limits"
           asChild={!disableButton}
           disabled={disableButton}
-          tooltipContent="You reached the limits"
         >
           <Link href="./status-pages/edit">Create</Link>
-        </Button>
+        </ButtonWithDisableTooltip>
       </Header>
       {Boolean(pages?.length) ? (
         pages?.map((page, index) => (

--- a/apps/web/src/components/ui/button-with-disable-tooltip.tsx
+++ b/apps/web/src/components/ui/button-with-disable-tooltip.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { Button } from "./button";
 import type { ButtonProps } from "./button";
 import {
@@ -30,7 +31,9 @@ export const ButtonWithDisableTooltip = ({
     return (
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger>{ButtonComponent}</TooltipTrigger>
+          <TooltipTrigger asChild>
+            <span tabIndex={0}>{ButtonComponent}</span>
+          </TooltipTrigger>
           <TooltipContent>{tooltip}</TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/apps/web/src/components/ui/button-with-disable-tooltip.tsx
+++ b/apps/web/src/components/ui/button-with-disable-tooltip.tsx
@@ -16,7 +16,13 @@ export const ButtonWithDisableTooltip = ({
   disabled,
   ...props
 }: ButtonWithDisableTooltipProps) => {
-  const ButtonComponent = <Button {...props} disabled={disabled} />;
+  const ButtonComponent = (
+    <Button
+      {...props}
+      disabled={disabled}
+      className={cn(disabled && "pointer-events-none")}
+    />
+  );
 
   if (disabled) {
     // If the button is disabled, we wrap it in a tooltip since

--- a/apps/web/src/components/ui/button-with-disable-tooltip.tsx
+++ b/apps/web/src/components/ui/button-with-disable-tooltip.tsx
@@ -1,0 +1,35 @@
+import { Button } from "./button";
+import type { ButtonProps } from "./button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
+
+interface ButtonWithDisableTooltipProps extends ButtonProps {
+  tooltip: string;
+}
+
+export const ButtonWithDisableTooltip = ({
+  tooltip,
+  disabled,
+  ...props
+}: ButtonWithDisableTooltipProps) => {
+  const ButtonComponent = <Button {...props} disabled={disabled} />;
+
+  if (disabled) {
+    // If the button is disabled, we wrap it in a tooltip since
+    // we don't want to show the tooltip if the button is enabled.
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>{ButtonComponent}</TooltipTrigger>
+          <TooltipContent>{tooltip}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return ButtonComponent;
+};

--- a/apps/web/src/components/ui/button-with-disable-tooltip.tsx
+++ b/apps/web/src/components/ui/button-with-disable-tooltip.tsx
@@ -15,13 +15,14 @@ interface ButtonWithDisableTooltipProps extends ButtonProps {
 export const ButtonWithDisableTooltip = ({
   tooltip,
   disabled,
+  className,
   ...props
 }: ButtonWithDisableTooltipProps) => {
   const ButtonComponent = (
     <Button
       {...props}
       disabled={disabled}
-      className={cn(disabled && "pointer-events-none")}
+      className={cn(className, disabled && "pointer-events-none")}
     />
   );
 

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,6 +4,12 @@ import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
@@ -39,18 +45,48 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  tooltipContent?: string;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      tooltipContent,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : "button";
-    return (
+    const ButtonToReturn = (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        disabled={disabled}
         {...props}
       />
     );
+
+    if (disabled && tooltipContent) {
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <span tabIndex={0}>{ButtonToReturn}</span>
+            </TooltipTrigger>
+            <TooltipContent className="text-xs">
+              {tooltipContent}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    }
+
+    return ButtonToReturn;
   },
 );
 Button.displayName = "Button";

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,12 +4,6 @@ import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "./tooltip";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
@@ -45,24 +39,12 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
-  tooltipContent?: string;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      className,
-      variant,
-      size,
-      asChild = false,
-      tooltipContent,
-      disabled,
-      ...props
-    },
-    ref,
-  ) => {
+  ({ className, variant, size, asChild = false, disabled, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    const ButtonToReturn = (
+    return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
@@ -70,23 +52,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       />
     );
-
-    if (disabled && tooltipContent) {
-      return (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger>
-              <span tabIndex={0}>{ButtonToReturn}</span>
-            </TooltipTrigger>
-            <TooltipContent className="text-xs">
-              {tooltipContent}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      );
-    }
-
-    return ButtonToReturn;
   },
 );
 Button.displayName = "Button";


### PR DESCRIPTION
When a button is disabled, show additional tooltip content to the the user indicating why the button has been disabled.