### PR TITLE
Fix limits FAQ entry with updated amount of monitors

### DIFF
--- a/apps/web/src/content/faq/limits.mdx
+++ b/apps/web/src/content/faq/limits.mdx
@@ -3,7 +3,7 @@ title: What are the limits?
 order: 1
 ---
 
-As free user you will start with a total of **3 monitors** and **1 status page**
+As free user you will start with a total of **1 monitor** and **1 status page**
 as well as cron jobs of min. `10m`. You can upgrade to a paid plan at any time.
 Check the pricing table for more details.
 


### PR DESCRIPTION
## Type of change


- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation

## Description

The FAQ on the pricing page displayed **3 monitors**, but it's just one on the free tier.

