### PR TITLE
feat(web): add "How it works" section to marketing landing page

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -10,6 +10,7 @@ import {
   getJsonLDSoftwareApplication,
   getJsonLDWebPage,
 } from "@/lib/metadata/structured-data";
+import { HowItWorks } from "@/components/marketing/how-it-works";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = defaultMetadata;
@@ -37,6 +38,12 @@ export default function Page() {
       />
       <h1>{homePage.metadata.title}</h1>
       <p className="text-lg">{homePage.metadata.description}</p>
+      
+      {/* How it works section - placed between hero and features */}
+      <div className="not-prose mt-12 mb-16">
+        <HowItWorks />
+      </div>
+
       <CustomMDX source={homePage.content} />
     </div>
   );

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -1,0 +1,120 @@
+import { Bell, Globe, Monitor } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@openstatus/ui/components/ui/card";
+import { cn } from "@openstatus/ui/lib/utils";
+
+const steps = [
+  {
+    step: 1,
+    title: "Add your monitors",
+    description:
+      "Connect your websites and APIs in seconds. Set your check frequency and regions.",
+    icon: Monitor,
+  },
+  {
+    step: 2,
+    title: "Get notified instantly",
+    description:
+      "Receive alerts via email, Slack, or SMS the moment downtime is detected.",
+    icon: Bell,
+  },
+  {
+    step: 3,
+    title: "Share your status",
+    description:
+      "Publish a beautiful public status page to keep your users informed.",
+    icon: Globe,
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section className="bg-muted/50 py-16 md:py-24 -mx-8 px-8">
+      <div className="mx-auto max-w-6xl">
+        {/* Header */}
+        <div className="text-center mb-12 md:mb-16">
+          <h2 className="text-3xl font-medium tracking-tight text-foreground md:text-4xl">
+            How it works
+          </h2>
+          <p className="mt-4 text-lg text-muted-foreground max-w-2xl mx-auto">
+            Get started with OpenStatus in three simple steps
+          </p>
+        </div>
+
+        {/* Steps Grid */}
+        <div className="relative">
+          {/* Desktop connecting line */}
+          <div
+            className="absolute top-1/2 left-0 right-0 hidden md:block -translate-y-1/2 z-0"
+            aria-hidden="true"
+          >
+            <div className="mx-auto max-w-3xl px-16">
+              <div className="border-t-2 border-dashed border-border" />
+            </div>
+          </div>
+
+          {/* Cards */}
+          <div className="relative z-10 grid grid-cols-1 gap-8 md:grid-cols-3 md:gap-6">
+            {steps.map((step, index) => (
+              <div key={step.step} className="relative">
+                {/* Desktop arrow between cards */}
+                {index < steps.length - 1 && (
+                  <div
+                    className="absolute -right-3 top-1/2 hidden md:block -translate-y-1/2 z-20"
+                    aria-hidden="true"
+                  >
+                    <svg
+                      className="h-6 w-6 text-muted-foreground/50"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </div>
+                )}
+
+                <Card
+                  className={cn(
+                    "relative h-full border-border bg-background transition-shadow hover:shadow-md",
+                    "rounded-none"
+                  )}
+                >
+                  {/* Step badge */}
+                  <div className="absolute -top-3 left-6">
+                    <span className="inline-flex h-7 w-7 items-center justify-center bg-foreground text-background text-sm font-medium">
+                      {step.step}
+                    </span>
+                  </div>
+
+                  <CardHeader className="pt-8">
+                    <div className="mb-4 flex h-12 w-12 items-center justify-center bg-muted">
+                      <step.icon className="h-6 w-6 text-foreground" />
+                    </div>
+                    <CardTitle className="text-lg">{step.title}</CardTitle>
+                  </CardHeader>
+
+                  <CardContent>
+                    <CardDescription className="text-base leading-relaxed">
+                      {step.description}
+                    </CardDescription>
+                  </CardContent>
+                </Card>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a new "How it works" section to the marketing landing page
(apps/web) to help visitors quickly understand the OpenStatus workflow.

## What changed
- Created apps/web/src/components/marketing/how-it-works.tsx
- Imported and placed the section in apps/web/src/app/(marketing)/page.tsx
  between the Hero section and the Features section

## Type of change
- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring

## Details
The section includes 3 steps:
1. Add your monitors
2. Get notified instantly
3. Share your status page

Built using the existing stack: Next.js + Tailwind CSS + shadcn/ui + lucide-react.
Fully responsive and dark/light mode compatible.

## Screenshots
See attachment
<img width="1195" height="634" alt="Screenshot 2026-03-04 205339" src="https://github.com/user-attachments/assets/84d12aa0-d913-40bc-9f4c-174c61afb6e5" />


## Checklist
- [x] Follows existing coding conventions and style guide
- [x] Uses existing shadcn/ui components
- [x] Dark/light mode compatible
- [x] Mobile responsive
- [x] No new dependencies added