### PR TITLE
[FIX] Get all Page endpoint to return expected array as response

### DIFF
--- a/apps/server/src/v1/page.test.ts
+++ b/apps/server/src/v1/page.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "bun:test";
 
 import { api } from ".";
-import { iso8601Regex } from "./test-utils";
 
 test.only("Create a page", async () => {
   const data = {

--- a/apps/server/src/v1/page.ts
+++ b/apps/server/src/v1/page.ts
@@ -338,8 +338,7 @@ pageApi.openapi(getAllRoute, async (c) => {
   const result = await db
     .select()
     .from(page)
-    .where(and(eq(page.workspaceId, workspaceId)))
-    .get();
+    .where(and(eq(page.workspaceId, workspaceId)));
 
   if (!result) return c.json({ code: 404, message: "Not Found" }, 404);
   const data = z.array(PageSchema).parse(result);


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

- Get All Page https://docs.openstatus.dev/api-reference/page/get-page is expected to return an Array of Pages instead of object. This is breaking all Endpoints of Page in production.

<!--- Describe your changes in detail -->

### A picture tells a thousand words (if any)

### Before this PR
- before it was giving Internal Server Error (Server was Crashing)
{Please add a screenshot here}

### After this PR

<img width="1093" alt="StatusPage" src="https://github.com/openstatusHQ/openstatus/assets/65061890/c83ed9d8-5de0-45f3-b53e-dbf5354fc7b0">

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->
