### PR TITLE
fix(docker): update Dockerfile to install curl for health check

### DIFF
--- a/apps/workflows/Dockerfile
+++ b/apps/workflows/Dockerfile
@@ -116,6 +116,7 @@ COPY \
     --chown=1000:1000 \
     --link \
     "/etc/ssl/certs/ca-certificates.crt" "/etc/ssl/certs/"
+RUN apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
 USER 1000:1000
 EXPOSE 3000
 ENTRYPOINT ["/app/apps/workflows/app"]

--- a/apps/workflows/dofigen.lock
+++ b/apps/workflows/dofigen.lock
@@ -12,63 +12,13 @@ effective: |
   - /packages/error
   - /packages/tracker
   builders:
-    libsql:
-      fromImage:
-        path: oven/bun
-        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      label:
-        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
-        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      workdir: /app/
-      copy:
-      - fromBuilder: docker
-        paths:
-        - /app/apps/build-docker/package.json
-        target: /app/package.json
-      run:
-      - bun install
-    build:
-      fromImage:
-        path: oven/bun
-        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      label:
-        org.opencontainers.image.stage: build
-        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
-        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      workdir: /app/apps/workflows
-      env:
-        NODE_ENV: production
-      copy:
-      - paths:
-        - .
-        target: /app/
-      - fromBuilder: install
-        paths:
-        - /app/node_modules
-        target: /app/node_modules
-      run:
-      - bun build --compile --target bun  --sourcemap --format=cjs src/index.ts --outfile=app
-    docker:
-      fromImage:
-        path: oven/bun
-        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      label:
-        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
-        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      workdir: /app/apps/workflows
-      copy:
-      - paths:
-        - .
-        target: /app/
-      run:
-      - bun run src/build-docker.ts
     ca-certs:
       fromImage:
         path: debian
-        digest: sha256:530a3348fc4b5734ffe1a137ddbcee6850154285251b53c3425c386ea8fac77b
+        digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
       label:
         org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
-        org.opencontainers.image.base.digest: sha256:530a3348fc4b5734ffe1a137ddbcee6850154285251b53c3425c386ea8fac77b
+        org.opencontainers.image.base.digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
       run:
       - apt update && apt install -y ca-certificates && update-ca-certificates
     install:
@@ -131,18 +81,68 @@ effective: |
         source: packages/upstash/package.json
       - target: packages/theme-store/package.json
         source: packages/theme-store/package.json
+    build:
+      fromImage:
+        path: oven/bun
+        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+      label:
+        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+        org.opencontainers.image.stage: build
+        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
+      workdir: /app/apps/workflows
+      env:
+        NODE_ENV: production
+      copy:
+      - paths:
+        - .
+        target: /app/
+      - fromBuilder: install
+        paths:
+        - /app/node_modules
+        target: /app/node_modules
+      run:
+      - bun build --compile --target bun  --sourcemap --format=cjs src/index.ts --outfile=app
+    docker:
+      fromImage:
+        path: oven/bun
+        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+      label:
+        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
+      workdir: /app/apps/workflows
+      copy:
+      - paths:
+        - .
+        target: /app/
+      run:
+      - bun run src/build-docker.ts
+    libsql:
+      fromImage:
+        path: oven/bun
+        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+      label:
+        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
+      workdir: /app/
+      copy:
+      - fromBuilder: docker
+        paths:
+        - /app/apps/build-docker/package.json
+        target: /app/package.json
+      run:
+      - bun install
   fromImage:
     path: debian
-    digest: sha256:530a3348fc4b5734ffe1a137ddbcee6850154285251b53c3425c386ea8fac77b
+    digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
   label:
-    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
-    org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
+    io.dofigen.version: 2.6.0
     org.opencontainers.image.vendor: OpenStatus
     org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
-    org.opencontainers.image.title: OpenStatus Workflows
-    org.opencontainers.image.base.digest: sha256:530a3348fc4b5734ffe1a137ddbcee6850154285251b53c3425c386ea8fac77b
+    org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
+    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
+    org.opencontainers.image.base.digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
     org.opencontainers.image.authors: OpenStatus Team
-    io.dofigen.version: 2.6.0
+    org.opencontainers.image.title: OpenStatus Workflows
   workdir: /app/
   copy:
   - fromBuilder: build
@@ -162,6 +162,8 @@ effective: |
     paths:
     - /etc/ssl/certs/ca-certificates.crt
     target: /etc/ssl/certs/
+  run:
+  - apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
   entrypoint:
   - /app/apps/workflows/app
   expose:
@@ -171,14 +173,14 @@ images:
     library:
       debian:
         bullseye-slim:
-          digest: sha256:530a3348fc4b5734ffe1a137ddbcee6850154285251b53c3425c386ea8fac77b
+          digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
     oven:
       bun:
         1.3.6:
           digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
 resources:
   dofigen.yml:
-    hash: ef348ec787ab960110922454936b54cd60350bd6bc47879ae60e42f9a1db7c3d
+    hash: d4c321cbb7593d300b7c6a74e58cb7ef2b3a4f37253386bd348d2d0f844b7248
     content: |
       ignore:
         - node_modules
@@ -291,4 +293,6 @@ resources:
           source: /etc/ssl/certs/ca-certificates.crt
           target: /etc/ssl/certs/
       expose: "3000"
+      run: apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
+
       entrypoint: /app/apps/workflows/app

--- a/apps/workflows/dofigen.yml
+++ b/apps/workflows/dofigen.yml
@@ -109,4 +109,6 @@ copy:
     source: /etc/ssl/certs/ca-certificates.crt
     target: /etc/ssl/certs/
 expose: "3000"
+run: apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
+
 entrypoint: /app/apps/workflows/app


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

During docker deployment, the healthcheck for the `workflows` service never passes, preventing other services that depend on it from starting. This is caused by `curl` not being in the PATH for the final runtime image (not included in `docker.io/debian:bullseye-slim`).

```
deploy@status:~/docker/openstatus$ docker exec -it openstatus-workflows sh
$ curl -f http://localhost:3000/ping
sh: 1: curl: not found
```

Installing `curl` in the `runtime` stage resolves this.

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->

- Following the install/deployment steps for https://github.com/openstatusHQ/openstatus/issues/1732 (which are the default docker deployment steps), this user will eventually hit this problem as well.
