### PR TITLE
Fix spelling of incident in meta description

### DIFF
--- a/apps/web/src/app/shared-metadata.ts
+++ b/apps/web/src/app/shared-metadata.ts
@@ -1,6 +1,6 @@
 const TITLE = "OpenStatus";
 const DESCRIPTION =
-  "Open-Source synthetic monitoring with incidement management.";
+  "Open-Source synthetic monitoring with incident management.";
 
 export const defaultMetadata = {
   title: TITLE,


### PR DESCRIPTION
# What does this PR do?
This pull request fixes the typo of "incidement" to "incident" in the meta description of the website.

Fixes  #351

## Type of change
- Typo fix

### Extra details
The word "incidement" was incorrectly used instead of "incident" in the shared-metadata.ts file. This commit corrects the spelling and clarifies the meaning of the sentence.