### PR TITLE
Fix: Ensure toast close button is visible in dark mode

### DIFF
--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -21,6 +21,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+            closeButton:
+              "group-[.toast]:text-black", 
         },
       }}
       {...props}

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -22,7 +22,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
             closeButton:
-              "group-[.toast]:text-black", 
+              "group-[.toast]:text-muted-foreground"
         },
       }}
       {...props}

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -21,8 +21,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
-            closeButton:
-              "group-[.toast]:text-muted-foreground"
+          closeButton: "group-[.toast]:text-muted-foreground",
         },
       }}
       {...props}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

Earlier the toaster close button was not visible in dark-mode due to the text-color.
Changed the text-color to black such that it is visible in dark mode also.
Confirmed working in both Light-mode and Dark-mode

### Before this PR
![445763428-2b7dc1de-647e-431b-8138-ddae014a829a](https://github.com/user-attachments/assets/14045dd4-0644-4df8-a50f-13cac3ee9da4)




### After this PR

https://github.com/user-attachments/assets/38977b0c-1321-4059-bae3-d129ce378a25




### Related Issue (optional)

https://github.com/openstatusHQ/openstatus/issues/1258
