### PR TITLE
feat: audit logs

### DIFF
--- a/apps/server/src/checker/alerting.ts
+++ b/apps/server/src/checker/alerting.ts
@@ -47,7 +47,7 @@ export const triggerAlerting = async ({
     // ALPHA
     await checkerAudit.publishAuditLog({
       id: `monitor:${monitorId}`,
-      action: "notification.send",
+      action: "notification.sent",
       targets: [{ id: monitorId, type: "monitor" }],
       metadata: { provider: notif.notification.provider },
     });

--- a/apps/server/src/checker/alerting.ts
+++ b/apps/server/src/checker/alerting.ts
@@ -48,6 +48,7 @@ export const triggerAlerting = async ({
     await checkerAudit.publishAuditLog({
       id: `monitor:${monitorId}`,
       action: "notification.send",
+      targets: [{ id: monitorId, type: "monitor" }],
       metadata: { provider: notif.notification.provider },
     });
     //

--- a/apps/server/src/checker/alerting.ts
+++ b/apps/server/src/checker/alerting.ts
@@ -7,6 +7,7 @@ import {
 import { flyRegionsDict } from "@openstatus/utils";
 
 import { env } from "../env";
+import { checkerAudit } from "../utils/audit-log";
 import { providerToFunction } from "./utils";
 
 export const triggerAlerting = async ({
@@ -43,6 +44,13 @@ export const triggerAlerting = async ({
       statusCode,
       message,
     });
+    // ALPHA
+    await checkerAudit.publishAuditLog({
+      id: `monitor:${monitorId}`,
+      action: "notification.send",
+      metadata: { provider: notif.notification.provider },
+    });
+    //
   }
 };
 

--- a/apps/server/src/checker/checker.ts
+++ b/apps/server/src/checker/checker.ts
@@ -1,4 +1,5 @@
 import { env } from "../env";
+import { checkerAudit } from "../utils/audit-log";
 import { triggerAlerting, upsertMonitorStatus } from "./alerting";
 import type { PublishPingType } from "./ping";
 import { pingEndpoint, publishPing } from "./ping";
@@ -80,6 +81,13 @@ const run = async (data: Payload, retry: number) => {
         monitorId: data.monitorId,
         status: "active",
       });
+      // ALPHA
+      await checkerAudit.publishAuditLog({
+        id: `monitor:${data.monitorId}`,
+        action: "monitor.recovered",
+        metadata: { region: env.FLY_REGION },
+      });
+      //
     }
   } else {
     if (retry < 2) {
@@ -110,6 +118,13 @@ const run = async (data: Payload, retry: number) => {
           statusCode: res?.status,
           message,
         });
+        // ALPHA
+        await checkerAudit.publishAuditLog({
+          id: `monitor:${data.monitorId}`,
+          action: "monitor.failed",
+          metadata: { region: env.FLY_REGION },
+        });
+        //
       }
     }
   }

--- a/apps/server/src/checker/monitor-handler.ts
+++ b/apps/server/src/checker/monitor-handler.ts
@@ -12,6 +12,7 @@ export async function handleMonitorRecovered(data: Payload, res: Response) {
   await checkerAudit.publishAuditLog({
     id: `monitor:${data.monitorId}`,
     action: "monitor.recovered",
+    targets: [{ id: data.monitorId, type: "monitor" }],
     metadata: { region: env.FLY_REGION, statusCode: res.status },
   });
   //
@@ -30,6 +31,7 @@ export async function handleMonitorFailed(
   await checkerAudit.publishAuditLog({
     id: `monitor:${data.monitorId}`,
     action: "monitor.failed",
+    targets: [{ id: data.monitorId, type: "monitor" }],
     metadata: {
       region: env.FLY_REGION,
       statusCode: res?.status,

--- a/apps/server/src/checker/monitor-handler.ts
+++ b/apps/server/src/checker/monitor-handler.ts
@@ -1,0 +1,46 @@
+import { env } from "../env";
+import { checkerAudit } from "../utils/audit-log";
+import { triggerAlerting, upsertMonitorStatus } from "./alerting";
+import type { Payload } from "./schema";
+
+export async function handleMonitorRecovered(data: Payload, res: Response) {
+  await upsertMonitorStatus({
+    monitorId: data.monitorId,
+    status: "active",
+  });
+  // ALPHA
+  await checkerAudit.publishAuditLog({
+    id: `monitor:${data.monitorId}`,
+    action: "monitor.recovered",
+    metadata: { region: env.FLY_REGION, statusCode: res.status },
+  });
+  //
+}
+
+export async function handleMonitorFailed(
+  data: Payload,
+  res: Response | null,
+  message?: string,
+) {
+  // ALPHA
+  await checkerAudit.publishAuditLog({
+    id: `monitor:${data.monitorId}`,
+    action: "monitor.failed",
+    metadata: {
+      region: env.FLY_REGION,
+      statusCode: res?.status,
+      message,
+    },
+  });
+  //
+  await upsertMonitorStatus({
+    monitorId: data.monitorId,
+    status: "error",
+  });
+  await triggerAlerting({
+    monitorId: data.monitorId,
+    region: env.FLY_REGION,
+    statusCode: res?.status,
+    message,
+  });
+}

--- a/apps/server/src/checker/monitor-handler.ts
+++ b/apps/server/src/checker/monitor-handler.ts
@@ -22,6 +22,10 @@ export async function handleMonitorFailed(
   res: Response | null,
   message?: string,
 ) {
+  await upsertMonitorStatus({
+    monitorId: data.monitorId,
+    status: "error",
+  });
   // ALPHA
   await checkerAudit.publishAuditLog({
     id: `monitor:${data.monitorId}`,
@@ -33,10 +37,6 @@ export async function handleMonitorFailed(
     },
   });
   //
-  await upsertMonitorStatus({
-    monitorId: data.monitorId,
-    status: "error",
-  });
   await triggerAlerting({
     monitorId: data.monitorId,
     region: env.FLY_REGION,

--- a/apps/server/src/utils/audit-log.ts
+++ b/apps/server/src/utils/audit-log.ts
@@ -1,26 +1,7 @@
-import { z } from "zod";
-
 import { AuditLog, Tinybird } from "@openstatus/tinybird";
 
 import { env } from "../env";
 
 const tb = new Tinybird({ token: env.TINY_BIRD_API_KEY });
 
-const checkerAuditName = "checker_audit_log";
-
-const statusUnion = z.discriminatedUnion("status", [
-  z.object({ status: z.literal("success"), data: z.string() }),
-  z.object({ status: z.literal("failed"), error: z.instanceof(Error) }),
-]);
-
-const checkerMetadataSchema = z.object({
-  region: z.string(),
-  // details: z.string().optional(),
-  // statusUnion,
-});
-
-export const checkerAudit = new AuditLog({
-  tb,
-  name: checkerAuditName,
-  metadataSchema: checkerMetadataSchema,
-});
+export const checkerAudit = new AuditLog({ tb });

--- a/apps/server/src/utils/audit-log.ts
+++ b/apps/server/src/utils/audit-log.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+import { AuditLog, Tinybird } from "@openstatus/tinybird";
+
+import { env } from "../env";
+
+const tb = new Tinybird({ token: env.TINY_BIRD_API_KEY });
+
+const checkerAuditName = "checker_audit_log";
+
+const statusUnion = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("success"), data: z.string() }),
+  z.object({ status: z.literal("failed"), error: z.instanceof(Error) }),
+]);
+
+const checkerMetadataSchema = z.object({
+  region: z.string(),
+  // details: z.string().optional(),
+  // statusUnion,
+});
+
+export const checkerAudit = new AuditLog({
+  tb,
+  name: checkerAuditName,
+  metadataSchema: checkerMetadataSchema,
+});

--- a/packages/tinybird/datasources/audit_log.datasource
+++ b/packages/tinybird/datasources/audit_log.datasource
@@ -10,4 +10,4 @@ SCHEMA >
     `version` Int16 `json:$.version`
 
 ENGINE "MergeTree"
-ENGINE_SORTING_KEY "id, timestamp action, targets"
+ENGINE_SORTING_KEY "id, timestamp, targets, action"

--- a/packages/tinybird/datasources/audit_log.datasource
+++ b/packages/tinybird/datasources/audit_log.datasource
@@ -10,4 +10,4 @@ SCHEMA >
     `version` Int16 `json:$.version`
 
 ENGINE "MergeTree"
-ENGINE_SORTING_KEY "id, action, timestamp"
+ENGINE_SORTING_KEY "id, timestamp action, targets"

--- a/packages/tinybird/datasources/audit_log.datasource
+++ b/packages/tinybird/datasources/audit_log.datasource
@@ -10,4 +10,4 @@ SCHEMA >
     `version` Int16 `json:$.version`
 
 ENGINE "MergeTree"
-ENGINE_SORTING_KEY "id, timestamp, targets, action"
+ENGINE_SORTING_KEY "id, timestamp, action"

--- a/packages/tinybird/datasources/audit_log.datasource
+++ b/packages/tinybird/datasources/audit_log.datasource
@@ -1,0 +1,13 @@
+VERSION 0
+
+SCHEMA >
+    `action` String `json:$.action`,
+    `actor` String `json:$.actor`,
+    `id` String `json:$.id`,
+    `targets` Nullable(String) `json:$.targets`,
+    `metadata` Nullable(String) `json:$.metadata`,
+    `timestamp` Int64 `json:$.timestamp`,
+    `version` Int16 `json:$.version`
+
+ENGINE "MergeTree"
+ENGINE_SORTING_KEY "id, action, timestamp"

--- a/packages/tinybird/package.json
+++ b/packages/tinybird/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "license": "MIT",
   "dependencies": {
-    "@chronark/zod-bird": "0.2.2",
+    "@chronark/zod-bird": "0.3.1",
     "zod": "3.22.2"
   },
   "devDependencies": {

--- a/packages/tinybird/pipes/endpoint_audit_log.pipe
+++ b/packages/tinybird/pipes/endpoint_audit_log.pipe
@@ -1,0 +1,8 @@
+VERSION 0
+
+NODE audit_test_pipe_0
+SQL >
+
+    % SELECT * FROM audit_test_datasource WHERE id = {{ String(event_id, 1) }}
+
+

--- a/packages/tinybird/pipes/endpoint_audit_log.pipe
+++ b/packages/tinybird/pipes/endpoint_audit_log.pipe
@@ -3,6 +3,6 @@ VERSION 0
 NODE endpoint_audit_pipe_0
 SQL >
 
-    % SELECT * FROM audit_log__v0 WHERE id = {{ String(event_id, 1) }}
+    % SELECT * FROM audit_log__v0 WHERE id = {{ String(event_id, 1) }} ORDER BY timestamp DESC
 
 

--- a/packages/tinybird/pipes/endpoint_audit_log.pipe
+++ b/packages/tinybird/pipes/endpoint_audit_log.pipe
@@ -1,8 +1,8 @@
 VERSION 0
 
-NODE audit_test_pipe_0
+NODE endpoint_audit_pipe_0
 SQL >
 
-    % SELECT * FROM audit_test_datasource WHERE id = {{ String(event_id, 1) }}
+    % SELECT * FROM audit_log__v0 WHERE id = {{ String(event_id, 1) }}
 
 

--- a/packages/tinybird/src/audit-log/README.md
+++ b/packages/tinybird/src/audit-log/README.md
@@ -1,4 +1,4 @@
-### Motivation
+## Motivation
 
 We want to track every change made for the `incident` and `monitor`. Therefore,
 it requires us to build some audit log / event sourcing foundation.
@@ -62,7 +62,7 @@ The objects are parsed and stored as string via
 `schema.transform(val => JSON.stringify(val))` and transformed back into an
 object before parsing via `z.preprocess(val => JSON.parse(val), schema)`.
 
-### Example
+## Example
 
 ```ts
 const tb = new Tinybird({ token: process.env.TINY_BIRD_API_KEY || "" });
@@ -79,11 +79,11 @@ await auditLog.publishAuditLog({
 await auditLog.getAuditLog({ event_id: "monitor:1" });
 ```
 
-### Inspiration
+## Inspiration
 
 - WorkOS [Audit Logs](https://workos.com/docs/audit-logs)
 
-### Tinybird
+## Tinybird
 
 Push the pipe and datasource to tinybird:
 
@@ -91,3 +91,9 @@ Push the pipe and datasource to tinybird:
 tb push datasources/audit_log.datasource
 tb push pipes/endpoint_audit_log.pipe
 ```
+
+---
+
+### Possible extention
+
+> TODO: Remove `Nullable` from `targets` to better index and query it.

--- a/packages/tinybird/src/audit-log/README.md
+++ b/packages/tinybird/src/audit-log/README.md
@@ -1,0 +1,83 @@
+### Motivation
+
+We want to track every change made for the `incident` and `monitor`. Therefore,
+it requires us to build some audit log / event sourcing foundation.
+
+The `Event` is what the data type stored within [Tinybird](https://tinybird.co).
+It has basic props that every event includes, as well as a `metadata` prop that
+can be used to store additional informations.
+
+```ts
+export type Event = {
+  /**
+   * Unique identifier for the event.
+   */
+  id: string;
+
+  /**
+   * The actor that triggered the event.
+   * @default { id: "", name: "system" }
+   * @example { id: "1", name: "mxkaske" }
+   */
+  actor?: {
+    id: string;
+    name: string;
+  };
+
+  /**
+   * The ressources affected by the action taken.
+   * @example [{ id: "1", name: "organization" }]
+   */
+  targets?: {
+    id: string;
+    name: string;
+  }[];
+
+  /**
+   * The action that was triggered.
+   * @example monitor.down | incident.create
+   */
+  action: string;
+
+  /**
+   * The timestamp of the event in milliseconds since epoch UTC.
+   * @default Date.now()
+   */
+  timestamp?: number;
+
+  /**
+   * The version of the event. Should be incremented on each update.
+   * @default 1
+   */
+  version?: number;
+
+  /**
+   * Metadata for the event.
+   */
+  metadata?: Record<string, unknown>;
+};
+```
+
+The objects are parsed and stored as string via
+`schema.transform(val => JSON.stringify(val))` and transformed back into an
+object before parsing via `z.preprocess(val => JSON.parse(val), schema)`.
+
+### Improvements
+
+Right now, the `metadata` object is not very typesafe. It would be great if we
+could make `zod` generics work and extend/merge the base schema such that we get
+the correct metadata types after validation.
+
+Something like:
+
+```ts
+const schemaExtender = <T extends z.ZodRawShape>(p: z.ZodObject<T>) =>
+  z.object({ foo: z.boolean() }).merge(p);
+const schema = schemaExtender(z.object({ bar: z.number() }));
+type Schema = z.infer<typeof schema>;
+// ^? { foo: boolean; bar: number; }
+```
+
+### Inspiration
+
+- WorkOS [Audit Logs](https://workos.com/docs/audit-logs)

--- a/packages/tinybird/src/audit-log/README.md
+++ b/packages/tinybird/src/audit-log/README.md
@@ -66,15 +66,13 @@ object before parsing via `z.preprocess(val => JSON.parse(val), schema)`.
 
 ```ts
 const tb = new Tinybird({ token: process.env.TINY_BIRD_API_KEY || "" });
-const metadataSchema = z.object({ region: z.string() });
-const name = "audit_log__v0";
 
-const auditLog = new AuditLog({ tb, name, metadataSchema });
+const auditLog = new AuditLog({ tb });
 
 await auditLog.publishAuditLog({
   id: "monitor:1",
   action: "monitor.down",
-  metadata: { region: "gru" },
+  metadata: { region: "gru", statusCode: 400, message: "timeout" },
 });
 
 await auditLog.getAuditLog({ event_id: "monitor:1" });

--- a/packages/tinybird/src/audit-log/README.md
+++ b/packages/tinybird/src/audit-log/README.md
@@ -81,3 +81,12 @@ await auditLog.getAuditLog({ event_id: "monitor:1" });
 ### Inspiration
 
 - WorkOS [Audit Logs](https://workos.com/docs/audit-logs)
+
+### Tinybird
+
+Push the pipe and datasource to tinybird:
+
+```
+tb push datasources/audit_log.datasource
+tb push pipes/endpoint_audit_log.pipe
+```

--- a/packages/tinybird/src/audit-log/README.md
+++ b/packages/tinybird/src/audit-log/README.md
@@ -26,7 +26,7 @@ export type Event = {
 
   /**
    * The ressources affected by the action taken.
-   * @example [{ id: "1", name: "organization" }]
+   * @example [{ id: "1", name: "monitor" }]
    */
   targets?: {
     id: string;
@@ -72,6 +72,7 @@ const auditLog = new AuditLog({ tb });
 await auditLog.publishAuditLog({
   id: "monitor:1",
   action: "monitor.down",
+  targets: [{ id: "1", type: "monitor" }], // not mandatory, but could be useful later on
   metadata: { region: "gru", statusCode: 400, message: "timeout" },
 });
 

--- a/packages/tinybird/src/audit-log/action-schema.ts
+++ b/packages/tinybird/src/audit-log/action-schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+/**
+ * The schema for the monitor.recovered action.
+ * It represents the event when a monitor has recovered from a failure.
+ */
+export const monitorRecoveredSchema = z.object({
+  action: z.literal("monitor.recovered"),
+  metadata: z.object({ region: z.string(), statusCode: z.number() }),
+});
+
+/**
+ * The schema for the monitor.failed action.
+ * It represents the event when a monitor has failed.
+ */
+export const monitorFailedSchema = z.object({
+  action: z.literal("monitor.failed"),
+  metadata: z.object({
+    region: z.string(),
+    statusCode: z.number().optional(),
+    message: z.string().optional(),
+  }),
+});
+
+/**
+ * The schema for the notification.send action.
+ *
+ */
+export const notificationSentSchema = z.object({
+  action: z.literal("notification.sent"),
+  // we could use the notificationProviderSchema for more type safety
+  metadata: z.object({ provider: z.string() }),
+});
+
+// TODO: update schemas with correct metadata and description
+
+export const incidentCreatedSchema = z.object({
+  action: z.literal("incident.created"),
+  metadata: z.object({}), // tbd
+});
+
+export const incidentResolvedSchema = z.object({
+  action: z.literal("incident.resolved"),
+  metadata: z.object({}), // tbd
+});
+
+// ...

--- a/packages/tinybird/src/audit-log/action-validation.ts
+++ b/packages/tinybird/src/audit-log/action-validation.ts
@@ -6,7 +6,7 @@ import { ingestBaseEventSchema, pipeBaseResponseData } from "./base-validation";
  * The schema for the monitor.recovered action.
  * It represents the event when a monitor has recovered from a failure.
  */
-const monitorUpSchema = z.object({
+const monitorRecoveredSchema = z.object({
   action: z.literal("monitor.recovered"),
   metadata: z.object({ region: z.string(), statusCode: z.number() }),
 });
@@ -15,7 +15,7 @@ const monitorUpSchema = z.object({
  * The schema for the monitor.failed action.
  * It represents the event when a monitor has failed.
  */
-const monitorDownSchema = z.object({
+const monitorFailedSchema = z.object({
   action: z.literal("monitor.failed"),
   metadata: z.object({
     region: z.string(),
@@ -28,8 +28,8 @@ const monitorDownSchema = z.object({
  * The schema for the notification.send action.
  *
  */
-const notificationSendSchema = z.object({
-  action: z.literal("notification.send"),
+const notificationSentSchema = z.object({
+  action: z.literal("notification.sent"),
   // we could use the notificationProviderSchema for more type safety
   metadata: z.object({ provider: z.string() }),
 });
@@ -47,9 +47,9 @@ export const ingestActionEventSchema = z
     // Unfortunately, the array cannot be dynamic, otherwise could be added to the Client
     // and made available to devs as library
     z.discriminatedUnion("action", [
-      monitorUpSchema,
-      monitorDownSchema,
-      notificationSendSchema,
+      monitorRecoveredSchema,
+      monitorFailedSchema,
+      notificationSentSchema,
     ]),
     ingestBaseEventSchema,
   )
@@ -68,22 +68,22 @@ export const ingestActionEventSchema = z
  */
 export const pipeActionResponseData = z.intersection(
   z.discriminatedUnion("action", [
-    monitorUpSchema.extend({
+    monitorRecoveredSchema.extend({
       metadata: z.preprocess(
         (val) => JSON.parse(String(val)),
-        monitorUpSchema.shape.metadata,
+        monitorRecoveredSchema.shape.metadata,
       ),
     }),
-    monitorDownSchema.extend({
+    monitorFailedSchema.extend({
       metadata: z.preprocess(
         (val) => JSON.parse(String(val)),
-        monitorDownSchema.shape.metadata,
+        monitorFailedSchema.shape.metadata,
       ),
     }),
-    notificationSendSchema.extend({
+    notificationSentSchema.extend({
       metadata: z.preprocess(
         (val) => JSON.parse(String(val)),
-        notificationSendSchema.shape.metadata,
+        notificationSentSchema.shape.metadata,
       ),
     }),
   ]),

--- a/packages/tinybird/src/audit-log/action-validation.ts
+++ b/packages/tinybird/src/audit-log/action-validation.ts
@@ -89,3 +89,6 @@ export const pipeActionResponseData = z.intersection(
   ]),
   pipeBaseResponseData,
 );
+
+export type IngestActionEvent = z.infer<typeof ingestActionEventSchema>;
+export type PipeActionResponseData = z.infer<typeof pipeActionResponseData>;

--- a/packages/tinybird/src/audit-log/action-validation.ts
+++ b/packages/tinybird/src/audit-log/action-validation.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+import { ingestBaseEventSchema } from "./base-validation";
+
+const monitorUpSchema = z.object({
+  action: z.literal("monitor.up"),
+  metadata: z.object({ region: z.string() }),
+});
+
+const monitorDownSchema = z.object({
+  action: z.literal("monitor.down"),
+  metadata: z.object({ test: z.string() }),
+});
+
+export const ingestActionEventSchema = z
+  .intersection(
+    z.discriminatedUnion("action", [monitorUpSchema, monitorDownSchema]), // Unfortunately, the array cannot be dynamic
+    ingestBaseEventSchema,
+  )
+  .transform((val) => ({
+    metadata: JSON.stringify(val.metadata),
+  }));
+
+export const pipeActionResponseData = z.intersection(
+  z.discriminatedUnion("action", [
+    monitorUpSchema.extend({
+      metadata: z.preprocess(
+        (val) => JSON.parse(String(val)),
+        monitorUpSchema.shape.metadata,
+      ),
+    }),
+    monitorDownSchema.extend({
+      metadata: z.preprocess(
+        (val) => JSON.parse(String(val)),
+        monitorDownSchema.shape.metadata,
+      ),
+    }),
+  ]),
+  ingestBaseEventSchema,
+);
+
+export type IngestActionEventSchema = z.input<typeof ingestActionEventSchema>;
+export type PipeActionResponseData = z.output<typeof pipeActionResponseData>;
+
+//
+
+export const logEvent: IngestActionEventSchema = {
+  id: "monitor:1",
+  action: "monitor.up",
+  metadata: { region: "gru" },
+};
+
+// export const outputEvent: PipeActionResponseData = {
+//   id: "monitor:1",
+//   action: "monitor.up",
+//   metadata: { region: "gru" },
+// };

--- a/packages/tinybird/src/audit-log/action-validation.ts
+++ b/packages/tinybird/src/audit-log/action-validation.ts
@@ -1,38 +1,11 @@
 import { z } from "zod";
 
+import {
+  monitorFailedSchema,
+  monitorRecoveredSchema,
+  notificationSentSchema,
+} from "./action-schema";
 import { ingestBaseEventSchema, pipeBaseResponseData } from "./base-validation";
-
-/**
- * The schema for the monitor.recovered action.
- * It represents the event when a monitor has recovered from a failure.
- */
-const monitorRecoveredSchema = z.object({
-  action: z.literal("monitor.recovered"),
-  metadata: z.object({ region: z.string(), statusCode: z.number() }),
-});
-
-/**
- * The schema for the monitor.failed action.
- * It represents the event when a monitor has failed.
- */
-const monitorFailedSchema = z.object({
-  action: z.literal("monitor.failed"),
-  metadata: z.object({
-    region: z.string(),
-    statusCode: z.number().optional(),
-    message: z.string().optional(),
-  }),
-});
-
-/**
- * The schema for the notification.send action.
- *
- */
-const notificationSentSchema = z.object({
-  action: z.literal("notification.sent"),
-  // we could use the notificationProviderSchema for more type safety
-  metadata: z.object({ provider: z.string() }),
-});
 
 /**
  * The schema for the event object.

--- a/packages/tinybird/src/audit-log/action-validation.ts
+++ b/packages/tinybird/src/audit-log/action-validation.ts
@@ -2,13 +2,19 @@ import { z } from "zod";
 
 import { ingestBaseEventSchema, pipeBaseResponseData } from "./base-validation";
 
-// TODO: add description to every action
-
+/**
+ * The schema for the monitor.recovered action.
+ * It represents the event when a monitor has recovered from a failure.
+ */
 const monitorUpSchema = z.object({
   action: z.literal("monitor.recovered"),
   metadata: z.object({ region: z.string(), statusCode: z.number() }),
 });
 
+/**
+ * The schema for the monitor.failed action.
+ * It represents the event when a monitor has failed.
+ */
 const monitorDownSchema = z.object({
   action: z.literal("monitor.failed"),
   metadata: z.object({
@@ -18,12 +24,24 @@ const monitorDownSchema = z.object({
   }),
 });
 
+/**
+ * The schema for the notification.send action.
+ *
+ */
 const notificationSendSchema = z.object({
   action: z.literal("notification.send"),
   // we could use the notificationProviderSchema for more type safety
   metadata: z.object({ provider: z.string() }),
 });
 
+/**
+ * The schema for the event object.
+ * It extends the base schema. It uses the `discriminatedUnion` method for faster
+ * evaluation to determine which schema to be used to parse the input.
+ * It also transforms the metadata object into a string.
+ *
+ * @todo: whenever a new action is added, it should be included to the discriminatedUnion
+ */
 export const ingestActionEventSchema = z
   .intersection(
     // Unfortunately, the array cannot be dynamic, otherwise could be added to the Client
@@ -40,6 +58,14 @@ export const ingestActionEventSchema = z
     metadata: JSON.stringify(val.metadata),
   }));
 
+/**
+ * The schema for the response object.
+ * It extends the base schema. It uses the `discriminatedUnion` method for faster
+ * evaluation to determine which schema to be used to parse the input.
+ * It also preprocesses the metadata string into the correct schema object.
+ *
+ * @todo: whenever a new action is added, it should be included to the discriminatedUnion
+ */
 export const pipeActionResponseData = z.intersection(
   z.discriminatedUnion("action", [
     monitorUpSchema.extend({
@@ -63,6 +89,3 @@ export const pipeActionResponseData = z.intersection(
   ]),
   pipeBaseResponseData,
 );
-
-export type IngestActionEventSchema = z.input<typeof ingestActionEventSchema>;
-export type PipeActionResponseData = z.output<typeof pipeActionResponseData>;

--- a/packages/tinybird/src/audit-log/base-validation.ts
+++ b/packages/tinybird/src/audit-log/base-validation.ts
@@ -88,3 +88,7 @@ export const pipeBaseResponseData = baseSchema.extend({
  * It represents the parameters that are passed to the pipe.
  */
 export const pipeParameterData = z.object({ event_id: z.string().min(1) });
+
+export type PipeParameterData = z.infer<typeof pipeParameterData>;
+export type PipeBaseResponseData = z.infer<typeof pipeBaseResponseData>;
+export type IngestBaseEvent = z.infer<typeof ingestBaseEventSchema>;

--- a/packages/tinybird/src/audit-log/base-validation.ts
+++ b/packages/tinybird/src/audit-log/base-validation.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
  * on datasource ingestion and pipe retrieval.
  */
 export const baseSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().min(1), // DISCUSS: we could use the `${targets.type}:${targets.id}` format automatic generation
   action: z.string(),
   // REMINDER: do not use .default(Date.now()), it will be evaluated only once
   timestamp: z
@@ -37,13 +37,25 @@ export const actorSchema = z
   });
 
 /**
+ * The schema for the target type.
+ * It represents the type of the target that is affected by the event.
+ */
+export const targetTypeSchema = z.enum([
+  "monitor",
+  "page",
+  "incident",
+  "user",
+  "notification",
+]);
+
+/**
  * The schema for the targets object.
- * It represents the targets that are permitted to access the entry.
+ * It represents the targets that are affected by the event.
  */
 export const targetsSchema = z
   .object({
     id: z.string(),
-    name: z.string(),
+    type: targetTypeSchema,
   })
   .array()
   .optional();

--- a/packages/tinybird/src/audit-log/base-validation.ts
+++ b/packages/tinybird/src/audit-log/base-validation.ts
@@ -47,7 +47,7 @@ export const targetsSchema = z
  * It extends the base schema and transforms the actor, targets
  * objects into strings.
  */
-export const ingestEventSchema = baseSchema.extend({
+export const ingestBaseEventSchema = baseSchema.extend({
   actor: actorSchema.transform((val) => JSON.stringify(val)),
   targets: targetsSchema.transform((val) => JSON.stringify(val)),
 });
@@ -57,7 +57,7 @@ export const ingestEventSchema = baseSchema.extend({
  * It extends the base schema and transforms the actor, targets
  * back into typed objects.
  */
-export const pipeResponseData = baseSchema.extend({
+export const pipeBaseResponseData = baseSchema.extend({
   actor: z.preprocess((val) => JSON.parse(String(val)), actorSchema),
   targets: z.preprocess(
     (val) => (val ? JSON.parse(String(val)) : undefined),

--- a/packages/tinybird/src/audit-log/base-validation.ts
+++ b/packages/tinybird/src/audit-log/base-validation.ts
@@ -17,17 +17,23 @@ export const baseSchema = z.object({
 });
 
 /**
+ * The schema for the actor type.
+ * It represents the type of the user that triggered the event.
+ */
+export const actorTypeSchema = z.enum(["user", "system"]);
+
+/**
  * The schema for the actor object.
  * It represents the user that triggered the event.
  */
 export const actorSchema = z
   .object({
     id: z.string(),
-    name: z.string(),
+    type: actorTypeSchema,
   })
   .default({
     id: "",
-    name: "system",
+    type: "system",
   });
 
 /**

--- a/packages/tinybird/src/audit-log/base-validation.ts
+++ b/packages/tinybird/src/audit-log/base-validation.ts
@@ -32,7 +32,7 @@ export const actorSchema = z
     type: actorTypeSchema,
   })
   .default({
-    id: "",
+    id: "server",
     type: "system",
   });
 
@@ -46,6 +46,7 @@ export const targetTypeSchema = z.enum([
   "incident",
   "user",
   "notification",
+  "organization",
 ]);
 
 /**

--- a/packages/tinybird/src/audit-log/client.ts
+++ b/packages/tinybird/src/audit-log/client.ts
@@ -1,4 +1,5 @@
 import type { Tinybird } from "@chronark/zod-bird";
+import { z } from "zod";
 
 import {
   ingestEventSchema,
@@ -6,17 +7,54 @@ import {
   pipeResponseData,
 } from "./validation";
 
-export function publishAuditLog(tb: Tinybird) {
-  return tb.buildIngestEndpoint({
-    datasource: "audit_log__v0",
-    event: ingestEventSchema,
-  });
-}
+export class AuditLog<T extends z.ZodRawShape> {
+  private readonly tb: Tinybird;
+  private readonly metadataSchema: z.ZodObject<T>;
+  private readonly datasource: string;
+  private readonly pipe: string;
 
-export function getAuditLog(tb: Tinybird) {
-  return tb.buildPipe({
-    pipe: "endpoint_audit_log__v0",
-    parameters: pipeParameterData,
-    data: pipeResponseData,
-  });
+  constructor(opts: {
+    tb: Tinybird;
+    name: string;
+    metadataSchema: z.ZodObject<T>;
+  }) {
+    this.tb = opts.tb;
+    this.metadataSchema = opts.metadataSchema;
+    this.datasource = `${opts.name}`;
+    this.pipe = `endpoint_${opts.name}`;
+  }
+
+  private metadataIngestExtender() {
+    return ingestEventSchema.merge(
+      z.object({
+        metadata: this.metadataSchema.transform((val) => JSON.stringify(val)),
+      }),
+    );
+  }
+
+  private metadataPipeExtender() {
+    return pipeResponseData.merge(
+      z.object({
+        metadata: z.preprocess(
+          (val) => (val ? JSON.parse(String(val)) : undefined),
+          this.metadataSchema,
+        ),
+      }),
+    );
+  }
+
+  get publishAuditLog() {
+    return this.tb.buildIngestEndpoint({
+      datasource: this.datasource,
+      event: this.metadataIngestExtender(),
+    });
+  }
+
+  get getAuditLog() {
+    return this.tb.buildPipe({
+      pipe: this.pipe,
+      parameters: pipeParameterData,
+      data: this.metadataPipeExtender(),
+    });
+  }
 }

--- a/packages/tinybird/src/audit-log/client.ts
+++ b/packages/tinybird/src/audit-log/client.ts
@@ -1,0 +1,22 @@
+import type { Tinybird } from "@chronark/zod-bird";
+
+import {
+  ingestEventSchema,
+  pipeParameterData,
+  pipeResponseData,
+} from "./validation";
+
+export function publishAuditLog(tb: Tinybird) {
+  return tb.buildIngestEndpoint({
+    datasource: "audit_log__v0",
+    event: ingestEventSchema,
+  });
+}
+
+export function getAuditLog(tb: Tinybird) {
+  return tb.buildPipe({
+    pipe: "endpoint_audit_log__v0",
+    parameters: pipeParameterData,
+    data: pipeResponseData,
+  });
+}

--- a/packages/tinybird/src/audit-log/client.ts
+++ b/packages/tinybird/src/audit-log/client.ts
@@ -2,10 +2,10 @@ import type { Tinybird } from "@chronark/zod-bird";
 import { z } from "zod";
 
 import {
-  ingestEventSchema,
+  ingestBaseEventSchema,
+  pipeBaseResponseData,
   pipeParameterData,
-  pipeResponseData,
-} from "./validation";
+} from "./base-validation";
 
 export class AuditLog<T extends z.ZodRawShape> {
   private readonly tb: Tinybird;
@@ -25,7 +25,7 @@ export class AuditLog<T extends z.ZodRawShape> {
   }
 
   private metadataIngestExtender() {
-    return ingestEventSchema.merge(
+    return ingestBaseEventSchema.merge(
       z.object({
         metadata: this.metadataSchema.transform((val) => JSON.stringify(val)),
       }),
@@ -33,7 +33,7 @@ export class AuditLog<T extends z.ZodRawShape> {
   }
 
   private metadataPipeExtender() {
-    return pipeResponseData.merge(
+    return pipeBaseResponseData.merge(
       z.object({
         metadata: z.preprocess(
           (val) => (val ? JSON.parse(String(val)) : undefined),

--- a/packages/tinybird/src/audit-log/examples.ts
+++ b/packages/tinybird/src/audit-log/examples.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Tinybird } from "@chronark/zod-bird";
 
 import { AuditLog } from "./client";
@@ -43,9 +44,3 @@ async function history() {
 // if (first.action === "monitor.failed") {
 //   first.metadata.message;
 // }
-
-// ========
-
-async function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/packages/tinybird/src/audit-log/examples.ts
+++ b/packages/tinybird/src/audit-log/examples.ts
@@ -1,33 +1,31 @@
 import { Tinybird } from "@chronark/zod-bird";
+import { z } from "zod";
 
-import { getAuditLog, publishAuditLog } from "./client";
+import { AuditLog } from "./client";
 
 const tb = new Tinybird({ token: process.env.TINY_BIRD_API_KEY || "" });
+const metadataSchema = z.object({ region: z.string() });
+const name = "audit_log__v0";
+
+const auditLog = new AuditLog({ tb, name, metadataSchema });
 
 async function seed() {
-  await publishAuditLog(tb)({
+  await auditLog.publishAuditLog({
     id: "monitor:1",
     action: "monitor.down",
-    timestamp: Date.now(),
-    metadata: { region: "gru" },
-  });
-  await wait(1000);
-  await publishAuditLog(tb)({
-    id: "monitor:1",
-    action: "monitor.up",
-    timestamp: Date.now(),
     metadata: { region: "gru" },
   });
 }
 
 async function history() {
-  return await getAuditLog(tb)({
-    event_id: "monitor:1",
-  });
+  return await auditLog.getAuditLog({ event_id: "monitor:1" });
 }
 
-// seed();
-// await history();
+seed();
+// const all = await history();
+// console.log(all);
+
+// ========
 
 async function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/tinybird/src/audit-log/examples.ts
+++ b/packages/tinybird/src/audit-log/examples.ts
@@ -8,22 +8,40 @@ const auditLog = new AuditLog({ tb });
 
 async function seed() {
   await auditLog.publishAuditLog({
-    id: "monitor:1",
+    id: "monitor:2",
     action: "monitor.failed",
+    targets: [{ id: "2", type: "monitor" }],
     metadata: { region: "gru", statusCode: 500, message: "timeout" },
+  });
+  await auditLog.publishAuditLog({
+    id: "monitor:1",
+    action: "monitor.recovered",
+    targets: [{ id: "1", type: "monitor" }],
+    metadata: { region: "gru", statusCode: 200 },
+  });
+  await auditLog.publishAuditLog({
+    id: "user:1",
+    actor: {
+      type: "user",
+      id: "1",
+    },
+    targets: [{ id: "1", type: "user" }],
+    action: "notification.send",
+    metadata: { provider: "email" },
   });
 }
 
 async function history() {
-  return await auditLog.getAuditLog({ event_id: "monitor:1" });
+  return await auditLog.getAuditLog({ event_id: "user:1" });
 }
 
 // seed();
 // const all = await history();
+// console.log(all);
 // const first = all.data[0];
 
-// if (first.action === "monitor.down") {
-//   first.metadata.region;
+// if (first.action === "monitor.failed") {
+//   first.metadata.message;
 // }
 
 // ========

--- a/packages/tinybird/src/audit-log/examples.ts
+++ b/packages/tinybird/src/audit-log/examples.ts
@@ -26,7 +26,7 @@ async function seed() {
       id: "1",
     },
     targets: [{ id: "1", type: "user" }],
-    action: "notification.send",
+    action: "notification.sent",
     metadata: { provider: "email" },
   });
 }

--- a/packages/tinybird/src/audit-log/examples.ts
+++ b/packages/tinybird/src/audit-log/examples.ts
@@ -1,0 +1,34 @@
+import { Tinybird } from "@chronark/zod-bird";
+
+import { getAuditLog, publishAuditLog } from "./client";
+
+const tb = new Tinybird({ token: process.env.TINY_BIRD_API_KEY || "" });
+
+async function seed() {
+  await publishAuditLog(tb)({
+    id: "monitor:1",
+    action: "monitor.down",
+    timestamp: Date.now(),
+    metadata: { region: "gru" },
+  });
+  await wait(1000);
+  await publishAuditLog(tb)({
+    id: "monitor:1",
+    action: "monitor.up",
+    timestamp: Date.now(),
+    metadata: { region: "gru" },
+  });
+}
+
+async function history() {
+  return await getAuditLog(tb)({
+    event_id: "monitor:1",
+  });
+}
+
+// seed();
+// await history();
+
+async function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/tinybird/src/audit-log/examples.ts
+++ b/packages/tinybird/src/audit-log/examples.ts
@@ -1,19 +1,16 @@
 import { Tinybird } from "@chronark/zod-bird";
-import { z } from "zod";
 
 import { AuditLog } from "./client";
 
 const tb = new Tinybird({ token: process.env.TINY_BIRD_API_KEY || "" });
-const metadataSchema = z.object({ region: z.string() });
-const name = "audit_log__v0";
 
-const auditLog = new AuditLog({ tb, name, metadataSchema });
+const auditLog = new AuditLog({ tb });
 
 async function seed() {
   await auditLog.publishAuditLog({
     id: "monitor:1",
-    action: "monitor.down",
-    metadata: { region: "gru" },
+    action: "monitor.failed",
+    metadata: { region: "gru", statusCode: 500, message: "timeout" },
   });
 }
 
@@ -21,9 +18,13 @@ async function history() {
   return await auditLog.getAuditLog({ event_id: "monitor:1" });
 }
 
-seed();
+// seed();
 // const all = await history();
-// console.log(all);
+// const first = all.data[0];
+
+// if (first.action === "monitor.down") {
+//   first.metadata.region;
+// }
 
 // ========
 

--- a/packages/tinybird/src/audit-log/index.ts
+++ b/packages/tinybird/src/audit-log/index.ts
@@ -1,2 +1,1 @@
 export * from "./client";
-export * from "./validation";

--- a/packages/tinybird/src/audit-log/index.ts
+++ b/packages/tinybird/src/audit-log/index.ts
@@ -1,3 +1,1 @@
 export * from "./client";
-export * from "./action-validation";
-export * from "./base-validation";

--- a/packages/tinybird/src/audit-log/index.ts
+++ b/packages/tinybird/src/audit-log/index.ts
@@ -1,0 +1,2 @@
+export * from "./client";
+export * from "./validation";

--- a/packages/tinybird/src/audit-log/index.ts
+++ b/packages/tinybird/src/audit-log/index.ts
@@ -1,1 +1,3 @@
 export * from "./client";
+export * from "./action-validation";
+export * from "./base-validation";

--- a/packages/tinybird/src/audit-log/validation.ts
+++ b/packages/tinybird/src/audit-log/validation.ts
@@ -1,0 +1,87 @@
+import * as z from "zod";
+
+/**
+ * The base schema for every event, used to validate it's structure
+ * on datasource ingestion and pipe retrieval.
+ */
+export const baseSchema = z.object({
+  id: z.string().min(1),
+  action: z.string(),
+  timestamp: z.number().int().default(Date.now()),
+  version: z.number().int().default(1),
+});
+
+/**
+ * The schema for the actor object.
+ * It represents the user that triggered the event.
+ */
+export const actorSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+  })
+  .default({
+    id: "",
+    name: "system",
+  });
+
+/**
+ * The schema for the targets object.
+ * It represents the targets that are permitted to access the entry.
+ */
+export const targetsSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+  })
+  .array()
+  .optional();
+
+/**
+ * The schema for the metadata object.
+ * All the extra information that is not part of the base schema.
+ */
+export const metadataSchema = z.record(z.unknown()).optional();
+
+/**
+ * The schema for the event object.
+ * It extends the base schema and transforms the actor, targets and metadata
+ * objects into strings.
+ */
+export const ingestEventSchema = baseSchema.extend({
+  actor: actorSchema.transform((val) => JSON.stringify(val)),
+  targets: targetsSchema.transform((val) => JSON.stringify(val)),
+  metadata: metadataSchema.transform((val) => JSON.stringify(val)),
+});
+
+/**
+ * The schema for the response object.
+ * It extends the base schema and transforms the actor, targets and metadata objects
+ * back into typed objects.
+ */
+export const pipeResponseData = baseSchema.extend({
+  actor: z.preprocess((val) => JSON.parse(String(val)), actorSchema),
+  targets: z.preprocess(
+    (val) => (val ? JSON.parse(String(val)) : undefined),
+    targetsSchema,
+  ),
+  metadata: z.preprocess((val) => JSON.parse(String(val)), metadataSchema),
+});
+
+/**
+ * The schema for the parameters object.
+ * It represents the parameters that are passed to the pipe.
+ */
+export const pipeParameterData = z.object({ event_id: z.string().min(1) });
+
+export type BaseSchemaInput = z.input<typeof baseSchema>;
+export type IngestEventSchemaInput = z.input<typeof ingestEventSchema>;
+
+export type BaseSchema = z.infer<typeof baseSchema>;
+export type ActorSchema = z.infer<typeof actorSchema>;
+export type TargetsSchema = z.infer<typeof targetsSchema>;
+export type MetadataSchema = z.infer<typeof metadataSchema>;
+
+export type IngestEventSchema = z.infer<typeof ingestEventSchema>;
+export type PipeResponseDataSchema = z.infer<typeof pipeResponseData>;
+export type PipeParameterDataSchema = z.infer<typeof pipeParameterData>;

--- a/packages/tinybird/src/index.ts
+++ b/packages/tinybird/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./client";
 export * from "./validation";
+export * from "./audit-log";
 export * from "@chronark/zod-bird";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,22 +408,6 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
-  packages/audit-trail:
-    dependencies:
-      '@chronark/zod-bird':
-        specifier: 0.3.1-canary.1
-        version: 0.3.1-canary.1
-      zod:
-        specifier: 3.22.2
-        version: 3.22.2
-    devDependencies:
-      '@openstatus/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      typescript:
-        specifier: 5.2.2
-        version: 5.2.2
-
   packages/config/eslint:
     dependencies:
       '@types/eslint':
@@ -1198,12 +1182,6 @@ packages:
 
   /@chronark/zod-bird@0.3.1:
     resolution: {integrity: sha512-4PNJx41m37Psk/3XAxdXxMb9VGAep43/puiwxAyFWYzIoQ1kq3Cwh1sA51LkTFSVHm+B2peMmW+p3/+oCHH9zg==}
-    dependencies:
-      zod: 3.22.2
-    dev: false
-
-  /@chronark/zod-bird@0.3.1-canary.1:
-    resolution: {integrity: sha512-dAbebH6emwAznrKWiFy894O22iNKtvYgwXat6bjASHfNYT15UCWYQOOpbV7rm1nukphtrpYCTJu+ONtJFaHANQ==}
     dependencies:
       zod: 3.22.2
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,22 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/audit-trail:
+    dependencies:
+      '@chronark/zod-bird':
+        specifier: 0.3.1-canary.1
+        version: 0.3.1-canary.1
+      zod:
+        specifier: 3.22.2
+        version: 3.22.2
+    devDependencies:
+      '@openstatus/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/config/eslint:
     dependencies:
       '@types/eslint':
@@ -745,8 +761,8 @@ importers:
   packages/tinybird:
     dependencies:
       '@chronark/zod-bird':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.3.1
+        version: 0.3.1
       zod:
         specifier: 3.22.2
         version: 3.22.2
@@ -1180,8 +1196,14 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  /@chronark/zod-bird@0.2.2:
-    resolution: {integrity: sha512-0mmiiw4dny1aiEOmawsIJUaYW16vhWRuDGsDa62GfFhdD3F7hHrTi3lWNWYCVq2KsCS+CYwMj8nkdFuOnejCTA==}
+  /@chronark/zod-bird@0.3.1:
+    resolution: {integrity: sha512-4PNJx41m37Psk/3XAxdXxMb9VGAep43/puiwxAyFWYzIoQ1kq3Cwh1sA51LkTFSVHm+B2peMmW+p3/+oCHH9zg==}
+    dependencies:
+      zod: 3.22.2
+    dev: false
+
+  /@chronark/zod-bird@0.3.1-canary.1:
+    resolution: {integrity: sha512-dAbebH6emwAznrKWiFy894O22iNKtvYgwXat6bjASHfNYT15UCWYQOOpbV7rm1nukphtrpYCTJu+ONtJFaHANQ==}
     dependencies:
       zod: 3.22.2
     dev: false


### PR DESCRIPTION
### Motivation

 We want to track every change made for the `incident` and `monitor`. Therefore,
 it requires us to build some audit log / event sourcing foundation.

 The `Event` is what the data type stored within [Tinybird](https://tinybird.co).
 It has basic props that every event includes, as well as a `metadata` prop that
 can be used to store additional informations.

 ```ts
 export type Event = {
   /**
    * Unique identifier for the event.
    */
   id: string;

   /**
    * The actor that triggered the event.
    * @default { id: "", name: "system" }
    * @example { id: "1", name: "mxkaske" }
    */
   actor?: {
     id: string;
     name: string;
   };

   /**
    * The ressources affected by the action taken.
    * @example [{ id: "1", name: "monitor" }]
    */
   targets?: {
     id: string;
     name: string;
   }[];

   /**
    * The action that was triggered.
    * @example monitor.down | incident.create
    */
   action: string;

   /**
    * The timestamp of the event in milliseconds since epoch UTC.
    * @default Date.now()
    */
   timestamp?: number;

   /**
    * The version of the event. Should be incremented on each update.
    * @default 1
    */
   version?: number;

   /**
    * Metadata for the event. Defined via zod schema.
    */
   metadata?: unknown;
 };
 ```

 The objects are parsed and stored as string via
 `schema.transform(val => JSON.stringify(val))` and transformed back into an
 object before parsing via `z.preprocess(val => JSON.parse(val), schema)`.

<img width="1391" alt="CleanShot 2023-11-19 at 14 15 52@2x" src="https://github.com/openstatusHQ/openstatus/assets/56969857/dd95dffb-464d-4e6b-8226-269fe36cb95b">

 ### Example

 ```ts
 const tb = new Tinybird({ token: process.env.TINY_BIRD_API_KEY || "" });

 const auditLog = new AuditLog({ tb });

 await auditLog.publishAuditLog({
   id: "monitor:1",
   action: "monitor.down",
   targets: [{ id: "1", type: "monitor" }], // not mandatory, but could be useful later on
   metadata: { region: "gru", statusCode: 400, message: "timeout" },
 });

 await auditLog.getAuditLog({ event_id: "monitor:1" });
 ```

 ### Inspiration

 - WorkOS [Audit Logs](https://workos.com/docs/audit-logs)

 ### Tinybird

 Push the pipe and datasource to tinybird:

 ```
 tb push datasources/audit_log.datasource
 tb push pipes/endpoint_audit_log.pipe
 ```