### PR TITLE
chore: allow shoogle.dev to embed site in iframe

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,11 +1,11 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 
-// REMINDER: avoid Clickjacking attacks by setting the X-Frame-Options header
+// REMINDER: avoid Clickjacking attacks by setting the frame-ancestors directive
 const securityHeaders = [
   {
-    key: "X-Frame-Options",
-    value: "SAMEORIGIN",
+    key: "Content-Security-Policy",
+    value: "frame-ancestors 'self' https://shoogle.dev",
   },
 ];
 


### PR DESCRIPTION
## Summary
- Replace `X-Frame-Options: SAMEORIGIN` with `Content-Security-Policy: frame-ancestors 'self' https://shoogle.dev` to allow shoogle.dev to embed the site in an iframe
- Maintains self-origin protection while enabling the integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)