### PR TITLE
add missing .csv file to the docs

### DIFF
--- a/apps/docs/developer-guide/setup-env.mdx
+++ b/apps/docs/developer-guide/setup-env.mdx
@@ -275,8 +275,7 @@ configurations.
    > Please make sure you chose the admin token otherwise it may give an error
    > like auth token invalid
 
-3. Then download this file
-   [ping_response\_\_v3](https://docs.openstatus.dev/dummy/ping_response__v3.csv)
+3. Then download this file [ping_response\_\_v3](/dummy/ping_response__v3.csv)
 
 4. install the tinybird-cli
 

--- a/apps/docs/dummy/ping_response__v3.csv
+++ b/apps/docs/dummy/ping_response__v3.csv
@@ -1,0 +1,4 @@
+id;latency;monitorId;pageId;region;statusCode;timestamp;url;workspaceId;cronTimestamp;metadata
+JCnILXx7nLkiF3g9Yk-Qr;290;openstatusPing;openstatus;kix1;200;1695573755478;https://openstatus.dev/api/ping;openstatus;1695573646204;{}
+nrxgkZ_D6Dq3gWj8mqKwP;240;openstatusPing;openstatus;gru1;200;1695573755337;https://openstatus.dev/api/ping;openstatus;1695573646204;{}
+Y4POia0YWtxx3bx6Gc1qt;277;openstatusPing;openstatus;hkg1;200;1695573743935;https://openstatus.dev/api/ping;openstatus;1695573646204;{}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description
Links present in the [docs](https://docs.openstatus.dev/developer-guide/setup-env) page didn't point to the `.csv` file as it was absent.

## Changes
- Add the `.csv` file in `/dummy` folder and updated the links.
