### PR TITLE
Fix issue when test pinging a monitor endpoint

### DIFF
--- a/apps/web/src/app/api/checker/regions/_checker.ts
+++ b/apps/web/src/app/api/checker/regions/_checker.ts
@@ -123,8 +123,7 @@ export const ping = async (
       ...headers,
     },
     // Avoid having "TypeError: Request with a GET or HEAD method cannot have a body." error
-    ...(data.method !== "GET" &&
-      data.method !== "HEAD" && { body: data?.body }),
+    ...(data.method === "POST" && { body: data?.body }),
   });
 
   return res;

--- a/apps/web/src/app/api/checker/regions/_checker.ts
+++ b/apps/web/src/app/api/checker/regions/_checker.ts
@@ -123,7 +123,8 @@ export const ping = async (
       ...headers,
     },
     // Avoid having "TypeError: Request with a GET or HEAD method cannot have a body." error
-    ...(data.method !== "GET" && { body: data?.body }),
+    ...(data.method !== "GET" &&
+      data.method !== "HEAD" && { body: data?.body }),
   });
 
   return res;


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

Initially when the `HEAD` request method is selected, the body is still passed in to the fetch call which will cause a failure in the ping.

### Before this PR
Testing monitor endpoints with `HEAD` method no fails

### After this PR
Testing monitor endpoints with `HEAD` method no longer fails

### Related Issue (optional)
#409 
<!--- Please link to the issue here: -->
