### PR TITLE
fix: correct schema formatting in tcp_response.datasource

### DIFF
--- a/packages/tinybird/datasources/tcp_response.datasource
+++ b/packages/tinybird/datasources/tcp_response.datasource
@@ -11,7 +11,7 @@ SCHEMA >
     `errorMessage` Nullable(String) `json:$.errorMessage`,
     `error` Int16 `json:$.error`,
     `trigger` Nullable(String) `json:$.trigger`,
-    `uri` Nullable(String) `json:$.uri`,
+    `uri` Nullable(String) `json:$.uri`
 
 
 ENGINE "MergeTree"


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

This PR removes an illegal trailing comma from `packages/tinybird/datasources/tcp_response.datasource`, which caused `tb push datasources/*.datasource` to fail.

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->
