### PR TITLE
feat(checker): implement backoff retry

### DIFF
--- a/apps/checker/go.mod
+++ b/apps/checker/go.mod
@@ -3,6 +3,7 @@ module github.com/openstatushq/openstatus/apps/checker
 go 1.21.4
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/gin-gonic/gin v1.9.1
 	github.com/rs/zerolog v1.31.0
 	github.com/stretchr/testify v1.8.3

--- a/apps/checker/go.sum
+++ b/apps/checker/go.sum
@@ -1,6 +1,8 @@
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

Updating some proper backoff retry instead of nested retry inside errors. I also clarified some use cases so the only reasons for the request to be retried inside the backoff would be:
- We were unable to build the request — it is not likely to happen but we still need to handle that use case.
- The server behind the monitor is unreachable — not a timeout or bad error code, just unreachable.

These two use cases will end in an immediate retry inside the first HTTP call to the checker.

Added a few questions (prefixed by `// Q:`) for some use cases as there seems to be a logic before the status update. My take is that the checker itself should be dumb and only execute the check and return the status of the check to the caller which should itself handle the status.

### A picture tells a thousand words (if any)

### Before this PR

n/a.

### After this PR

n/a.

### Related Issue (optional)

n/a.
