### PR TITLE
fix broken link in docs - /setup-env

### DIFF
--- a/apps/docs/developer-guide/setup-env.mdx
+++ b/apps/docs/developer-guide/setup-env.mdx
@@ -34,7 +34,7 @@ to Cleark Auth.
 6. Paste these values into the `.env` file under their respective variables. It
    should look something like this (real values without censorship):
 
-![Create your monitor](/img/setup-env/clerk.png)
+![Create your monitor](/images/setup-env/clerk.png)
 
 ```
 # CLERK for auth
@@ -70,7 +70,7 @@ Here's how to obtain the Resend API key:
    variable. It should look something like this (real values without
    censorship):
 
-![Create your monitor](/img/setup-env/resend.png)
+![Create your monitor](/images/setup-env/resend.png)
 
 ```
 # RESEND for email
@@ -152,7 +152,7 @@ UPSTASH.
 You will need to create an API token, Go to Auth tokens > Workspace tokens > Add
 a new token > Select your token
 
-![Create your monitor](/img/setup-env/tinybird.png)
+![Create your monitor](/images/setup-env/tinybird.png)
 
 ```
 # TinyBird


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description
Fix typo in image links in the `docs` page.

### Before this PR
URL - [https://docs.openstatus.dev/developer-guide/setup-env](https://docs.openstatus.dev/developer-guide/setup-env)

![image](https://github.com/openstatusHQ/openstatus/assets/79012023/ee7d2d0c-d0ed-4f49-bc3c-d802659505ca)

### After this PR
![image](https://github.com/openstatusHQ/openstatus/assets/79012023/8f89e0bd-0d71-4735-ac2f-9f129b385cb3)


{Please add a screenshot here}
