### PR TITLE
fix: filter expected tRPC errors from Sentry notifications

### DIFF
--- a/apps/dashboard/sentry.edge.config.ts
+++ b/apps/dashboard/sentry.edge.config.ts
@@ -4,6 +4,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
 
+// tRPC error codes that should not be reported to Sentry (expected client errors)
+const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -13,4 +16,13 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
+
+  beforeSend(event) {
+    // Filter out expected tRPC errors (401, 404, 400)
+    const message = event.exception?.values?.[0]?.value || "";
+    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/apps/dashboard/sentry.edge.config.ts
+++ b/apps/dashboard/sentry.edge.config.ts
@@ -3,9 +3,14 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
+import { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+const IGNORED_TRPC_CODES: TRPCError["code"][] = [
+  "UNAUTHORIZED",
+  "NOT_FOUND",
+  "BAD_REQUEST",
+];
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -17,10 +22,11 @@ Sentry.init({
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
-  beforeSend(event) {
-    // Filter out expected tRPC errors (401, 404, 400)
-    const message = event.exception?.values?.[0]?.value || "";
-    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+  beforeSend(event, hint) {
+    if (
+      hint.originalException instanceof TRPCError &&
+      IGNORED_TRPC_CODES.includes(hint.originalException.code)
+    ) {
       return null;
     }
     return event;

--- a/apps/dashboard/sentry.server.config.ts
+++ b/apps/dashboard/sentry.server.config.ts
@@ -3,9 +3,14 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+const IGNORED_TRPC_CODES: TRPCError["code"][] = [
+  "UNAUTHORIZED",
+  "NOT_FOUND",
+  "BAD_REQUEST",
+];
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -17,10 +22,11 @@ Sentry.init({
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
-  beforeSend(event) {
-    // Filter out expected tRPC errors (401, 404, 400)
-    const message = event.exception?.values?.[0]?.value || "";
-    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+  beforeSend(event, hint) {
+    if (
+      hint.originalException instanceof TRPCError &&
+      IGNORED_TRPC_CODES.includes(hint.originalException.code)
+    ) {
       return null;
     }
     return event;

--- a/apps/dashboard/sentry.server.config.ts
+++ b/apps/dashboard/sentry.server.config.ts
@@ -4,6 +4,9 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+// tRPC error codes that should not be reported to Sentry (expected client errors)
+const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -13,4 +16,13 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
+
+  beforeSend(event) {
+    // Filter out expected tRPC errors (401, 404, 400)
+    const message = event.exception?.values?.[0]?.value || "";
+    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/apps/status-page/sentry.edge.config.ts
+++ b/apps/status-page/sentry.edge.config.ts
@@ -3,7 +3,7 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
+import type { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
 const IGNORED_TRPC_CODES: TRPCError["code"][] = [

--- a/apps/status-page/sentry.edge.config.ts
+++ b/apps/status-page/sentry.edge.config.ts
@@ -4,6 +4,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
 
+// tRPC error codes that should not be reported to Sentry (expected client errors)
+const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -13,4 +16,13 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
+
+  beforeSend(event) {
+    // Filter out expected tRPC errors (401, 404, 400)
+    const message = event.exception?.values?.[0]?.value || "";
+    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/apps/status-page/sentry.edge.config.ts
+++ b/apps/status-page/sentry.edge.config.ts
@@ -3,9 +3,14 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
+import type { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+const IGNORED_TRPC_CODES: TRPCError["code"][] = [
+  "UNAUTHORIZED",
+  "NOT_FOUND",
+  "BAD_REQUEST",
+];
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/apps/status-page/sentry.edge.config.ts
+++ b/apps/status-page/sentry.edge.config.ts
@@ -3,7 +3,7 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
-import type { TRPCError } from "@trpc/server";
+import { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
 const IGNORED_TRPC_CODES: TRPCError["code"][] = [
@@ -22,10 +22,11 @@ Sentry.init({
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
-  beforeSend(event) {
-    // Filter out expected tRPC errors (401, 404, 400)
-    const message = event.exception?.values?.[0]?.value || "";
-    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+  beforeSend(event, hint) {
+    if (
+      hint.originalException instanceof TRPCError &&
+      IGNORED_TRPC_CODES.includes(hint.originalException.code)
+    ) {
       return null;
     }
     return event;

--- a/apps/status-page/sentry.edge.config.ts
+++ b/apps/status-page/sentry.edge.config.ts
@@ -3,7 +3,7 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
-import type { TRPCError } from "@trpc/server";
+import { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
 const IGNORED_TRPC_CODES: TRPCError["code"][] = [

--- a/apps/status-page/sentry.server.config.ts
+++ b/apps/status-page/sentry.server.config.ts
@@ -3,9 +3,14 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+const IGNORED_TRPC_CODES: TRPCError["code"][] = [
+  "UNAUTHORIZED",
+  "NOT_FOUND",
+  "BAD_REQUEST",
+];
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -17,10 +22,11 @@ Sentry.init({
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
-  beforeSend(event) {
-    // Filter out expected tRPC errors (401, 404, 400)
-    const message = event.exception?.values?.[0]?.value || "";
-    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+  beforeSend(event, hint) {
+    if (
+      hint.originalException instanceof TRPCError &&
+      IGNORED_TRPC_CODES.includes(hint.originalException.code)
+    ) {
       return null;
     }
     return event;

--- a/apps/status-page/sentry.server.config.ts
+++ b/apps/status-page/sentry.server.config.ts
@@ -4,6 +4,9 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+// tRPC error codes that should not be reported to Sentry (expected client errors)
+const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -13,4 +16,13 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
+
+  beforeSend(event) {
+    // Filter out expected tRPC errors (401, 404, 400)
+    const message = event.exception?.values?.[0]?.value || "";
+    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -3,11 +3,16 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { TRPCError } from "@trpc/server";
 
 import { env } from "@/env";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES = ["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST"];
+const IGNORED_TRPC_CODES: TRPCError["code"][] = [
+  "UNAUTHORIZED",
+  "NOT_FOUND",
+  "BAD_REQUEST",
+];
 
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN,
@@ -19,10 +24,11 @@ Sentry.init({
   debug: false,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
-  beforeSend(event) {
-    // Filter out expected tRPC errors (401, 404, 400)
-    const message = event.exception?.values?.[0]?.value || "";
-    if (IGNORED_TRPC_CODES.some((code) => message.includes(code))) {
+  beforeSend(event, hint) {
+    if (
+      hint.originalException instanceof TRPCError &&
+      IGNORED_TRPC_CODES.includes(hint.originalException.code)
+    ) {
       return null;
     }
     return event;


### PR DESCRIPTION
Mute UNAUTHORIZED (401), NOT_FOUND (404), and BAD_REQUEST (400) errors to reduce noise from expected client errors.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

<!--- Describe your changes in detail -->

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->
