### PR TITLE
feat: improvements on response log page

### DIFF
--- a/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/_components/metrics.tsx
+++ b/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/_components/metrics.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { formatDistanceToNowStrict } from "date-fns";
 
 import type { LatencyMetric, ResponseTimeMetrics } from "@openstatus/tinybird";
@@ -72,7 +73,7 @@ export function Metrics({
         ) : null}
         <MetricsCard title="total pings" value={current.count} suffix="#" />
       </div>
-      <div>
+      <div className="grid gap-4">
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 md:grid-cols-5 md:gap-6">
           {metricsOrder.map((key) => {
             const value = current[key];
@@ -90,13 +91,28 @@ export function Metrics({
             );
           })}
         </div>
-        <p className="text-muted-foreground mt-4 text-xs">
-          Metrics calculated from the{" "}
-          <span className="font-medium lowercase">
-            {periodFormatter(period)}
-          </span>{" "}
-          over all the regions and compared with the previous period.
-        </p>
+        <div className="grid gap-2">
+          <p className="text-muted-foreground text-xs">
+            Metrics calculated from the{" "}
+            <span className="font-medium lowercase">
+              {periodFormatter(period)}
+            </span>{" "}
+            over all the regions and compared with the previous period.
+          </p>
+          {/* restricted to max 3d as we only support it in the list -> TODO: add more periods */}
+          {failures > 0 && ["1h", "1d", "3d", "7d"].includes(period) ? (
+            <p className="text-destructive text-xs">
+              The monitor had {failures} failed ping(s). See more in the{" "}
+              <Link
+                href={`./data?error=true&period=${period}`}
+                className=" underline underline-offset-4 hover:no-underline"
+              >
+                response logs
+              </Link>
+              .
+            </p>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/data/_components/data-table-wrapper.tsx
+++ b/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/data/_components/data-table-wrapper.tsx
@@ -4,7 +4,11 @@
 "use client";
 
 import { Suspense, use } from "react";
-import type { Row } from "@tanstack/react-table";
+import type {
+  ColumnFiltersState,
+  PaginationState,
+  Row,
+} from "@tanstack/react-table";
 
 import * as assertions from "@openstatus/assertions";
 import type { OSTinybird } from "@openstatus/tinybird";
@@ -20,7 +24,7 @@ import { api } from "@/trpc/client";
 type T = Awaited<ReturnType<ReturnType<OSTinybird["endpointList"]>>>;
 
 // FIXME: use proper type
-type Monitor = {
+export type Monitor = {
   monitorId: string;
   url: string;
   latency: number;
@@ -33,13 +37,23 @@ type Monitor = {
   assertions?: string | null;
 };
 
-export function DataTableWrapper({ data }: { data: Monitor[] }) {
+export function DataTableWrapper({
+  data,
+  filters,
+  pagination,
+}: {
+  data: Monitor[];
+  filters?: ColumnFiltersState;
+  pagination?: PaginationState;
+}) {
   return (
     <DataTable
       columns={columns}
       data={data}
       getRowCanExpand={() => true}
       renderSubComponent={renderSubComponent}
+      defaultColumnFilters={filters}
+      defaultPagination={pagination}
     />
   );
 }

--- a/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/data/_components/download-csv-button.tsx
+++ b/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/data/_components/download-csv-button.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Download } from "lucide-react";
+
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@openstatus/ui";
+
+import type { Monitor } from "./data-table-wrapper";
+
+function jsonToCsv(jsonData: Record<string, unknown>[]): string {
+  const csvRows: string[] = [];
+  const headers = Object.keys(jsonData[0]);
+
+  // Add header row
+  csvRows.push(headers.join(","));
+
+  // Add data rows
+  for (const row of jsonData) {
+    const values = headers.map((header) => {
+      const escaped = ("" + row[header]).replace(/"/g, '\\"');
+      return `"${escaped}"`;
+    });
+    csvRows.push(values.join(","));
+  }
+
+  return csvRows.join("\n");
+}
+
+function downloadCsv(data: string, filename: string) {
+  const blob = new Blob([data], { type: "text/csv" });
+  const link = document.createElement("a");
+  link.href = window.URL.createObjectURL(blob);
+  link.setAttribute("download", filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export function DownloadCSVButton({
+  data,
+  filename,
+}: {
+  data: Monitor[];
+  filename: string;
+}) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => {
+              const content = jsonToCsv(data);
+              downloadCsv(content, filename);
+            }}
+          >
+            <Download className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            Download <code>csv</code> file
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/data/loading.tsx
+++ b/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/data/loading.tsx
@@ -5,14 +5,14 @@ import { DataTableSkeleton } from "@/components/data-table/data-table-skeleton";
 export default function Loading() {
   return (
     <div className="grid gap-4">
-      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-        <div className="grid gap-1">
-          <Skeleton className="h-4 w-12" />
-          <Skeleton className="h-10 w-[150px]" />
-        </div>
+      <div className="flex flex-row items-center justify-between">
+        <Skeleton className="h-10 w-[150px]" />
+        <Skeleton className="h-9 w-9" />
       </div>
       <div className="grid gap-3">
         <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-8 w-32" />
           <Skeleton className="h-8 w-32" />
           <Skeleton className="h-8 w-16" />
         </div>

--- a/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/layout.tsx
+++ b/apps/web/src/app/app/[workspaceSlug]/(dashboard)/monitors/[id]/layout.tsx
@@ -1,10 +1,9 @@
 import { notFound } from "next/navigation";
 
-import { Badge } from "@openstatus/ui";
-
 import { Header } from "@/components/dashboard/header";
 import AppPageWithSidebarLayout from "@/components/layout/app-page-with-sidebar-layout";
 import { StatusDotWithTooltip } from "@/components/monitor/status-dot-with-tooltip";
+import { TagBadgeWithTooltip } from "@/components/monitor/tag-badge-with-tooltip";
 import { api } from "@/trpc/server";
 
 export default async function Layout({
@@ -37,9 +36,11 @@ export default async function Layout({
               status={monitor.status}
             />
             <span className="text-muted-foreground/50 text-xs">•</span>
-            <Badge className="inline-flex" variant="secondary">
-              {monitor.method}
-            </Badge>
+            <TagBadgeWithTooltip
+              tags={monitor.monitorTagsToMonitors.map(
+                ({ monitorTag }) => monitorTag,
+              )}
+            />
             <span className="text-muted-foreground/50 text-xs">•</span>
             <span className="text-sm">
               every <code>{monitor.periodicity}</code>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -9,6 +9,7 @@ import { Shell } from "@/components/dashboard/shell";
 
 export default function NotFound() {
   const router = useRouter();
+  // user should go back to dashboard
 
   return (
     <main className="flex min-h-screen w-full flex-col space-y-6 p-4 md:p-8">

--- a/apps/web/src/app/play/checker/[id]/_components/response-header-table.tsx
+++ b/apps/web/src/app/play/checker/[id]/_components/response-header-table.tsx
@@ -28,7 +28,7 @@ export function ResponseHeaderTable({
         {Object.entries(headers).map(([key, value]) => (
           <TableRow key={key}>
             <TableCell className="group">
-              <div className="flex items-center justify-between gap-4">
+              <div className="min-[130px] flex items-center justify-between gap-1">
                 <code className="break-all font-medium">{key}</code>
                 <CopyToClipboardButton
                   copyValue={key}
@@ -37,7 +37,7 @@ export function ResponseHeaderTable({
               </div>
             </TableCell>
             <TableCell className="group">
-              <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center justify-between gap-1">
                 <code className="break-all">{value}</code>
                 <CopyToClipboardButton
                   copyValue={value}

--- a/apps/web/src/app/play/checker/[id]/page.tsx
+++ b/apps/web/src/app/play/checker/[id]/page.tsx
@@ -50,12 +50,12 @@ export default async function CheckPage({ params, searchParams }: Props) {
     <>
       <BackButton href="/play/checker" />
       <Shell className="flex flex-col gap-8">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex flex-col gap-1">
-            <h1 className="text-3xl font-semibold">
-              <span className="truncate">{data.url}</span>
+        <div className="flex justify-between gap-4">
+          <div className="flex max-w-[calc(100%-50px)] flex-col gap-1">
+            <h1 className="text-wrap truncate text-lg font-semibold sm:text-xl md:text-3xl">
+              {data.url}
             </h1>
-            <p className="text-muted-foreground">
+            <p className="text-muted-foreground text-sm sm:text-base">
               {timestampFormatter(data.time)}
             </p>
           </div>

--- a/apps/web/src/components/data-table/columns.tsx
+++ b/apps/web/src/components/data-table/columns.tsx
@@ -2,7 +2,6 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 import { format } from "date-fns";
-import { Check, X } from "lucide-react";
 import * as z from "zod";
 
 import type { Ping } from "@openstatus/tinybird";
@@ -19,20 +18,14 @@ import { DataTableStatusBadge } from "./data-table-status-badge";
 
 export const columns: ColumnDef<Ping>[] = [
   {
-    id: "state",
+    accessorKey: "error",
+    header: () => null,
     cell: ({ row }) => {
       if (row.original.error)
-        return (
-          <div className="max-w-max rounded-full bg-rose-500 p-1">
-            <X className="text-background h-3 w-3" />
-          </div>
-        );
-      return (
-        <div className="max-w-max rounded-full bg-green-500 p-1">
-          <Check className="text-background h-3 w-3" />
-        </div>
-      );
+        return <div className="h-2.5 w-2.5 rounded-full bg-rose-500" />;
+      return <div className="h-2.5 w-2.5 rounded-full bg-green-500" />;
     },
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
   },
   {
     accessorKey: "cronTimestamp",
@@ -86,6 +79,14 @@ export const columns: ColumnDef<Ping>[] = [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Latency (ms)" />
     ),
+    filterFn: (row, id, value) => {
+      const { select, input } = value || {};
+      if (select === "min" && input)
+        return parseInt(row.getValue(id)) > parseInt(input);
+      if (select === "max" && input)
+        return parseInt(row.getValue(id)) < parseInt(input);
+      return true;
+    },
   },
   {
     accessorKey: "region",

--- a/apps/web/src/components/data-table/data-table-faceted-input-dropdown.tsx
+++ b/apps/web/src/components/data-table/data-table-faceted-input-dropdown.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import type { Column } from "@tanstack/react-table";
+import { PlusCircle } from "lucide-react";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+} from "@openstatus/ui";
+
+interface DataTableFacetedInputDropdownProps<TData, TValue> {
+  column?: Column<TData, TValue>;
+  title?: string;
+  options: {
+    label: string;
+    value: string | number | boolean;
+    icon?: React.ComponentType<{ className?: string }>;
+  }[];
+}
+
+export function DataTableFacetedInputDropdown<TData, TValue>({
+  column,
+  title,
+  options,
+}: DataTableFacetedInputDropdownProps<TData, TValue>) {
+  const selectedValue = column?.getFilterValue() as {
+    input?: number;
+    select?: string;
+  };
+
+  return (
+    <div className="border-input ring-offset-background focus-within:ring-ring group flex h-8 items-center overflow-hidden rounded-md border border-dashed bg-transparent text-sm focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2">
+      <Select
+        value={selectedValue?.select || ""}
+        onValueChange={(value) => {
+          column?.setFilterValue({
+            ...selectedValue,
+            select: value,
+          });
+        }}
+      >
+        <SelectTrigger className="focus:ring-offet-0 hover:bg-muted h-8 max-w-min space-x-2 rounded-none border-0 ring-offset-inherit focus:ring-0">
+          <SelectValue
+            placeholder={
+              <div className="flex items-center text-xs font-medium">
+                <PlusCircle className="mr-2 h-4 w-4" />
+                {title}
+              </div>
+            }
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {options?.map((option) => {
+              return (
+                <SelectItem
+                  key={String(option.value)}
+                  value={String(option.value)}
+                >
+                  {option.icon && (
+                    <option.icon className="text-muted-foreground mr-2 h-4 w-4" />
+                  )}
+                  {option.label}
+                </SelectItem>
+              );
+            })}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <Separator orientation="vertical" className="h-4" />
+      <input
+        className="placeholder:text-muted-foreground bg-background w-24 rounded-md px-3 py-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        type="number"
+        placeholder="4000"
+        min={0}
+        value={selectedValue?.input || ""}
+        onChange={(e) => {
+          column?.setFilterValue({
+            ...selectedValue,
+            input: parseInt(e.target.value),
+          });
+        }}
+      />
+      <div className="border-input bg-muted flex h-full items-center p-2 text-sm">
+        ms
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/data-table/data-table-pagination.tsx
+++ b/apps/web/src/components/data-table/data-table-pagination.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useRouter } from "next/navigation";
 import type { Table } from "@tanstack/react-table";
 import {
   ChevronLeft,
@@ -15,6 +18,10 @@ import {
   SelectValue,
 } from "@openstatus/ui";
 
+import useUpdateSearchParams from "@/hooks/use-update-search-params";
+
+// REMINDER: pageIndex pagination issue - jumping back to 0 after change
+
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
 }
@@ -22,9 +29,23 @@ interface DataTablePaginationProps<TData> {
 export function DataTablePagination<TData>({
   table,
 }: DataTablePaginationProps<TData>) {
+  const updateSearchParams = useUpdateSearchParams();
+  const router = useRouter();
+
+  const updatePageSearchParams = (
+    values: Record<string, number | string | null>,
+  ) => {
+    const newSearchParams = updateSearchParams(values);
+    router.replace(`?${newSearchParams}`, { scroll: false });
+  };
+
   return (
     <div className="flex items-center justify-between px-2">
-      <div />
+      <div>
+        <p className="text-muted-foreground text-sm">
+          {table.getFilteredRowModel().rows.length} row(s) filtered
+        </p>
+      </div>
       <div className="flex items-center space-x-6 lg:space-x-8">
         <div className="flex items-center space-x-2">
           <p className="text-sm font-medium">Rows per page</p>
@@ -32,6 +53,7 @@ export function DataTablePagination<TData>({
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {
               table.setPageSize(Number(value));
+              updatePageSearchParams({ pageSize: value });
             }}
           >
             <SelectTrigger className="h-8 w-[70px]">
@@ -54,7 +76,9 @@ export function DataTablePagination<TData>({
           <Button
             variant="outline"
             className="hidden h-8 w-8 p-0 lg:flex"
-            onClick={() => table.setPageIndex(0)}
+            onClick={() => {
+              table.setPageIndex(0);
+            }}
             disabled={!table.getCanPreviousPage()}
           >
             <span className="sr-only">Go to first page</span>
@@ -63,7 +87,9 @@ export function DataTablePagination<TData>({
           <Button
             variant="outline"
             className="h-8 w-8 p-0"
-            onClick={() => table.previousPage()}
+            onClick={() => {
+              table.previousPage();
+            }}
             disabled={!table.getCanPreviousPage()}
           >
             <span className="sr-only">Go to previous page</span>
@@ -72,7 +98,9 @@ export function DataTablePagination<TData>({
           <Button
             variant="outline"
             className="h-8 w-8 p-0"
-            onClick={() => table.nextPage()}
+            onClick={() => {
+              table.nextPage();
+            }}
             disabled={!table.getCanNextPage()}
           >
             <span className="sr-only">Go to next page</span>
@@ -81,7 +109,9 @@ export function DataTablePagination<TData>({
           <Button
             variant="outline"
             className="hidden h-8 w-8 p-0 lg:flex"
-            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            onClick={() => {
+              table.setPageIndex(table.getPageCount() - 1);
+            }}
             disabled={!table.getCanNextPage()}
           >
             <span className="sr-only">Go to last page</span>

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import type { Table } from "@tanstack/react-table";
 import { X } from "lucide-react";
 
@@ -7,7 +8,9 @@ import { Button } from "@openstatus/ui";
 import { flyRegionsDict } from "@openstatus/utils";
 
 import { codesDict } from "@/data/code-dictionary";
+import useUpdateSearchParams from "@/hooks/use-update-search-params";
 import { DataTableFacetedFilter } from "./data-table-faceted-filter";
+import { DataTableFacetedInputDropdown } from "./data-table-faceted-input-dropdown";
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
@@ -16,11 +19,13 @@ interface DataTableToolbarProps<TData> {
 export function DataTableToolbar<TData>({
   table,
 }: DataTableToolbarProps<TData>) {
+  const router = useRouter();
+  const updateSearchParams = useUpdateSearchParams();
   const isFiltered = table.getState().columnFilters.length > 0;
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3">
-      <div className="flex flex-1 items-center gap-2">
+      <div className="flex flex-1 flex-wrap items-center gap-2">
         {table.getColumn("statusCode") && (
           <DataTableFacetedFilter
             column={table.getColumn("statusCode")}
@@ -47,10 +52,41 @@ export function DataTableToolbar<TData>({
             })}
           />
         )}
+        {table.getColumn("error") && (
+          <DataTableFacetedFilter
+            column={table.getColumn("error")}
+            title="Request"
+            options={[
+              // once we include 'degraded' requests, we can revert error to a number
+              { value: true, label: "Failed" },
+              { value: false, label: "Success" },
+            ]}
+          />
+        )}
+        <DataTableFacetedInputDropdown
+          title="Latency"
+          column={table.getColumn("latency")}
+          options={[
+            { value: "min", label: "Min." },
+            { value: "max", label: "Max." },
+          ]}
+        />
         {isFiltered && (
           <Button
             variant="ghost"
-            onClick={() => table.resetColumnFilters()}
+            onClick={() => {
+              table.resetColumnFilters();
+
+              // reset filter search params (but not period e.g.)
+              const newSearchParams = updateSearchParams({
+                error: null,
+                statusCode: null,
+                region: null,
+              });
+              router.replace(`?${newSearchParams}`, {
+                scroll: false,
+              });
+            }}
             className="h-8 px-2 lg:px-3"
           >
             Reset
@@ -58,7 +94,6 @@ export function DataTableToolbar<TData>({
           </Button>
         )}
       </div>
-      {/* <DataTableDateRangePicker /> */}
     </div>
   );
 }

--- a/apps/web/src/components/data-table/data-table.tsx
+++ b/apps/web/src/components/data-table/data-table.tsx
@@ -5,6 +5,7 @@ import type {
   ColumnDef,
   ColumnFiltersState,
   ExpandedState,
+  PaginationState,
   Row,
   SortingState,
 } from "@tanstack/react-table";
@@ -36,6 +37,8 @@ interface DataTableProps<TData, TValue> {
   renderSubComponent(props: { row: Row<TData> }): React.ReactElement;
   getRowCanExpand(row: Row<TData>): boolean;
   autoResetExpanded?: boolean;
+  defaultColumnFilters?: ColumnFiltersState;
+  defaultPagination?: PaginationState;
 }
 
 export function DataTable<TData, TValue>({
@@ -44,17 +47,21 @@ export function DataTable<TData, TValue>({
   renderSubComponent,
   getRowCanExpand,
   autoResetExpanded,
+  defaultColumnFilters = [],
+  defaultPagination = { pageIndex: 0, pageSize: 10 },
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    [],
-  );
+  const [columnFilters, setColumnFilters] =
+    React.useState<ColumnFiltersState>(defaultColumnFilters);
   const [expanded, setExpanded] = React.useState<ExpandedState>({});
+  const [pagination, setPagination] =
+    React.useState<PaginationState>(defaultPagination);
 
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    onPaginationChange: setPagination,
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
@@ -68,6 +75,7 @@ export function DataTable<TData, TValue>({
       sorting,
       columnFilters,
       expanded,
+      pagination,
     },
   });
 

--- a/apps/web/src/components/data-table/monitor/columns.tsx
+++ b/apps/web/src/components/data-table/monitor/columns.tsx
@@ -11,7 +11,6 @@ import type {
 } from "@openstatus/tinybird";
 import { Tracker } from "@openstatus/tracker";
 import {
-  Badge,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -19,7 +18,7 @@ import {
 } from "@openstatus/ui";
 
 import { StatusDotWithTooltip } from "@/components/monitor/status-dot-with-tooltip";
-import { TagBadge } from "@/components/monitor/tag-badge";
+import { TagBadgeWithTooltip } from "@/components/monitor/tag-badge-with-tooltip";
 import { Bar } from "@/components/tracker/tracker";
 import { DataTableRowActions } from "./data-table-row-actions";
 
@@ -52,14 +51,7 @@ export const columns: ColumnDef<{
     header: "Tags",
     cell: ({ row }) => {
       const { tags } = row.original;
-      const [first, second, ...rest] = tags || [];
-      return (
-        <div className="flex gap-2">
-          {first ? <TagBadge {...first} /> : null}
-          {second ? <TagBadge {...second} /> : null}
-          {rest.length > 0 ? <TagsTooltip tags={rest || []} /> : null}
-        </div>
-      );
+      return <TagBadgeWithTooltip tags={tags} />;
     },
     filterFn: (row, id, value) => {
       if (!Array.isArray(value)) return true;
@@ -153,23 +145,6 @@ export const columns: ColumnDef<{
     },
   },
 ];
-
-function TagsTooltip({ tags }: { tags: MonitorTag[] }) {
-  return (
-    <TooltipProvider>
-      <Tooltip delayDuration={200}>
-        <TooltipTrigger>
-          <Badge variant="secondary">+{tags.length}</Badge>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="flex gap-2">
-          {tags.map((tag) => (
-            <TagBadge key={tag.id} {...tag} />
-          ))}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
 
 function HeaderTooltip({ label, content }: { label: string; content: string }) {
   return (

--- a/apps/web/src/components/data-table/monitor/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/monitor/data-table-toolbar.tsx
@@ -21,7 +21,7 @@ export function DataTableToolbar<TData>({
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3">
-      <div className="flex flex-1 items-center gap-2">
+      <div className="flex flex-1 flex-wrap items-center gap-2">
         <Input
           placeholder="Filter names..."
           value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}

--- a/apps/web/src/components/monitor/tag-badge-with-tooltip.tsx
+++ b/apps/web/src/components/monitor/tag-badge-with-tooltip.tsx
@@ -1,0 +1,34 @@
+import type { MonitorTag } from "@openstatus/db/src/schema";
+import {
+  Badge,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@openstatus/ui";
+
+import { TagBadge } from "./tag-badge";
+
+export function TagBadgeWithTooltip({ tags }: { tags?: MonitorTag[] }) {
+  const [first, second, ...rest] = tags || [];
+  return (
+    <div className="flex gap-2">
+      {first ? <TagBadge {...first} /> : null}
+      {second ? <TagBadge {...second} /> : null}
+      {rest.length > 0 ? (
+        <TooltipProvider>
+          <Tooltip delayDuration={200}>
+            <TooltipTrigger>
+              <Badge variant="secondary">+{rest.length}</Badge>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="flex gap-2">
+              {rest.map((tag) => (
+                <TagBadge key={tag.id} {...tag} />
+              ))}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/monitor/tag-badge.tsx
+++ b/apps/web/src/components/monitor/tag-badge.tsx
@@ -2,8 +2,8 @@ import { Badge } from "@openstatus/ui";
 
 function getStyle(color: string) {
   return {
-    borderColor: `${color}20`,
-    backgroundColor: `${color}30`,
+    borderColor: `${color}10`,
+    backgroundColor: `${color}20`,
     color,
   };
 }

--- a/packages/tinybird/pipes/__ttl_3d.pipe
+++ b/packages/tinybird/pipes/__ttl_3d.pipe
@@ -12,7 +12,8 @@ SQL >
         statusCode,
         url,
         workspaceId,
-        cronTimestamp
+        cronTimestamp,
+        timestamp
     FROM ping_response__v8
 
 TYPE materialized

--- a/packages/tinybird/pipes/__ttl_3d_list_get.pipe
+++ b/packages/tinybird/pipes/__ttl_3d_list_get.pipe
@@ -1,0 +1,14 @@
+VERSION 1
+
+NODE __ttl_3d_list_get__v1_0
+SQL >
+
+    %
+    SELECT latency, monitorId, error, region, statusCode, url, workspaceId, cronTimestamp, timestamp
+    FROM __ttl_3d_mv__v1
+    WHERE
+        monitorId = {{ String(monitorId, '1') }}
+        {% if defined(url) %} AND url = {{ String(url) }} {% end %}
+    ORDER BY cronTimestamp DESC
+
+

--- a/packages/tinybird/pipes/__ttl_7d.pipe
+++ b/packages/tinybird/pipes/__ttl_7d.pipe
@@ -12,7 +12,8 @@ SQL >
         statusCode,
         url,
         workspaceId,
-        cronTimestamp
+        cronTimestamp,
+        timestamp
     FROM ping_response__v8
 
 TYPE materialized

--- a/packages/tinybird/pipes/__ttl_7d_list_get.pipe
+++ b/packages/tinybird/pipes/__ttl_7d_list_get.pipe
@@ -1,0 +1,14 @@
+VERSION 1
+
+NODE __ttl_7d_list_get__v1_0
+SQL >
+
+    %
+    SELECT latency, monitorId, error, region, statusCode, url, workspaceId, cronTimestamp, timestamp
+    FROM __ttl_7d_mv__v1
+    WHERE
+        monitorId = {{ String(monitorId, '1') }}
+        {% if defined(url) %} AND url = {{ String(url) }} {% end %}
+    ORDER BY cronTimestamp DESC
+
+

--- a/packages/tinybird/src/os-client.ts
+++ b/packages/tinybird/src/os-client.ts
@@ -164,9 +164,7 @@ export class OSTinybird {
     };
   }
 
-  // TBH: not sure if we need more than 1d for that, better allow the user
-  // to click on a specific region and time
-  endpointList(period: "1h" | "1d") {
+  endpointList(period: "1h" | "1d" | "3d" | "7d") {
     const parameters = z.object({
       monitorId: z.string(),
       url: z.string().optional(),


### PR DESCRIPTION
Related to #735.

- add max/min latency filter
- add request 'failed'/'success' filter
- add '3d' and '7d' response log period (tb) to access more data
- add total of rows queried (for better overview)
- add better search queries for shareability + add destructive text on overview with link to filtered response logs in case of error
- add download button for period filter (commented out yet)
- small UI improvements