### PR TITLE
chore: feeds are not available for protected pages

### DIFF
--- a/apps/web/src/app/status-page/[domain]/_components/header.tsx
+++ b/apps/web/src/app/status-page/[domain]/_components/header.tsx
@@ -68,6 +68,7 @@ export function Header({ navigation, plan, page }: Props) {
               plan={plan}
               slug={page.slug}
               customDomain={page.customDomain}
+              passwordProtected={page.passwordProtected}
             />
           </div>
         </div>

--- a/apps/web/src/app/status-page/[domain]/_components/subscribe-button.tsx
+++ b/apps/web/src/app/status-page/[domain]/_components/subscribe-button.tsx
@@ -20,6 +20,7 @@ interface Props {
   plan: WorkspacePlan;
   slug: string;
   customDomain?: string;
+  passwordProtected?: boolean | null;
   isDemo?: boolean;
 }
 
@@ -27,6 +28,7 @@ export function SubscribeButton({
   plan,
   slug,
   customDomain,
+  passwordProtected = false,
   isDemo = false,
 }: Props) {
   const [showModal, setShowModal] = useState(false);
@@ -46,28 +48,32 @@ export function SubscribeButton({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild>
-            <a
-              href={`${baseUrl}/feed/rss`}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2"
-            >
-              <Rss className="h-4 w-4" />
-              RSS
-            </a>
-          </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <a
-              href={`${baseUrl}/feed/atom`}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2"
-            >
-              <Rss className="h-4 w-4" />
-              Atom
-            </a>
-          </DropdownMenuItem>
+          {!passwordProtected ? (
+            <>
+              <DropdownMenuItem asChild>
+                <a
+                  href={`${baseUrl}/feed/rss`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2"
+                >
+                  <Rss className="h-4 w-4" />
+                  RSS
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a
+                  href={`${baseUrl}/feed/atom`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2"
+                >
+                  <Rss className="h-4 w-4" />
+                  Atom
+                </a>
+              </DropdownMenuItem>
+            </>
+          ) : null}
           {isSubscribers ? (
             <DropdownMenuItem onClick={() => setShowModal(true)}>
               <Mail className="h-4 w-4 mr-2" />

--- a/apps/web/src/app/status-page/[domain]/feed/[type]/route.ts
+++ b/apps/web/src/app/status-page/[domain]/feed/[type]/route.ts
@@ -1,7 +1,7 @@
 import { statusDict } from "@/data/incidents-dictionary";
 import { api } from "@/trpc/server";
 import { Feed } from "feed";
-import { notFound } from "next/navigation";
+import { notFound, unauthorized } from "next/navigation";
 import { getBaseUrl } from "../../utils";
 
 export const revalidate = 60;
@@ -15,6 +15,7 @@ export async function GET(
 
   const page = await api.page.getPageBySlug.query({ slug: domain });
   if (!page) return notFound();
+  if (page.passwordProtected) return unauthorized();
 
   const baseUrl = getBaseUrl({
     slug: page.slug,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description
Hides feed buttons and disables rss/atom endpoints for protected status pages.

### Related Issue

https://github.com/openstatusHQ/openstatus/issues/1139