### PR TITLE
(Web): Add ""How it works" section to marketing landing page 

### DIFF
--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { cn } from "@/lib/utils";
 import { Bell, Globe, Monitor } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 const steps = [
   {
@@ -25,22 +28,64 @@ const steps = [
   },
 ] as const;
 
+function useInView(threshold = 0.15) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true);
+          observer.unobserve(el);
+        }
+      },
+      { threshold },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold]);
+
+  return { ref, isInView };
+}
+
 function StepCard({
   step,
+  index,
+  isVisible,
 }: {
   step: (typeof steps)[number];
+  index: number;
+  isVisible: boolean;
 }) {
   const Icon = step.icon;
   return (
-    <div className="relative flex flex-col gap-4 border border-border bg-background p-6">
+    <div
+      className={cn(
+        "relative flex flex-col gap-4 border border-border bg-background p-6",
+        "transition-all duration-500 ease-out",
+        "hover:border-success/50 hover:shadow-[0_0_20px_-4px] hover:shadow-success/15",
+        isVisible
+          ? "translate-y-0 opacity-100"
+          : "translate-y-8 opacity-0",
+      )}
+      style={{ transitionDelay: `${index * 150}ms` }}
+    >
       <span
-        className="flex h-6 w-6 items-center justify-center border border-border font-mono text-xs text-muted-foreground"
+        className="flex h-6 w-6 items-center justify-center border border-success/40 bg-success/10 font-mono text-xs text-success"
         aria-hidden="true"
       >
         {step.number}
       </span>
       <div className="flex items-center gap-3">
-        <Icon className="h-5 w-5 shrink-0 text-foreground" aria-hidden="true" />
+        <Icon
+          className="h-5 w-5 shrink-0 text-success"
+          aria-hidden="true"
+        />
         <h3 className="font-mono text-sm font-medium text-foreground">
           {step.title}
         </h3>
@@ -52,27 +97,47 @@ function StepCard({
   );
 }
 
-function DottedConnector() {
+function DottedConnector({ isVisible, index }: { isVisible: boolean; index: number }) {
   return (
     <div
       className="hidden items-center justify-center md:flex"
       aria-hidden="true"
     >
-      <div className="h-px w-full border-t border-dashed border-border" />
+      <div
+        className={cn(
+          "h-px w-full border-t border-dashed border-success/40",
+          "transition-all duration-500 ease-out",
+          isVisible ? "scale-x-100 opacity-100" : "scale-x-0 opacity-0",
+        )}
+        style={{ transitionDelay: `${index * 150 + 75}ms` }}
+      />
     </div>
   );
 }
 
 export function HowItWorks() {
+  const { ref, isInView } = useInView(0.15);
+
   return (
-    <section className="not-prose my-8 border border-border bg-muted/30 p-6 md:p-8">
-      <div className="mb-8 text-center">
-        <h2 className="font-mono text-lg font-medium text-foreground">
+    <section
+      ref={ref}
+      className="not-prose my-8 border border-border bg-muted/30 p-6 md:p-8"
+    >
+      <div
+        className={cn(
+          "mb-8 text-center transition-all duration-500 ease-out",
+          isInView ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
+        )}
+      >
+        <p className="font-mono text-xs uppercase tracking-widest text-success">
           How it works
+        </p>
+        <h2 className="mt-2 font-mono text-lg font-medium text-foreground">
+          Up and running in minutes
         </h2>
         <p className="mx-auto mt-2 max-w-xl font-mono text-sm text-muted-foreground">
-          From endpoint checks to alerts and a public status page — in a few
-          minutes.
+          From endpoint checks to alerts and a public status page — three steps
+          is all it takes.
         </p>
       </div>
       <div
@@ -81,11 +146,11 @@ export function HowItWorks() {
           "md:grid-cols-[1fr_auto_1fr_auto_1fr] md:gap-0",
         )}
       >
-        <StepCard step={steps[0]} />
-        <DottedConnector />
-        <StepCard step={steps[1]} />
-        <DottedConnector />
-        <StepCard step={steps[2]} />
+        <StepCard step={steps[0]} index={0} isVisible={isInView} />
+        <DottedConnector isVisible={isInView} index={0} />
+        <StepCard step={steps[1]} index={1} isVisible={isInView} />
+        <DottedConnector isVisible={isInView} index={1} />
+        <StepCard step={steps[2]} index={2} isVisible={isInView} />
       </div>
     </section>
   );

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@/lib/utils";
+import { Bell, Globe, Monitor } from "lucide-react";
+
+const steps = [
+  {
+    number: 1,
+    title: "Add your monitors",
+    description:
+      "Add websites and APIs. Choose interval and regions. Add assertions (status, headers, body).",
+    icon: Monitor,
+  },
+  {
+    number: 2,
+    title: "Get notified instantly",
+    description:
+      "Alert on failures and latency. Notify via email + integrations like Slack, Discord, and PagerDuty.",
+    icon: Bell,
+  },
+  {
+    number: 3,
+    title: "Share your status",
+    description:
+      "Publish a clean status page that reflects incidents automatically. Customize theme and branding.",
+    icon: Globe,
+  },
+] as const;
+
+function StepCard({
+  step,
+}: {
+  step: (typeof steps)[number];
+}) {
+  const Icon = step.icon;
+  return (
+    <div className="relative flex flex-col gap-4 border border-border bg-background p-6">
+      <span
+        className="flex h-6 w-6 items-center justify-center border border-border font-mono text-xs text-muted-foreground"
+        aria-hidden="true"
+      >
+        {step.number}
+      </span>
+      <div className="flex items-center gap-3">
+        <Icon className="h-5 w-5 shrink-0 text-foreground" aria-hidden="true" />
+        <h3 className="font-mono text-sm font-medium text-foreground">
+          {step.title}
+        </h3>
+      </div>
+      <p className="font-mono text-sm leading-relaxed text-muted-foreground">
+        {step.description}
+      </p>
+    </div>
+  );
+}
+
+function DottedConnector() {
+  return (
+    <div
+      className="hidden items-center justify-center md:flex"
+      aria-hidden="true"
+    >
+      <div className="h-px w-full border-t border-dashed border-border" />
+    </div>
+  );
+}
+
+export function HowItWorks() {
+  return (
+    <section className="not-prose my-8 border border-border bg-muted/30 p-6 md:p-8">
+      <div className="mb-8 text-center">
+        <h2 className="font-mono text-lg font-medium text-foreground">
+          How it works
+        </h2>
+        <p className="mx-auto mt-2 max-w-xl font-mono text-sm text-muted-foreground">
+          From endpoint checks to alerts and a public status page — in a few
+          minutes.
+        </p>
+      </div>
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-4",
+          "md:grid-cols-[1fr_auto_1fr_auto_1fr] md:gap-0",
+        )}
+      >
+        <StepCard step={steps[0]} />
+        <DottedConnector />
+        <StepCard step={steps[1]} />
+        <DottedConnector />
+        <StepCard step={steps[2]} />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/content/mdx-components/index.tsx
+++ b/apps/web/src/content/mdx-components/index.tsx
@@ -1,3 +1,4 @@
+import { HowItWorks } from "@/components/marketing/how-it-works";
 import { LatencyChartTable } from "../latency-chart-table";
 import { ButtonLink } from "./button-link";
 import { Code } from "./code";
@@ -32,4 +33,5 @@ export const components = {
   SimpleChart: LatencyChartTable,
   Tweet: MDXTweet,
   StatusPageExample: MDXStatusPageExample,
+  HowItWorks,
 };

--- a/apps/web/src/content/pages/home.mdx
+++ b/apps/web/src/content/pages/home.mdx
@@ -45,6 +45,8 @@ faq:
   <a href="https://superwall.com">Superwall</a>
 </Grid>
 
+<HowItWorks />
+
 ## Beautiful, open-source status pages
 
 A status page helps you communicate incidents more effectively. It adds **transparency**, so users aren't left guessing. It enables **proactive communication**, giving updates without users needing to ask. And it shows **reliability**, not just in uptime but in how you handle downtime and keep people informed.


### PR DESCRIPTION
## Summary 

Add a new "How it works" section to the marketing landing page 
('apps/web') to help visitors understand the Open Status workflow.

## What changed 
- Created 'apps/web/src/components/marketing/how-it-works.tsx'
- Imported and placed the section in 'apps/web/src/app(marketing)/page.tsx

## Type of change
-[X] New Feature (non- breaking)

## Details 
The section includes 3 steps: 
1. Add your monitors 
2. Get notified instantly 
3. Share your status

Builtusing existing stack : Next.js + Tailwind CSS + shadcn/ui + lucide-react
Fully responsive 

## Screenshots 
<img width="984" height="596" alt="image" src="https://github.com/user-attachments/assets/4b1a4020-90e9-482a-a86b-c0ab305720c5" />

## Checklist
- [x] Follows existing coding conventions and style guide
- [x] Uses existing shadcn/ui components
- [x] Dark/light mode compatible
- [x] Mobile responsive
- [x] No new dependencies added





