### PR TITLE
chore: convert timezone to gmt

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "cobe": "0.6.3",
     "contentlayer": "0.3.4",
     "date-fns": "2.30.0",
+    "date-fns-tz": "2.0.0",
     "lucide-react": "0.279.0",
     "luxon": "3.3.0",
     "micro": "10.0.1",

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -1,8 +1,8 @@
-import { headers } from "next/headers";
 import { ImageResponse } from "next/server";
 
 import { DESCRIPTION, TITLE } from "@/app/shared-metadata";
 import { getMonitorListData } from "@/lib/tb";
+import { convertTimezoneToGMT } from "@/lib/timezone";
 import {
   addBlackListInfo,
   getStatus,
@@ -18,7 +18,6 @@ const size = {
 };
 
 const LIMIT = 40;
-const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 const interRegular = fetch(
   new URL("../../../public/fonts/Inter-Regular.ttf", import.meta.url),
@@ -47,8 +46,7 @@ export async function GET(req: Request) {
     ? searchParams.get("monitorId")
     : undefined;
 
-  const headersList = headers();
-  const timezone = headersList.get("x-vercel-ip-timezone") || currentTimezone;
+  const timezone = convertTimezoneToGMT();
 
   // currently, we only show the tracker for a single(!) monitor
   const data =

--- a/apps/web/src/components/marketing/status-page/tracker-example.tsx
+++ b/apps/web/src/components/marketing/status-page/tracker-example.tsx
@@ -1,13 +1,11 @@
 import { Suspense } from "react";
-import { headers } from "next/headers";
 import Link from "next/link";
 
 import { Button } from "@openstatus/ui";
 
 import { Tracker } from "@/components/tracker";
 import { getHomeMonitorListData } from "@/lib/tb";
-
-const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+import { convertTimezoneToGMT } from "@/lib/timezone";
 
 export async function TrackerExample() {
   return (
@@ -36,9 +34,8 @@ function ExampleTrackerFallback() {
 }
 
 async function ExampleTracker() {
-  const headersList = headers();
-  const timezone = headersList.get("x-vercel-ip-timezone") || currentTimezone;
-  const data = await getHomeMonitorListData({ timezone });
+  const gmt = convertTimezoneToGMT();
+  const data = await getHomeMonitorListData({ timezone: gmt });
   if (!data) return null;
   return (
     <Tracker
@@ -47,7 +44,6 @@ async function ExampleTracker() {
       name="Ping"
       context="play"
       url="https://www.openstatus.dev/api/ping"
-      timezone={timezone}
     />
   );
 }

--- a/apps/web/src/components/status-page/monitor.tsx
+++ b/apps/web/src/components/status-page/monitor.tsx
@@ -1,4 +1,3 @@
-import { headers } from "next/headers";
 import type { z } from "zod";
 
 import type {
@@ -7,9 +6,8 @@ import type {
 } from "@openstatus/db/src/schema";
 
 import { getMonitorListData } from "@/lib/tb";
+import { convertTimezoneToGMT } from "@/lib/timezone";
 import { Tracker } from "../tracker";
-
-const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 export const Monitor = async ({
   monitor,
@@ -18,12 +16,10 @@ export const Monitor = async ({
   monitor: z.infer<typeof selectPublicMonitorSchema>;
   statusReports: z.infer<typeof selectPublicStatusReportSchemaWithRelation>[];
 }) => {
-  const headersList = headers();
-  const timezone = headersList.get("x-vercel-ip-timezone") || currentTimezone;
-
+  const gmt = convertTimezoneToGMT();
   const data = await getMonitorListData({
     monitorId: String(monitor.id),
-    timezone,
+    timezone: gmt,
   });
 
   // TODO: we could handle the `statusReports` here instead of passing it down to the tracker

--- a/apps/web/src/components/tracker.tsx
+++ b/apps/web/src/components/tracker.tsx
@@ -57,7 +57,6 @@ interface TrackerProps {
   name: string;
   description?: string;
   context?: "play" | "status-page"; // TODO: we might need to extract those two different use cases - for now it's ok I'd say.
-  timezone?: string;
   reports?: (StatusReport & { statusReportUpdates: StatusReportUpdate[] })[];
 }
 

--- a/apps/web/src/lib/timezone.ts
+++ b/apps/web/src/lib/timezone.ts
@@ -1,0 +1,38 @@
+import { headers } from "next/headers";
+import { getTimezoneOffset } from "date-fns-tz";
+
+export function getRequestHeaderTimezone() {
+  const headersList = headers();
+
+  /**
+   * Vercel includes ip timezone to request header
+   */
+  const requestTimezone = headersList.get("x-vercel-ip-timezone");
+
+  return requestTimezone;
+}
+
+export function convertTimezoneToGMT(timezone?: string) {
+  const requestTimezone = getRequestHeaderTimezone();
+
+  /**
+   * Server region timezone as fallback
+   */
+  const clientTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const msOffset = getTimezoneOffset(
+    timezone || requestTimezone || clientTimezone,
+  );
+
+  if (isNaN(msOffset)) return "Etc/UTC";
+
+  const hrOffset = msOffset / (1000 * 60 * 60);
+  const offset = hrOffset >= 0 ? `-${hrOffset}` : `+${Math.abs(hrOffset)}`;
+
+  return `Etc/GMT${offset}` as const;
+}
+
+/**
+ * All supported browser / node timezones
+ */
+export const supportedTimezones = Intl.supportedValuesOf("timeZone");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       date-fns:
         specifier: 2.30.0
         version: 2.30.0
+      date-fns-tz:
+        specifier: 2.0.0
+        version: 2.0.0(date-fns@2.30.0)
       lucide-react:
         specifier: 0.279.0
         version: 0.279.0(react@18.2.0)
@@ -6557,6 +6560,14 @@ packages:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
+    dev: false
+
+  /date-fns-tz@2.0.0(date-fns@2.30.0):
+    resolution: {integrity: sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==}
+    peerDependencies:
+      date-fns: '>=2.0.0'
+    dependencies:
+      date-fns: 2.30.0
     dev: false
 
   /date-fns@2.30.0:


### PR DESCRIPTION
To improve our tracker caching, we now bundle all the timezones and convert them into the `Etc/GTM` standard.

That means, `"Europe/Berlin"`, `"Europe/Paris"`, "`Europe/Amsterdam"`,... all will be converted to `Etc/GTM-1`. 

That way, the cache will **HIT** for common regions.
