### PR TITLE
chore: include incident to public status

### DIFF
--- a/apps/docs/getting-started/status-widget.mdx
+++ b/apps/docs/getting-started/status-widget.mdx
@@ -32,6 +32,7 @@ enum Status {
   MajorOutage = "major_outage",
   UnderMaintenance = "under_maintenance", // currently not in use
   Unknown = "unknown",
+  Incident = "incident",
 }
 ```
 
@@ -53,6 +54,10 @@ function getStatus(ratio: number) {
 ```
 
 We are caching the result for `30 seconds` to reduce the load on our database.
+
+The `Status.Incident` will always be returned when then status of any incident
+on your page is **not** _"monitoring"_ or _"resolved"_. You can attach an
+incident to a monitor (implicit) or a page (explicit).
 
 > If you have a doubt about the above calculation, feel free to contact us via
 > [ping@openstatus.dev](mailto:ping@openstatus.dev) or
@@ -82,6 +87,7 @@ const statusEnum = z.enum([
   "major_outage",
   "under_maintenance",
   "unknown",
+  "incident",
 ]);
 
 const statusSchema = z.object({ status: statusEnum });
@@ -106,6 +112,10 @@ const dictionary = {
   unknown: {
     label: "Unknown",
     color: "bg-gray-500",
+  },
+  incident: {
+    label: "Incident",
+    color: "bg-yellow-500",
   },
   under_maintenance: {
     label: "Under Maintenance",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -85,7 +85,8 @@ export type Status =
   | "partial_outage"
   | "major_outage"
   | "under_maintenance"
-  | "unknown";
+  | "unknown"
+  | "incident";
 ```
 
 Learn more in the [docs](https://docs.openstatus.dev/packages/react).

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,4 +1,9 @@
-export const statusDictionary = {
+import type { Status } from "./widget";
+
+export const statusDictionary: Record<
+  Status,
+  { label: string; color: string }
+> = {
   operational: {
     label: "Operational",
     color: "bg-green-500",
@@ -18,6 +23,10 @@ export const statusDictionary = {
   unknown: {
     label: "Unknown",
     color: "bg-gray-500",
+  },
+  incident: {
+    label: "Incident",
+    color: "bg-yellow-500",
   },
   under_maintenance: {
     label: "Under Maintenance",

--- a/packages/react/src/widget.tsx
+++ b/packages/react/src/widget.tsx
@@ -6,7 +6,8 @@ export type Status =
   | "partial_outage"
   | "major_outage"
   | "under_maintenance"
-  | "unknown";
+  | "unknown"
+  | "incident";
 
 export type StatusResponse = { status: Status };
 
@@ -29,10 +30,9 @@ export type StatusWidgetProps = {
 };
 
 export async function StatusWidget({ slug, href }: StatusWidgetProps) {
-  const data = await getStatus(slug);
+  const { status } = await getStatus(slug);
 
-  const key = data.status;
-  const { label, color } = statusDictionary[key];
+  const { label, color } = statusDictionary[status];
 
   return (
     <a
@@ -43,7 +43,7 @@ export async function StatusWidget({ slug, href }: StatusWidgetProps) {
     >
       {label}
       <span className="relative flex h-2 w-2">
-        {data.status === "operational" ? (
+        {status === "operational" ? (
           <span
             className={`absolute inline-flex h-full w-full animate-ping rounded-full ${color} opacity-75 duration-1000`}
           />


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

Include the _"incident"_ status to our public `/public/status/:slug` api endpoint and include update within the `StatusWidget` package.

New return type:

```json
{ "status": "incident" }
```
