### PR TITLE
fix(opengraph): remove unnecessary bracket in metadata

### DIFF
--- a/apps/web/src/app/status-page/[domain]/page.tsx
+++ b/apps/web/src/app/status-page/[domain]/page.tsx
@@ -55,8 +55,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     twitter: {
       ...twitterMetadata,
       images: [
-        `/api/og?monitorId=${firstMonitor?.id}&title=${page?.title}&description=${
-          page?.description || `The ${page?.title} status page}`
+        `/api/og?monitorId=${firstMonitor?.id}&title=${page?.title}&description=${page?.description || `The ${page?.title} status page`
         }`,
       ],
       title: page?.title,
@@ -65,8 +64,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     openGraph: {
       ...ogMetadata,
       images: [
-        `/api/og?monitorId=${firstMonitor?.id}&title=${page?.title}&description=${
-          page?.description || `The ${page?.title} status page}`
+        `/api/og?monitorId=${firstMonitor?.id}&title=${page?.title}&description=${page?.description || `The ${page?.title} status page`
         }`,
       ],
       title: page?.title,


### PR DESCRIPTION
Hey there! 👋 

Just registered and configured my first monitor and while sharing it with the team on Slack, I noticed there was an extra bracket in the generated opengraph metadata. :)

![CleanShot 2023-10-01 at 19 06 11@2x](https://github.com/openstatusHQ/openstatus/assets/35616365/8fcee589-f016-4c91-a344-5100e4eace9e)

Thanks a lot, that is an useful & great looking tool!