### PR TITLE
feat: adding sitemap for docs

### DIFF
--- a/apps/docs/next-sitemap.config.js
+++ b/apps/docs/next-sitemap.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.SITE_URL || "https://docs.openstatus.dev/",
+  generateRobotsTxt: true,
+};

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,6 +3,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "onegobuild": "next build && next-sitemap",
+    "postbuild": "next-sitemap",
     "start": "next start"
   },
   "repository": {
@@ -13,6 +15,7 @@
   "dependencies": {
     "@vercel/analytics": "1.0.1",
     "next": "13.4.19",
+    "next-sitemap": "^4.2.3",
     "nextra": "2.13.1",
     "nextra-theme-docs": "2.13.1",
     "react": "18.2.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "onegobuild": "next build && next-sitemap",
+    "build:sitemap": "next build && next-sitemap",
     "postbuild": "next-sitemap",
     "start": "next start"
   },
@@ -15,7 +15,7 @@
   "dependencies": {
     "@vercel/analytics": "1.0.1",
     "next": "13.4.19",
-    "next-sitemap": "^4.2.3",
+    "next-sitemap": "4.2.3",
     "nextra": "2.13.1",
     "nextra-theme-docs": "2.13.1",
     "react": "18.2.0",

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://docs.openstatus.dev/
+
+# Sitemaps
+Sitemap: https://docs.openstatus.dev/sitemap.xml

--- a/apps/docs/public/sitemap-0.xml
+++ b/apps/docs/public/sitemap-0.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://docs.openstatus.dev</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/developer-guide/get-started</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/developer-guide/requirements</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/developer-guide/setup</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/developer-guide/setup-env</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/getting-started</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/getting-started/alerting</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/getting-started/heartbeat</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/getting-started/monitor</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/getting-started/status-page</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/discord</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/fly</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/otel</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/phone-call</loc><lastmod>2023-10-02T15:53:57.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/slack</loc><lastmod>2023-10-02T15:53:57.200Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/sms</loc><lastmod>2023-10-02T15:53:57.200Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/telegram</loc><lastmod>2023-10-02T15:53:57.200Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/integrations/vercel</loc><lastmod>2023-10-02T15:53:57.200Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/rest-api/auth</loc><lastmod>2023-10-02T15:53:57.200Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://docs.openstatus.dev/rest-api/openapi</loc><lastmod>2023-10-02T15:53:57.200Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://docs.openstatus.dev/sitemap-0.xml</loc></sitemap>
+</sitemapindex>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         specifier: 13.4.19
         version: 13.4.19(@babel/core@7.22.20)(react-dom@18.2.0)(react@18.2.0)
       next-sitemap:
-        specifier: ^4.2.3
+        specifier: 4.2.3
         version: 4.2.3(next@13.4.19)
       nextra:
         specifier: 2.13.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       next:
         specifier: 13.4.19
         version: 13.4.19(@babel/core@7.22.20)(react-dom@18.2.0)(react@18.2.0)
+      next-sitemap:
+        specifier: ^4.2.3
+        version: 4.2.3(next@13.4.19)
       nextra:
         specifier: 2.13.1
         version: 2.13.1(next@13.4.19)(react-dom@18.2.0)(react@18.2.0)
@@ -1256,6 +1259,10 @@ packages:
       oo-ascii-tree: 1.88.0
       ts-pattern: 4.3.0
       type-fest: 3.13.1
+    dev: false
+
+  /@corex/deepmerge@4.0.43:
+    resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
     dev: false
 
   /@cspotcode/source-map-support@0.8.1:
@@ -11182,6 +11189,20 @@ packages:
       next: 13.4.19(@babel/core@7.22.20)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /next-sitemap@4.2.3(next@13.4.19):
+    resolution: {integrity: sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==}
+    engines: {node: '>=14.18'}
+    hasBin: true
+    peerDependencies:
+      next: '*'
+    dependencies:
+      '@corex/deepmerge': 4.0.43
+      '@next/env': 13.5.3
+      fast-glob: 3.3.1
+      minimist: 1.2.8
+      next: 13.4.19(@babel/core@7.22.20)(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
   /next-themes@0.2.1(next@13.4.19)(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
**Issue Resolution for #346**

In order to resolve issue #346, I've successfully implemented the use of the `next-sitemap` package to generate the sitemap.xml for our documentation website.

**Prerequisites:**

1. Create a `.env` file within the `apps\docs` directory and add the following line:
   ```
   SITE_URL=https://docs.openstatus.dev/
   ```

Now, let's delve into the two methods available for generating the sitemap for our documentation:

**Method 1: Conventional Approach (Recommended by `next-sitemap`)**

This method involves two steps:

   a. First, initiate a build process using the command:
      ```
      pnpm build
      ```
   b. Once the build is completed, execute the following command to generate the sitemap:
      ```
      pnpm postbuild
      ```

**Method 2: Streamlined Approach (Recommended)**

For greater efficiency and to minimize the chance of missing steps, we have devised a single command to handle both build and sitemap generation:

   ```
   pnpm onegobuild
   ```

We highly recommend the second approach (Method 2) as it eliminates the possibility of forgetting to run `pnpm postbuild` when new content is added. This ensures a seamless and automated process for keeping our sitemap up to date.

Feel free to use this approach, and if you have any questions or encounter any issues, please don't hesitate to reach out for assistance.
