### PR TITLE
redirect to monitor creation form from status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ ngrok http 3000
 
 Videos to better understand the OpenStatus codebase:
 
-* [The code behind OpenStatus and how it uses Turbopack](https://youtube.com/watch?v=PYfSJATE8v8).
+- [The code behind OpenStatus and how it uses Turbopack](https://youtube.com/watch?v=PYfSJATE8v8).
 
 ## Roadmap
 

--- a/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/_components/empty-state.tsx
+++ b/apps/web/src/app/app/(dashboard)/[workspaceSlug]/status-pages/_components/empty-state.tsx
@@ -20,7 +20,7 @@ export function EmptyState({
         description="First create a monitor before creating a page."
         action={
           <Button asChild>
-            <Link href="./monitors">Go to monitors</Link>
+            <Link href="./monitors/edit">Create a monitor</Link>
           </Button>
         }
       />


### PR DESCRIPTION
When the user has no active monitors and is on the status page, rather than redirecting to the monitors page, let's move the user straight to the monitor creation form, skipping one step!