### PR TITLE
fix broken link

### DIFF
--- a/apps/web/src/content/posts/monitoring-latency-cf-workers-fly-koyeb-raylway-render.mdx
+++ b/apps/web/src/content/posts/monitoring-latency-cf-workers-fly-koyeb-raylway-render.mdx
@@ -37,7 +37,7 @@ app.get("/", (c) => {
 });
 ```
 
-You can find the code [here](https://github.com/openstatusHQ/status-code]), it’s
+You can find the code [here](https://github.com/openstatusHQ/status-code), it’s
 open source 😉.
 
 OpenStatus monitored our endpoint every **10 minutes** from **6 locations**


### PR DESCRIPTION
The link to https://github.com/openstatusHQ/status-code is broken on the new blog post!