### PR TITLE
Style/toast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ apps/web/tsconfig.tsbuildinfo
 openstatus-test.db
 openstatus-test.db-shm
 openstatus-test.db-wal
+
+#webstorm
+.idea

--- a/apps/web/src/components/forms/monitor-form.tsx
+++ b/apps/web/src/components/forms/monitor-form.tsx
@@ -202,10 +202,13 @@ export function MonitorForm({
   };
 
   const sendTestPing = () => {
+    if (isTestPending) {
+      return;
+    }
     const { url } = form.getValues();
     if (!url) {
       toast("test-warning-empty-url");
-      return false;
+      return;
     }
 
     startTestTransition(async () => {

--- a/apps/web/src/components/forms/monitor-form.tsx
+++ b/apps/web/src/components/forms/monitor-form.tsx
@@ -202,6 +202,12 @@ export function MonitorForm({
   };
 
   const sendTestPing = () => {
+    const { url } = form.getValues();
+    if (!url) {
+      toast("test-warning-empty-url");
+      return false;
+    }
+
     startTestTransition(async () => {
       const isSuccessful = await pingEndpoint();
       if (isSuccessful) {

--- a/apps/web/src/hooks/use-toast-action.tsx
+++ b/apps/web/src/hooks/use-toast-action.tsx
@@ -17,6 +17,7 @@ const config = {
   "unique-slug": {
     title: "Slug is already taken",
     description: "Please select another slug. Every slug is unique.",
+    variant: "warning",
   },
   success: { title: "Success" },
   deleted: { title: "Deleted successfully" }, // TODO: we are not informing the user besides the visual changes when an entry has been deleted
@@ -25,6 +26,11 @@ const config = {
     title: "Connection Failed",
     // description: "Be sure to include the auth headers.",
     variant: "destructive",
+  },
+  "test-warning-empty-url": {
+    title: "URL is Empty",
+    description: "Please enter a valid, non-empty URL",
+    variant: "warning",
   },
   "test-success": {
     title: "Connection Established",

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import * as React from "react";
+import { useMemo } from "react";
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
-import { X } from "lucide-react";
+import { Check, ShieldAlert, X } from "lucide-react";
 
 import { cn } from "../lib/utils";
 
@@ -26,13 +27,13 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "data-[swipe=move]:transition-none group relative pointer-events-auto flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full data-[state=closed]:slide-out-to-right-full",
+  "data-[swipe=move]:transition-none group relative pointer-events-auto flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full data-[state=closed]:slide-out-to-right-full bg-background",
   {
     variants: {
       variant: {
-        default: "bg-background border",
-        destructive:
-          "group destructive border-destructive bg-destructive text-destructive-foreground",
+        default: "",
+        destructive: "",
+        warning: "",
       },
     },
     defaultVariants: {
@@ -40,6 +41,19 @@ const toastVariants = cva(
     },
   },
 );
+
+const toastIconVariant = cva("", {
+  variants: {
+    variant: {
+      default: "bg-green-500",
+      destructive: "bg-destructive",
+      warning: "bg-amber-500",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
@@ -55,6 +69,32 @@ const Toast = React.forwardRef<
   );
 });
 Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastIcon = ({ variant }: VariantProps<typeof toastIconVariant>) => {
+  const Icon = useMemo(() => {
+    switch (variant) {
+      case "destructive":
+        return X;
+
+      case "warning":
+        return ShieldAlert;
+
+      default:
+        return Check;
+    }
+  }, [variant]);
+
+  return (
+    <div
+      className={cn(
+        "h-fit w-fit rounded-full p-2",
+        toastIconVariant({ variant }),
+      )}
+    >
+      <Icon className={"h-4 w-4"} color={"#fff"} />
+    </div>
+  );
+};
 
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
@@ -127,4 +167,5 @@ export {
   ToastDescription,
   ToastClose,
   ToastAction,
+  ToastIcon,
 };

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -31,6 +31,7 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
+        // REMINDER: same keys as toastIconVariant
         default: "",
         destructive: "",
         warning: "",
@@ -91,7 +92,7 @@ const ToastIcon = ({ variant }: VariantProps<typeof toastIconVariant>) => {
         toastIconVariant({ variant }),
       )}
     >
-      <Icon className={"h-4 w-4"} color={"#fff"} />
+      <Icon className="text-background h-4 w-4" />
     </div>
   );
 };

--- a/packages/ui/src/components/toaster.tsx
+++ b/packages/ui/src/components/toaster.tsx
@@ -4,6 +4,7 @@ import {
   Toast,
   ToastClose,
   ToastDescription,
+  ToastIcon,
   ToastProvider,
   ToastTitle,
   ToastViewport,
@@ -17,15 +18,18 @@ export function Toaster() {
     <ToastProvider>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
-          <Toast key={id} {...props}>
-            <div className="grid gap-1">
-              {title && <ToastTitle>{title}</ToastTitle>}
-              {description && (
-                <ToastDescription>{description}</ToastDescription>
-              )}
+          <Toast key={id} {...props} duration={1000000}>
+            <div className="flex w-fit items-center gap-3">
+              <ToastIcon variant={props.variant} />
+              <div className="grid gap-1">
+                {title && <ToastTitle>{title}</ToastTitle>}
+                {description && (
+                  <ToastDescription>{description}</ToastDescription>
+                )}
+              </div>
+              {action}
+              <ToastClose />
             </div>
-            {action}
-            <ToastClose />
           </Toast>
         );
       })}


### PR DESCRIPTION
## Type of change

1. On the "Create Monitor" page, users were able to submit an unlimited number of requests, even if the previous request was still in progress.
2. Added icons to toasts, and they are now displayed according to their specific variant to enhance their visual appeal. 
3. Introduced a new variant called 'warning' to categorize toasts that do not fall under the error or success categories. 
4. During testing, I made sure that if no URL was entered, it would simply display a fail message without any additional context, but we already know the error so better to communicate to user


### I've just started contributing this is my first open-source contribution, I'm open feedback and learn 

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

### Video of Point 4. after fixing and adding Toasts changes

https://github.com/openstatusHQ/openstatus/assets/58404935/049bdfbd-1f78-4b9c-becc-73b3d6dda60d


### Before this PR
<img width="417" alt="test-failed" src="https://github.com/openstatusHQ/openstatus/assets/58404935/89435291-bc46-4c41-a8b7-78f318a5c37f">
<img width="417" alt="test-success" src="https://github.com/openstatusHQ/openstatus/assets/58404935/65d42498-4a78-4df5-a211-675ac031972f">


### After this PR
 
<img width="417" alt="deleted" src="https://github.com/openstatusHQ/openstatus/assets/58404935/98dbf2cc-e8d2-4f99-ac79-918bac4f69c5">
<img width="417" alt="error" src="https://github.com/openstatusHQ/openstatus/assets/58404935/24122fe3-6877-4fb4-b3bf-882f9cd3abf5">
<img width="417" alt="saved" src="https://github.com/openstatusHQ/openstatus/assets/58404935/ca33c03d-f235-4174-aa42-05ab2601d1f1">
<img width="417" alt="success" src="https://github.com/openstatusHQ/openstatus/assets/58404935/d785d7e4-3064-4324-85a5-96c200f005b1">
<img width="417" alt="test-error" src="https://github.com/openstatusHQ/openstatus/assets/58404935/50928858-6927-4cee-8040-b084fc28689b">
<img width="417" alt="test-success" src="https://github.com/openstatusHQ/openstatus/assets/58404935/cc0d553d-60ea-43e3-a0ff-15b8e14fb2bb">
<img width="417" alt="test-warning-empty-url" src="https://github.com/openstatusHQ/openstatus/assets/58404935/d90b3a58-c612-4980-b9ba-c5e58835712d">
<img width="417" alt="unique-slug" src="https://github.com/openstatusHQ/openstatus/assets/58404935/586fe7b7-d3dd-4fa0-a185-7093ebfd37b3">