### PR TITLE
Fix API key description link in Dashboard CLI Page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/cli/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/cli/page.tsx
@@ -34,7 +34,7 @@ const installs = [
     description: (
       <>
         Create an API key in your workspace{" "}
-        <Link href="/settings/workspace">settings.</Link>
+        <Link href="/settings/general">settings.</Link>
       </>
     ),
     command: {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

The `settings` link under the `Add API Key` section within the Dashboard CLI Page currently redirects to a non-existent `/settings/workspace` page hence a 404, this commit fixes that and correctly redirects to `/settings/general`.

This fix at the very least works at the free tier dashboard level, I'm not familiar with the paid plan experience and if that lets users have multiple workspaces which might be an explanation for the existence of the erroneous link in the first place.

### A picture tells a thousand words (if any)
<img width="615" height="199" alt="Screenshot 2025-12-11 at 16 10 33" src="https://github.com/user-attachments/assets/c6325bc3-89a1-4e1b-b951-b5884a19ad40" />


### Before this PR

Clicking the link redirects to 404 error page

<img width="529" height="272" alt="image" src="https://github.com/user-attachments/assets/cfd0bf33-42ad-4604-8355-2f0a39e7feed" />

### After this PR

Clicking the link redirects to the settings page

<img width="1289" height="739" alt="Screenshot 2025-12-11 at 16 14 15" src="https://github.com/user-attachments/assets/6c1eb43f-d24b-483f-b005-b48cbd7f8216" />

### Related Issue (optional)

<!--- Please link to the issue here: -->
