### PR TITLE
proxy user-agent and location to op

### DIFF
--- a/apps/server/src/libs/middlewares/track.ts
+++ b/apps/server/src/libs/middlewares/track.ts
@@ -32,6 +32,8 @@ export function trackMiddleware(event: EventProps, eventProps?: string[]) {
           userId: `api_${workspace.id}`,
           workspaceId: `${workspace.id}`,
           plan: workspace.plan,
+          location: c.req.raw.headers.get("x-forwarded-for") ?? undefined,
+          userAgent: c.req.raw.headers.get("user-agent") ?? undefined,
         });
         await analytics.track({ ...event, additionalProps });
       }, 0);

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -6,6 +6,7 @@ import { db, eq } from "@openstatus/db";
 import { user } from "@openstatus/db/src/schema";
 
 import { WelcomeEmail, sendEmail } from "@openstatus/emails";
+import { headers } from "next/headers";
 import { adapter } from "./adapter";
 import { GitHubProvider, GoogleProvider, ResendProvider } from "./providers";
 
@@ -92,6 +93,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       const analytics = await setupAnalytics({
         userId: `usr_${params.user.id}`,
         email: params.user.email,
+        location: (await headers()).get("x-forwarded-for") ?? undefined,
+        userAgent: (await headers()).get("user-agent") ?? undefined,
       });
 
       await analytics.track(Events.CreateUser);
@@ -104,6 +107,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       const analytics = await setupAnalytics({
         userId: `usr_${params.user.id}`,
         email: params.user.email,
+        location: (await headers()).get("x-forwarded-for") ?? undefined,
+        userAgent: (await headers()).get("user-agent") ?? undefined,
       });
 
       await analytics.track(Events.SignInUser);

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -223,6 +223,7 @@ const enforceUserIsAuthed = t.middleware(async (opts) => {
 
       if (user && workspace) {
         identify = {
+          ...identify,
           userId: `usr_${user.id}`,
           email: user.email || undefined,
           workspaceId: String(workspace.id),


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

This will proxy the users user-agent and IP so backend events will get the same device_id as client request (make analytics better)

Also found a bug in trpc track middleware. identify was overwritten so `location` and `userAgent` was never set if userId existed.