### PR TITLE
fix: update contact link to use mailto instead of non-existent contac…

### DIFF
--- a/apps/dashboard/src/components/forms/monitor/form-general.tsx
+++ b/apps/dashboard/src/components/forms/monitor/form-general.tsx
@@ -306,7 +306,10 @@ export function FormGeneral({
                         </FormLabel>
                       </FormItem>
                       <div className="col-span-2 self-end text-muted-foreground text-xs sm:place-self-end">
-                        Missing a type? <Link href="mailto:ping@openstatus.dev">Contact us</Link>
+                        Missing a type?{" "}
+                        <Link href="mailto:ping@openstatus.dev">
+                          Contact us
+                        </Link>
                       </div>
                     </RadioGroup>
                   </FormControl>

--- a/apps/dashboard/src/components/forms/monitor/form-general.tsx
+++ b/apps/dashboard/src/components/forms/monitor/form-general.tsx
@@ -306,7 +306,7 @@ export function FormGeneral({
                         </FormLabel>
                       </FormItem>
                       <div className="col-span-2 self-end text-muted-foreground text-xs sm:place-self-end">
-                        Missing a type? <Link href="/contact">Contact us</Link>
+                        Missing a type? <Link href="mailto:ping@openstatus.dev">Contact us</Link>
                       </div>
                     </RadioGroup>
                   </FormControl>

--- a/apps/dashboard/src/components/forms/monitor/form-general.tsx
+++ b/apps/dashboard/src/components/forms/monitor/form-general.tsx
@@ -306,7 +306,7 @@ export function FormGeneral({
                         </FormLabel>
                       </FormItem>
                       <div className="col-span-2 self-end text-muted-foreground text-xs sm:place-self-end">
-                        Missing a type? <Link href="mailto:ping@openstatus.dev">Contact us</Link>
+                        Missing a type? <a href="mailto:ping@openstatus.dev">Contact us</a>
                       </div>
                     </RadioGroup>
                   </FormControl>


### PR DESCRIPTION
Fixed a 404 issue on the monitors creation page by updating the 'Contact us' link to use mailto:ping@openstatus.dev instead of redirecting to a non-existent /contact page.

Changes made:
- Updated the contact link in the monitor creation form to use mailto:ping@openstatus.dev
- This ensures users can directly send emails instead of encountering a 404 error

Testing:
- Verified that clicking the 'Contact us' link now opens the default email client
- Confirmed no other instances of incorrect contact links in the codebase