### PR TITLE
feat(private-location): implement wide event logging

### DIFF
--- a/apps/private-location/go.mod
+++ b/apps/private-location/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/openstatushq/openstatus/apps/checker v0.0.0-20251012205355-e366f661c23e
-	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d
 	go.opentelemetry.io/contrib/bridges/otelslog v0.14.0
@@ -36,6 +35,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rs/zerolog v1.34.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect

--- a/apps/private-location/internal/server/ingest_common.go
+++ b/apps/private-location/internal/server/ingest_common.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/openstatushq/openstatus/apps/private-location/internal/database"
-	"github.com/rs/zerolog/log"
 )
 
 // ingestContext holds common data needed for ingestion
@@ -19,14 +18,26 @@ func (h *privateLocationHandler) getIngestContext(ctx context.Context, token str
 	var monitor database.Monitor
 	err := h.db.Get(&monitor, "SELECT monitor.id, monitor.workspace_id, monitor.url, monitor.method, monitor.assertions FROM monitor JOIN private_location_to_monitor a ON monitor.id = a.monitor_id JOIN private_location b ON a.private_location_id = b.id WHERE b.token = ? AND monitor.deleted_at IS NULL and monitor.id = ?", token, monitorID)
 	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("failed to get monitor")
+		if holder := GetEvent(ctx); holder != nil {
+			holder.Event["error"] = map[string]any{
+				"message": err.Error(),
+				"source":  "database",
+				"type":    "monitor_lookup",
+			}
+		}
 		return nil, err
 	}
 
 	var region database.PrivateLocation
 	err = h.db.Get(&region, "SELECT private_location.id FROM private_location join private_location_to_monitor a ON private_location.id = a.private_location_id WHERE a.monitor_id = ? AND private_location.token = ?", monitor.ID, token)
 	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("failed to get private location")
+		if holder := GetEvent(ctx); holder != nil {
+			holder.Event["error"] = map[string]any{
+				"message": err.Error(),
+				"source":  "database",
+				"type":    "private_location_lookup",
+			}
+		}
 		return nil, err
 	}
 
@@ -38,15 +49,35 @@ func (h *privateLocationHandler) getIngestContext(ctx context.Context, token str
 
 // sendEventAndUpdateLastSeen sends the event to Tinybird and updates the last_seen_at timestamp
 func (h *privateLocationHandler) sendEventAndUpdateLastSeen(ctx context.Context, data any, dataSourceName string, regionID int) {
-	if err := h.TbClient.SendEvent(ctx, data, dataSourceName); err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("failed to send event to tinybird")
+	start := time.Now()
+	err := h.TbClient.SendEvent(ctx, data, dataSourceName)
+	duration := time.Since(start).Milliseconds()
+
+	// Enrich wide event with Tinybird operation context
+	if holder := GetEvent(ctx); holder != nil {
+		holder.Event["tinybird"] = map[string]any{
+			"datasource":  dataSourceName,
+			"duration_ms": duration,
+			"success":     err == nil,
+		}
+		if err != nil {
+			holder.Event["error"] = map[string]any{
+				"message": err.Error(),
+				"source":  "tinybird",
+			}
+		}
 	}
 
-	_, err := h.db.NamedExec("UPDATE private_location SET last_seen_at = :last_seen_at WHERE id = :id", map[string]any{
+	_, dbErr := h.db.NamedExec("UPDATE private_location SET last_seen_at = :last_seen_at WHERE id = :id", map[string]any{
 		"last_seen_at": time.Now().Unix(),
 		"id":           regionID,
 	})
-	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("failed to update private location")
+	if dbErr != nil {
+		if holder := GetEvent(ctx); holder != nil {
+			holder.Event["db_update_error"] = map[string]any{
+				"message": dbErr.Error(),
+				"type":    "last_seen_update",
+			}
+		}
 	}
 }

--- a/apps/private-location/internal/server/ingest_dns.go
+++ b/apps/private-location/internal/server/ingest_dns.go
@@ -44,9 +44,13 @@ func (h *privateLocationHandler) IngestDNS(ctx context.Context, req *connect.Req
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	if holder, ok := ctx.Value(eventKey).(*EventHolder); ok && holder != nil {
+	// Enrich wide event with business context
+	if holder := GetEvent(ctx); holder != nil {
 		holder.Event["private_location"] = map[string]any{
-			"monitor_id": req.Msg.MonitorId,
+			"monitor_id":   req.Msg.MonitorId,
+			"workspace_id": ic.Monitor.WorkspaceID,
+			"region_id":    ic.Region.ID,
+			"datasource":   tinybird.DatasourceDNS,
 		}
 	}
 

--- a/apps/private-location/internal/server/ingest_tcp.go
+++ b/apps/private-location/internal/server/ingest_tcp.go
@@ -43,9 +43,13 @@ func (h *privateLocationHandler) IngestTCP(ctx context.Context, req *connect.Req
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	if holder, ok := ctx.Value(eventKey).(*EventHolder); ok && holder != nil {
+	// Enrich wide event with business context
+	if holder := GetEvent(ctx); holder != nil {
 		holder.Event["private_location"] = map[string]any{
-			"monitor_id": req.Msg.MonitorId,
+			"monitor_id":   req.Msg.MonitorId,
+			"workspace_id": ic.Monitor.WorkspaceID,
+			"region_id":    ic.Region.ID,
+			"datasource":   tinybird.DatasourceTCP,
 		}
 	}
 

--- a/apps/private-location/internal/server/monitors_test.go
+++ b/apps/private-location/internal/server/monitors_test.go
@@ -18,7 +18,7 @@ func TestParseAssertions_TextBodyContains(t *testing.T) {
 		Valid:  true,
 	}
 
-	_, _, bodyAssertions := server.ParseAssertions(assertions)
+	_, _, bodyAssertions := server.ParseAssertions(context.Background(), assertions)
 
 	if len(bodyAssertions) != 1 {
 		t.Fatalf("expected 1 body assertion, got %d", len(bodyAssertions))
@@ -42,7 +42,7 @@ func TestParseAssertions_HttpStatusEquals(t *testing.T) {
 		Valid:  true,
 	}
 
-	statusAssertion, _, _ := server.ParseAssertions(assertions)
+	statusAssertion, _, _ := server.ParseAssertions(context.Background(), assertions)
 
 	if len(statusAssertion) != 1 {
 		t.Fatalf("expected 1 body assertion, got %d", len(statusAssertion))
@@ -64,7 +64,7 @@ func TestParseAssertions_InvalidJSON(t *testing.T) {
 		Valid:  true,
 	}
 
-	statusAssertions, headerAssertions, bodyAssertions := server.ParseAssertions(assertions)
+	statusAssertions, headerAssertions, bodyAssertions := server.ParseAssertions(context.Background(), assertions)
 
 	if len(statusAssertions) != 0 || len(headerAssertions) != 0 || len(bodyAssertions) != 0 {
 		t.Errorf("expected empty assertions for invalid JSON, got status=%d, header=%d, body=%d",
@@ -78,7 +78,7 @@ func TestParseAssertions_NullString(t *testing.T) {
 		Valid:  false,
 	}
 
-	statusAssertions, headerAssertions, bodyAssertions := server.ParseAssertions(assertions)
+	statusAssertions, headerAssertions, bodyAssertions := server.ParseAssertions(context.Background(), assertions)
 
 	if len(statusAssertions) != 0 || len(headerAssertions) != 0 || len(bodyAssertions) != 0 {
 		t.Errorf("expected empty assertions for null string, got status=%d, header=%d, body=%d",
@@ -93,7 +93,7 @@ func TestParseAssertions_HeaderAssertion(t *testing.T) {
 		Valid:  true,
 	}
 
-	_, headerAssertions, _ := server.ParseAssertions(assertions)
+	_, headerAssertions, _ := server.ParseAssertions(context.Background(), assertions)
 
 	if len(headerAssertions) != 1 {
 		t.Fatalf("expected 1 header assertion, got %d", len(headerAssertions))
@@ -122,7 +122,7 @@ func TestParseAssertions_MultipleAssertions(t *testing.T) {
 		Valid:  true,
 	}
 
-	statusAssertions, headerAssertions, bodyAssertions := server.ParseAssertions(assertions)
+	statusAssertions, headerAssertions, bodyAssertions := server.ParseAssertions(context.Background(), assertions)
 
 	if len(statusAssertions) != 1 {
 		t.Errorf("expected 1 status assertion, got %d", len(statusAssertions))
@@ -280,7 +280,7 @@ func TestParseRecordAssertions_DnsRecordContains(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 1 {
 		t.Fatalf("expected 1 record assertion, got %d", len(recordAssertions))
@@ -305,7 +305,7 @@ func TestParseRecordAssertions_DnsRecordEquals(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 1 {
 		t.Fatalf("expected 1 record assertion, got %d", len(recordAssertions))
@@ -334,7 +334,7 @@ func TestParseRecordAssertions_MultipleRecordTypes(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 3 {
 		t.Fatalf("expected 3 record assertions, got %d", len(recordAssertions))
@@ -371,7 +371,7 @@ func TestParseRecordAssertions_InvalidJSON(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 0 {
 		t.Errorf("expected empty assertions for invalid JSON, got %d", len(recordAssertions))
@@ -384,7 +384,7 @@ func TestParseRecordAssertions_NullString(t *testing.T) {
 		Valid:  false,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if recordAssertions != nil {
 		t.Errorf("expected nil for null string, got %v", recordAssertions)
@@ -403,7 +403,7 @@ func TestParseRecordAssertions_MixedAssertionTypes(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 1 {
 		t.Fatalf("expected 1 record assertion (only dnsRecord), got %d", len(recordAssertions))
@@ -455,7 +455,7 @@ func TestParseRecordAssertions_EmptyArray(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 0 {
 		t.Errorf("expected empty slice for empty JSON array, got %d", len(recordAssertions))
@@ -469,7 +469,7 @@ func TestParseRecordAssertions_UnknownComparator(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 1 {
 		t.Fatalf("expected 1 record assertion, got %d", len(recordAssertions))
@@ -488,7 +488,7 @@ func TestParseRecordAssertions_UnknownRecordType(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 1 {
 		t.Fatalf("expected 1 record assertion, got %d", len(recordAssertions))
@@ -509,7 +509,7 @@ func TestParseRecordAssertions_MissingRequiredFields(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions := server.ParseRecordAssertions(assertions)
+	recordAssertions := server.ParseRecordAssertions(context.Background(), assertions)
 
 	if len(recordAssertions) != 1 {
 		t.Fatalf("expected 1 record assertion, got %d", len(recordAssertions))
@@ -527,7 +527,7 @@ func TestParseRecordAssertions_MissingRequiredFields(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions2 := server.ParseRecordAssertions(assertions2)
+	recordAssertions2 := server.ParseRecordAssertions(context.Background(), assertions2)
 
 	if len(recordAssertions2) != 1 {
 		t.Fatalf("expected 1 record assertion, got %d", len(recordAssertions2))
@@ -545,7 +545,7 @@ func TestParseRecordAssertions_MissingRequiredFields(t *testing.T) {
 		Valid:  true,
 	}
 
-	recordAssertions3 := server.ParseRecordAssertions(assertions3)
+	recordAssertions3 := server.ParseRecordAssertions(context.Background(), assertions3)
 
 	if len(recordAssertions3) != 1 {
 		t.Fatalf("expected 1 record assertion, got %d", len(recordAssertions3))

--- a/apps/private-location/internal/tinybird/client.go
+++ b/apps/private-location/internal/tinybird/client.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-
-	"github.com/rs/zerolog/log"
 )
 
 // Datasource names for Tinybird events
@@ -49,7 +47,6 @@ func NewClient(httpClient *http.Client, apiKey string) Client {
 func (c client) SendEvent(ctx context.Context, event any, dataSourceName string) error {
 	requestURL, err := url.Parse(c.baseURL)
 	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("unable to parse url")
 		return fmt.Errorf("unable to parse url: %w", err)
 	}
 
@@ -59,26 +56,22 @@ func (c client) SendEvent(ctx context.Context, event any, dataSourceName string)
 
 	var payload bytes.Buffer
 	if err := json.NewEncoder(&payload).Encode(event); err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("unable to encode payload")
 		return fmt.Errorf("unable to encode payload: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(payload.Bytes()))
 	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("unable to create request")
 		return fmt.Errorf("unable to create request: %w", err)
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("unable to send request")
 		return fmt.Errorf("unable to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusAccepted {
-		log.Ctx(ctx).Error().Str("status", resp.Status).Msg("unexpected status code")
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
Add proper wide events (canonical log lines) for powerful debugging and analytics:

- Add build variables (Version, CommitSHA) and startup logging with configuration info
- Add service context (name, version, commit_sha, instance_id) to every request event
- Enrich wide events with business context (workspace_id, monitor counts, region_id)
- Add Tinybird operation metrics (datasource, duration_ms, success) to wide events
- Add health check context to wide event
- Replace zerolog with slog-based wide event pattern throughout codebase
- Remove zerolog dependency from monitors.go, ingest_common.go, and tinybird/client.go
- Update ParseAssertions and ParseRecordAssertions to use context for error tracking

Each request now emits one context-rich log event with all relevant fields for debugging.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

<!--- Describe your changes in detail -->

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->
