### PR TITLE
Fix spelling of "across"

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/overview/client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/overview/client.tsx
@@ -133,7 +133,7 @@ export function Client() {
         <SectionHeader>
           <SectionTitle>Uptime</SectionTitle>
           <SectionDescription>
-            Uptime accross all the selected regions
+            Uptime across all the selected regions
           </SectionDescription>
         </SectionHeader>
         <ChartBarUptime
@@ -148,7 +148,7 @@ export function Client() {
         <SectionHeader>
           <SectionTitle>Latency</SectionTitle>
           <SectionDescription>
-            Response time accross all the regions
+            Response time across all the regions
           </SectionDescription>
         </SectionHeader>
         <div className="flex flex-wrap gap-2">

--- a/apps/web/src/content/pages/blog/new-dashboard-we-are-so-back.mdx
+++ b/apps/web/src/content/pages/blog/new-dashboard-we-are-so-back.mdx
@@ -51,7 +51,7 @@ Let's **compare** right away: old (1) vs new (2) dashboard!
 
 The new design will look different to what you know from openstatus and might _look more familiar - maybe boring_. From day one, we used shadcn as our design system - back when it had just started as well. It's been in our DNA. We're keeping everything you already know, but with different color templates and the removal of the dotted background. We hope you won't miss it too much.
 
-Obviously, the biggest change on first sight is the layout: we are embracing the **sidebar navigation** to share more informations. Every individual status page or monitor will be shown there, making it easier to navigate accross entries and create new ones on the fly. They also include the status of the current entry (e.g. _active_, _error_, _degraded_) - heavily inspired by Tinybird's dashboard sidebar.
+Obviously, the biggest change on first sight is the layout: we are embracing the **sidebar navigation** to share more informations. Every individual status page or monitor will be shown there, making it easier to navigate across entries and create new ones on the fly. They also include the status of the current entry (e.g. _active_, _error_, _degraded_) - heavily inspired by Tinybird's dashboard sidebar.
 
 Since we moved the main navigation to the sidebar, the top header now shows **breadcrumb navigation** and lets you quickly switch between subpages via a select option.
 

--- a/apps/web/src/content/pages/blog/pricing-update-july-2024.mdx
+++ b/apps/web/src/content/pages/blog/pricing-update-july-2024.mdx
@@ -24,7 +24,7 @@ Let's dive into the details of our update and why it matters.
 
 You may notice something unusual in our new pricing structure: the absence of prices ending in 9 This isn't a random choice, but a deliberate step towards more transparent and honest pricing.
 
-The psychology behind pricing is fascinating. Research by [Paddle](https://www.paddle.com/blog/end-prices-in-9s) reveals that while prices ending in 9 can boost sales, it's a common practice accross all industry. They're often associated with discount brands or perceived as a marketing ploy. By embracing round numbers, we're making a statement about our product's quality and value. We're not trying to create an illusion of a bargain; instead, we're confidently presenting our true worth.
+The psychology behind pricing is fascinating. Research by [Paddle](https://www.paddle.com/blog/end-prices-in-9s) reveals that while prices ending in 9 can boost sales, it's a common practice across all industry. They're often associated with discount brands or perceived as a marketing ploy. By embracing round numbers, we're making a statement about our product's quality and value. We're not trying to create an illusion of a bargain; instead, we're confidently presenting our true worth.
 
 ## 🌍💰More Regions, Lower Price
 


### PR DESCRIPTION
I spotted this misspelling on the dashboard.