### PR TITLE
chore: parallelize follow-up email sending with Promise.all

### DIFF
--- a/apps/workflows/package.json
+++ b/apps/workflows/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@openstatus/tsconfig": "workspace:*",
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "typescript": "5.6.2"
   }
 }

--- a/apps/workflows/src/cron/emails.ts
+++ b/apps/workflows/src/cron/emails.ts
@@ -28,7 +28,7 @@ export async function sendFollowUpEmails() {
     .map((u) => u.email)
     .filter((email) => email !== null)
     //  I don't know why but I can't have both filter at the same time
-    .filter((email) => typeof email === "string" && email.trim() !== "");
+    .filter((email) => email.trim() !== "");
 
   // Chunk emails into batches of 80
   const batchSize = 80;

--- a/apps/workflows/src/cron/emails.ts
+++ b/apps/workflows/src/cron/emails.ts
@@ -28,7 +28,7 @@ export async function sendFollowUpEmails() {
     .map((u) => u.email)
     .filter((email) => email !== null)
     //  I don't know why but I can't have both filter at the same time
-    .filter((email) => email.trim() !== "");
+    .filter((email) => typeof email === "string" && email.trim() !== "");
 
   // Chunk emails into batches of 80
   const batchSize = 80;

--- a/apps/workflows/src/cron/emails.ts
+++ b/apps/workflows/src/cron/emails.ts
@@ -25,19 +25,20 @@ export async function sendFollowUpEmails() {
 
   // Filter valid emails
   const validEmails = users
-    .filter((user) => user.email)
-    .map((user) => user.email);
+    .filter((user): user is { email: string } => typeof user.email === "string" && user.email.trim() !== "")
+    .map(user => user.email);
 
-  // Chunk emails into batches of 100
+  // Chunk emails into batches of 80
   const batchSize = 80;
   for (let i = 0; i < validEmails.length; i += batchSize) {
-    const batch = validEmails.slice(i, i + batchSize) as string[];
+    const batch = validEmails.slice(i, i + batchSize);
     console.log(`Sending batch with ${batch.length} emails...`);
-
     try {
       await email.sendFollowUpBatched({ to: batch });
     } catch {
+      //Stop email send when rate limit error is faced in order to avoid wasteful API calls
       console.error("Rate limit exceeded. Stopping further sends.");
+      break;
     }
   }
 }

--- a/apps/workflows/src/cron/emails.ts
+++ b/apps/workflows/src/cron/emails.ts
@@ -25,8 +25,10 @@ export async function sendFollowUpEmails() {
 
   // Filter valid emails
   const validEmails = users
-    .filter((user): user is { email: string } => typeof user.email === "string" && user.email.trim() !== "")
-    .map(user => user.email);
+    .map((u) => u.email)
+    .filter((email) => email !== null)
+    //  I don't know why but I can't have both filter at the same time
+    .filter((email) => email.trim() !== "");
 
   // Chunk emails into batches of 80
   const batchSize = 80;

--- a/apps/workflows/src/cron/emails.ts
+++ b/apps/workflows/src/cron/emails.ts
@@ -21,9 +21,9 @@ export async function sendFollowUpEmails() {
 
   console.log(`Found ${users.length} users to send follow ups.`);
 
-  for (const user of users) {
-    if (user.email) {
-      await email.sendFollowUp({ to: user.email });
-    }
-  }
+  await Promise.all(
+    users
+      .filter((user) => user.email)
+      .map((user) => email.sendFollowUp({ to: user.email }))
+  );
 }

--- a/packages/emails/src/client.tsx
+++ b/packages/emails/src/client.tsx
@@ -106,12 +106,10 @@ export class EmailClient {
     try {
       const html = await render(<TeamInvitationEmail {...req} />);
       const result = await this.client.emails.send({
-        from: `${
-          req.workspaceName ?? "OpenStatus"
-        } <notifications@notifications.openstatus.dev>`,
-        subject: `You've been invited to join ${
-          req.workspaceName ?? "OpenStatus"
-        }`,
+        from: `${req.workspaceName ?? "OpenStatus"
+          } <notifications@notifications.openstatus.dev>`,
+        subject: `You've been invited to join ${req.workspaceName ?? "OpenStatus"
+          }`,
         to: req.to,
         html,
       });

--- a/packages/emails/src/client.tsx
+++ b/packages/emails/src/client.tsx
@@ -106,10 +106,12 @@ export class EmailClient {
     try {
       const html = await render(<TeamInvitationEmail {...req} />);
       const result = await this.client.emails.send({
-        from: `${req.workspaceName ?? "OpenStatus"
-          } <notifications@notifications.openstatus.dev>`,
-        subject: `You've been invited to join ${req.workspaceName ?? "OpenStatus"
-          }`,
+        from: `${
+          req.workspaceName ?? "OpenStatus"
+        } <notifications@notifications.openstatus.dev>`,
+        subject: `You've been invited to join ${
+          req.workspaceName ?? "OpenStatus"
+        }`,
         to: req.to,
         html,
       });

--- a/packages/emails/src/client.tsx
+++ b/packages/emails/src/client.tsx
@@ -56,21 +56,21 @@ export class EmailClient {
         }))
       );
 
-      if (result.error) {
-        if (result.error.name === "rate_limit_exceeded") {
-          throw result.error;
-        }
-
-        console.error(`Batch send error:`, result.error);
+      if (!result.error) {
+        console.log(`Sent follow up emails to ${req.to}`);
         return;
       }
 
-      console.log(`Sent follow up email to ${req.to}`);
-    } catch (err: any) {
-      if (err?.name === "rate_limit_exceeded") {
-        throw err;
-      };
-      // Also catch unexpected exceptions
+      throw result.error;
+    } catch (err: unknown) {
+      if (typeof err === "object" && err !== null && "name" in err) {
+        const error = err as { name: string };
+        //Only throw error if rate limit is exceeded, else use console error
+        if (error.name === "rate_limit_exceeded") {
+          throw error;
+        }
+      }
+
       console.error(`Unexpected error sending follow up emails to ${req.to}:`, err);
       return;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
       '@types/bun':
         specifier: latest
         version: 1.2.5
+      typescript:
+        specifier: 5.6.2
+        version: 5.6.2
 
   packages/analytics:
     dependencies:


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] 🔨 Breaking change
- [ ] 🐛 Bug fix
- [ ] 🌟 New feature

## Description

<!--- Describe your changes in detail -->
Previously, follow-up emails were sent sequentially inside a for...of loop, leading to slower execution. This change uses Promise.all to send emails in parallel, significantly improving the speed of the process.

This PR improves the performance of the sendFollowUpEmails function by replacing the sequential email sending (using a for...of loop) with parallel sending using Promise.all.
This change speeds up the process, especially when there are many users to email, without affecting the functionality.

### A picture tells a thousand words (if any)

### Before this PR

![Screenshot from 2025-04-28 03-40-11](https://github.com/user-attachments/assets/7c9ad5e5-0c98-4eba-971d-d0f07fa704de)

### After this PR

![Screenshot from 2025-04-28 03-40-40](https://github.com/user-attachments/assets/4d09360b-16d7-4317-b229-deb937f6aa1e)

### Related Issue (optional)

<!--- Please link to the issue here: -->
