### PR TITLE
Fix overflow issues on mobile for Status Pages

### DIFF
--- a/apps/web/src/app/status-page/[domain]/page.tsx
+++ b/apps/web/src/app/status-page/[domain]/page.tsx
@@ -39,7 +39,7 @@ export default async function Page({ params }: Props) {
   );
 
   return (
-    <div className="grid gap-6">
+    <div className="flex flex-col w-[90%] mx-auto gap-6">
       <Header
         title={page.title}
         description={page.description}

--- a/apps/web/src/app/status-page/[domain]/page.tsx
+++ b/apps/web/src/app/status-page/[domain]/page.tsx
@@ -39,7 +39,7 @@ export default async function Page({ params }: Props) {
   );
 
   return (
-    <div className="flex flex-col w-[90%] mx-auto gap-6">
+    <div className="mx-auto flex w-full flex-col gap-6">
       <Header
         title={page.title}
         description={page.description}

--- a/apps/web/src/components/dashboard/header.tsx
+++ b/apps/web/src/components/dashboard/header.tsx
@@ -20,9 +20,9 @@ function Header({ title, description, className, actions }: HeaderProps) {
       )}
     >
       <div className="flex w-full flex-col gap-1">
-        <h1 className="font-cal truncate text-3xl">{title}</h1>
+        <h1 className="font-cal text-3xl">{title}</h1>
         {description ? (
-          <p className="text-muted-foreground truncate">{description}</p>
+          <p className="text-muted-foreground">{description}</p>
         ) : null}
       </div>
       {actions ? (

--- a/apps/web/src/components/tracker.tsx
+++ b/apps/web/src/components/tracker.tsx
@@ -65,12 +65,14 @@ export function Tracker({
     <div className="flex flex-col">
       <div className="mb-2 flex justify-between text-sm">
         <div className="flex items-center gap-2">
-          <p className="text-foreground font-semibold">{name}</p>
+          <p className="text-foreground line-clamp-1 font-semibold">{name}</p>
           {description ? (
             <MoreInfo {...{ url, id, context, description }} />
           ) : null}
         </div>
-        <p className="text-muted-foreground font-light">{uptime}% uptime</p>
+        <p className="text-muted-foreground shrink-0 font-light">
+          {uptime}% uptime
+        </p>
       </div>
       <div className="relative h-full w-full">
         <div className="flex gap-0.5">


### PR DESCRIPTION
Issue screenshot:
![image](https://github.com/openstatusHQ/openstatus/assets/88056492/6ca4ac1f-5a83-4b68-812f-3b3042379931)

The solution seems to be just moving this to flex box and removing the truncate on the header title and description.