### PR TITLE
fix: overflow of text in assertion compare selector

### DIFF
--- a/apps/dashboard/src/components/forms/monitor/form-general.tsx
+++ b/apps/dashboard/src/components/forms/monitor/form-general.tsx
@@ -508,8 +508,10 @@ export function FormGeneral({
                                   value={field.value}
                                   onValueChange={field.onChange}
                                 >
-                                  <SelectTrigger className="w-full">
-                                    <SelectValue placeholder="Select compare" />
+                                  <SelectTrigger className="w-full min-w-16">
+                                    <span className="truncate">
+                                      <SelectValue placeholder="Select compare" />
+                                    </span>
                                   </SelectTrigger>
                                   <SelectContent>
                                     {assertion.type === "status"


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

Fixes the overflowing of text in select element.

### After this PR
<img width="617" height="261" alt="image" src="https://github.com/user-attachments/assets/f0158903-0f23-4b4d-94cd-3d2ebaa88075" />

### Related Issue (optional)
#1426 