### PR TITLE
feat: add validation for invalid test URLs

### DIFF
--- a/apps/web/src/app/api/checker/test/route.ts
+++ b/apps/web/src/app/api/checker/test/route.ts
@@ -5,6 +5,7 @@ import { monitorFlyRegionSchema } from "@openstatus/db/src/schema";
 
 import { checkRegion } from "@/app/play/checker/[id]/utils"; // TODO: move into a shared package
 import { payloadSchema } from "../schema";
+import { isAnInvalidTestUrl } from "../utils";
 
 export const runtime = "edge";
 export const preferredRegion = "auto";
@@ -28,9 +29,10 @@ export async function POST(request: Request) {
 
     const { url, region, method, headers, body } = _valid.data;
     // 🧑‍💻 for the smart one who want to create a loop hole
-    if (url === "https://www.openstatus.dev/api/checker/test") {
+    if (isAnInvalidTestUrl(url)) {
       return NextResponse.json({ success: true }, { status: 200 });
     }
+
     const res = await checkRegion(url, region, { method, headers, body });
 
     return NextResponse.json(res);

--- a/apps/web/src/app/api/checker/utils.ts
+++ b/apps/web/src/app/api/checker/utils.ts
@@ -1,0 +1,10 @@
+export const isAnInvalidTestUrl = (rawUrl: string) => {
+  const url = new URL(rawUrl);
+  const isSelfHostName = url.hostname
+    .split(".")
+    .slice(-2) // ex: any.sub.openstatus.dev
+    .join(".")
+    .includes("openstatus.dev"); // ex: openstatus.dev:80
+
+  return isSelfHostName && url.pathname.startsWith("/api/checker/");
+};


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

Hey!

I noticed that you can use links with different variations of the domain name and protocol. Here are some examples:

| Link | Explanation |
| --- | --- |
| <https://www.openstatus.dev/api/checker/test/> | Includes "www" and extra "/" |
| <https://openstatus.dev/api/checker/test/> | Does not include "www" |
| <http://www.openstatus.dev/api/checker/test/> | Uses HTTP instead of HTTPS |
| <http://openstatus.dev/api/checker/test/> | Uses HTTP instead of HTTPS and does not include "www" |

As we are only checking the URL string, we do not check the redirection of the links or the protocols. We only check the incoming URL.

It might be better if you parse the URL using `new URL()` and check if the origin is not the same as one of the hostnames configured in production (or the current host name included in the headers). 
Alternatively, if you want to continue allowing the use of your domain name, you can use `new URL(link).pathname` to check if the pathname is not strictly equal to the current route.

Hope this helps! Let me know if you have any questions 😁

Related: #732 
