### PR TITLE
fix: package/db/readme.md dead link fix

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -9,7 +9,7 @@ user/page/monitor settings. The timeseries data is stored in a
 Install the [Turso CLI](https://docs.turso.tech/reference/turso-cli).
 
 For local environment, first
-[install sqld](https://github.com/libsql/sqld/blob/main/docs/BUILD-RUN.md).
+[install sqld](https://github.com/tursodatabase/libsql/blob/main/docs/BUILD-RUN.md).
 
 When installing with Homebrew, follow:
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

packages/db/readme.md contains a hyperlink which redirects to repo which has been shifted.
I have just added the correct URL for it.

Old link: 
https://github.com/libsql/sqld/blob/main/docs/BUILD-RUN.md
![image](https://github.com/openstatusHQ/openstatus/assets/32923170/6c46ae68-3f79-4fae-a9d3-18ccd7018186)


New link:
https://github.com/tursodatabase/libsql/blob/main/docs/BUILD-RUN.md
![image](https://github.com/openstatusHQ/openstatus/assets/32923170/aad8691a-a4af-4cd7-baab-69a4b99429e2)


<!--- Please link to the issue here: -->
https://github.com/openstatusHQ/openstatus/issues/489