### PR TITLE
fix: handle missing Google account last name

### DIFF
--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -33,7 +33,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             lastName: params.profile.family_name || "",
             photoUrl: params.profile.picture,
             // keep the name in sync
-            name: ${params.profile.given_name}${params.profile.family_name ? " " + params.profile.family_name : ""},
+            name: `${params.profile.given_name} ${
+              params.profile.family_name || ""
+            }`.trim(),
             updatedAt: new Date(),
           })
           .where(eq(user.id, Number(params.user.id)))

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -30,10 +30,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           .update(user)
           .set({
             firstName: params.profile.given_name,
-            lastName: params.profile.family_name,
+            lastName: params.profile.family_name || "",
             photoUrl: params.profile.picture,
             // keep the name in sync
-            name: `${params.profile.given_name} ${params.profile.family_name}`,
+            name: ${params.profile.given_name}${params.profile.family_name ? " " + params.profile.family_name : ""},
             updatedAt: new Date(),
           })
           .where(eq(user.id, Number(params.user.id)))


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix  
- [ ] 🌟 New feature  
- [ ] 🔨 Breaking change  
- [ ] 📖 Refactoring / dependency upgrade / documentation  

## Description

This PR fixes a bug where the `lastName` and `name` fields stores `undefined` when a user signs in using Google and does not have a `last name` set on their profile.

The updated logic ensures that:
- `lastName` is an empty string if `params.profile.family_name` is missing.
- `name` only includes the last name if it exists.

This prevents user names like `"John undefined"` from being stored or displayed.

### A picture tells a thousand words (if any)

![image](https://github.com/user-attachments/assets/29143c1c-2c66-4ea5-9a02-a165919e4a4e)

### Before this PR

User name could be saved as `"John undefined"` if Google profile had no last name.

### After this PR

User name is saved as `"John"` in the same scenario.

### Related Issue (optional)

_No related issue linked._
