### PR TITLE
chore: clean up corepack usage in Devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -2,9 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.10.6/.schema/devbox.schema.json",
   "packages": ["turso-cli@latest", "nodejs@20", "bun@latest", "sqld@latest"],
   "env": {
-    "DEVBOX_COREPACK_ENABLED": "true"
-  },
-  "shell": {
-    "init_hook": ["yes | pnpm -v &> /dev/null"]
+    "DEVBOX_COREPACK_ENABLED": "true",
+    "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
   }
 }


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

<!--- Describe your changes in detail -->

It's a no-op change to make sure `corepack` doesn't display an interactive prompt the first time it downloads `pnpm`. There is an environment variable `COREPACK_ENABLE_DOWNLOAD_PROMPT` that can be used instead of the previous workaround.

To test:

1. Open a Devbox shell: `devbox shell`
2. Clear the corepack cache: `corepack cache clean`
3. Exit the Devbox shell: `exit`
4. Open a Devbox shell: `devbox shell`
5. Run `pnpm -v`

You should see the `pnpm` version printed without a prompt to download `pnpm`.