### PR TITLE
Named volume for workflows and added init for mountpoint for runtime

### DIFF
--- a/apps/workflows/Dockerfile
+++ b/apps/workflows/Dockerfile
@@ -107,7 +107,7 @@ COPY \
     --link \
     "/app/node_modules" "/app/node_modules"
 USER 0:0
-RUN apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
 USER 1000:1000
 EXPOSE 3000
 ENTRYPOINT ["/app/apps/workflows/app"]

--- a/apps/workflows/Dockerfile
+++ b/apps/workflows/Dockerfile
@@ -107,7 +107,7 @@ COPY \
     --link \
     "/app/node_modules" "/app/node_modules"
 USER 0:0
-RUN apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
+RUN apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown -R 1000:1000 /app/data
 USER 1000:1000
 EXPOSE 3000
 ENTRYPOINT ["/app/apps/workflows/app"]

--- a/apps/workflows/dofigen.lock
+++ b/apps/workflows/dofigen.lock
@@ -12,35 +12,29 @@ effective: |
   - /packages/error
   - /packages/tracker
   builders:
-    build:
+    libsql:
       fromImage:
         path: oven/bun
         digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       label:
-        org.opencontainers.image.stage: build
         org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
         org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      workdir: /app/apps/workflows
-      env:
-        NODE_ENV: production
+      workdir: /app/
       copy:
-      - paths:
-        - .
-        target: /app/
-      - fromBuilder: install
+      - fromBuilder: docker
         paths:
-        - /app/node_modules
-        target: /app/node_modules
+        - /app/apps/build-docker/package.json
+        target: /app/package.json
       run:
-      - bun build --compile --target bun  --sourcemap src/index.ts --outfile=app
+      - bun install
     install:
       fromImage:
         path: oven/bun
         digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       label:
-        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
         org.opencontainers.image.stage: install
         org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
+        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       workdir: /app/
       run:
       - bun install --production  --frozen-lockfile --verbose
@@ -97,6 +91,27 @@ effective: |
         source: packages/upstash/package.json
       - target: packages/theme-store/package.json
         source: packages/theme-store/package.json
+    build:
+      fromImage:
+        path: oven/bun
+        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+      label:
+        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+        org.opencontainers.image.stage: build
+        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
+      workdir: /app/apps/workflows
+      env:
+        NODE_ENV: production
+      copy:
+      - paths:
+        - .
+        target: /app/
+      - fromBuilder: install
+        paths:
+        - /app/node_modules
+        target: /app/node_modules
+      run:
+      - bun build --compile --target bun  --sourcemap src/index.ts --outfile=app
     docker:
       fromImage:
         path: oven/bun
@@ -111,33 +126,18 @@ effective: |
         target: /app/
       run:
       - bun run src/build-docker.ts
-    libsql:
-      fromImage:
-        path: oven/bun
-        digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-      label:
-        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
-        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
-      workdir: /app/
-      copy:
-      - fromBuilder: docker
-        paths:
-        - /app/apps/build-docker/package.json
-        target: /app/package.json
-      run:
-      - bun install
   fromImage:
     path: debian
     digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
   label:
-    org.opencontainers.image.base.digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
-    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
     org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
-    org.opencontainers.image.title: OpenStatus Workflows
+    org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
     org.opencontainers.image.vendor: OpenStatus
     org.opencontainers.image.authors: OpenStatus Team
-    org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
+    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
     io.dofigen.version: 2.8.0
+    org.opencontainers.image.base.digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
+    org.opencontainers.image.title: OpenStatus Workflows
   workdir: /app/
   copy:
   - fromBuilder: build
@@ -155,7 +155,7 @@ effective: |
     target: /app/node_modules
   root:
     run:
-    - apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
+    - apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown -R 1000:1000 /app/data
   entrypoint:
   - /app/apps/workflows/app
   expose:
@@ -172,7 +172,7 @@ images:
           digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
 resources:
   dofigen.yml:
-    hash: 018151e1935b279a60f0b3b3e1d7359931097232ff8a8fef2c7398f3f67fa4db
+    hash: c1eb3133586c1e6a56afa7e9d4a11eef1d1f09a04172cb239b54154e41e1c6af
     content: |
       ignore:
         - node_modules
@@ -259,7 +259,7 @@ resources:
       fromImage: debian:bullseye-slim
       workdir: /app/
       root:
-        run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
+        run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown -R 1000:1000 /app/data
 
       # Metadata labels
       labels:

--- a/apps/workflows/dofigen.lock
+++ b/apps/workflows/dofigen.lock
@@ -17,9 +17,9 @@ effective: |
         path: oven/bun
         digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       label:
-        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
         org.opencontainers.image.stage: build
         org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
+        org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       workdir: /app/apps/workflows
       env:
         NODE_ENV: production
@@ -38,9 +38,9 @@ effective: |
         path: oven/bun
         digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       label:
-        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
-        org.opencontainers.image.stage: install
         org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+        org.opencontainers.image.stage: install
+        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
       workdir: /app/
       run:
       - bun install --production  --frozen-lockfile --verbose
@@ -130,13 +130,13 @@ effective: |
     path: debian
     digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
   label:
-    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
     org.opencontainers.image.base.digest: sha256:b32674fb57780ad57d7b0749242d3f585f462f4ec4a60ae0adacd945f9cb9734
+    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
     org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
     org.opencontainers.image.title: OpenStatus Workflows
+    org.opencontainers.image.vendor: OpenStatus
     org.opencontainers.image.authors: OpenStatus Team
     org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
-    org.opencontainers.image.vendor: OpenStatus
     io.dofigen.version: 2.8.0
   workdir: /app/
   copy:
@@ -155,7 +155,7 @@ effective: |
     target: /app/node_modules
   root:
     run:
-    - apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+    - apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
   entrypoint:
   - /app/apps/workflows/app
   expose:
@@ -172,7 +172,7 @@ images:
           digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
 resources:
   dofigen.yml:
-    hash: 20ce6210844fca7742f132334c868c8c35f23e8e7d20b62c5769c3dd6ac371cf
+    hash: 018151e1935b279a60f0b3b3e1d7359931097232ff8a8fef2c7398f3f67fa4db
     content: |
       ignore:
         - node_modules
@@ -259,7 +259,7 @@ resources:
       fromImage: debian:bullseye-slim
       workdir: /app/
       root:
-        run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+        run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
 
       # Metadata labels
       labels:

--- a/apps/workflows/dofigen.yml
+++ b/apps/workflows/dofigen.yml
@@ -83,7 +83,7 @@ builders:
 fromImage: debian:bullseye-slim
 workdir: /app/
 root:
-  run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+  run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
 
 # Metadata labels
 labels:

--- a/apps/workflows/dofigen.yml
+++ b/apps/workflows/dofigen.yml
@@ -83,7 +83,7 @@ builders:
 fromImage: debian:bullseye-slim
 workdir: /app/
 root:
-  run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown 1000:1000 /app/data
+  run: apt-get update -q && apt-get install -y -q --no-install-recommends ca-certificates curl && update-ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /app/data && chown -R 1000:1000 /app/data
 
 # Metadata labels
 labels:

--- a/coolify-deployment.yaml
+++ b/coolify-deployment.yaml
@@ -105,6 +105,8 @@ networks:
 volumes:
   libsql-data:
     name: openstatus-libsql-data
+  workflows-data:
+    name: openstatus-workflows-data
 
 services:
   # External Dependencies
@@ -172,7 +174,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./data:/app/data
+      - workflows-data:/app/data
     environment:
       - DATABASE_URL=${DATABASE_URL:-http://libsql:8080}
       - DATABASE_AUTH_TOKEN=${DATABASE_AUTH_TOKEN:-}

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -6,6 +6,8 @@ networks:
 volumes:
     libsql-data:
         name: openstatus-libsql-data
+    workflows-data:
+        name: openstatus-workflows-data
 
 services:
     # External services
@@ -60,7 +62,7 @@ services:
         ports:
             - "3000:3000"
         volumes:
-            - ./data:/app/data
+            - workflows-data:/app/data
         env_file:
             - .env.docker
         environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,8 @@ networks:
 volumes:
     libsql-data:
         name: openstatus-libsql-data
+    workflows-data:
+        name: openstatus-workflows-data
 
 services:
     # External services
@@ -63,7 +65,7 @@ services:
         ports:
             - "3000:3000"
         volumes:
-            - ./data:/app/data
+            - workflows-data:/app/data
         env_file:
             - .env.docker
         environment:


### PR DESCRIPTION
Resolves https://github.com/openstatusHQ/openstatus/issues/1940

Changed from bind volume to named volume which solved the **host** side directory permissions conflict, 

This however exposed a second issue, which is another permission error as before. The workflows image does not create `/app/data/` before switching to `USER 1000:1000`, it only sets `workdir: /app/`, copies app files, installs packages, then runs as `1000:1000`. The image does not initialize the mountpoint for **non-root** runtime. This was solved by adding the following commands to the dofigen file:
```bash
... && mkdir -p /app/data && chown -R 1000:1000 /app/data
```

Initializing the directory before dropping privileges. 

### Test

After building the container locally and running the compose file, the compose file ran without a single hiccup for the first time compared to before. 

```bash
 ✔ Image ghcr.io/openstatushq/openstatus-private-location:latest Pulled                                                                                       36.2s
 ✔ Image ghcr.io/tursodatabase/libsql-server:latest              Pulled                                                                                       68.3s
 ✔ Image ghcr.io/openstatushq/openstatus-checker:latest          Pulled                                                                                       37.0s
 ✔ Image ghcr.io/openstatushq/openstatus-dashboard:latest        Pulled                                                                                       239.1s
 ✔ Image ghcr.io/openstatushq/openstatus-server:latest           Pulled                                                                                       37.6s
 ✔ Image tinybirdco/tinybird-local:latest                        Pulled                                                                                       260.0s
 ✔ Image ghcr.io/openstatushq/openstatus-status-page:latest      Pulled                                                                                       238.8s
 ✔ Image openstatus/workflows:latest                             Built                                                                                        216.0s
 ✔ Network openstatus                                            Created                                                                                      0.4s
 ✔ Volume openstatus-workflows-data                              Created                                                                                      0.1s
 ✔ Volume openstatus-libsql-data                                 Created                                                                                      0.0s
 ✔ Container openstatus-libsql                                   Healthy                                                                                      20.6s
 ✔ Container openstatus-tinybird                                 Started                                                                                      7.4s
 **✔ Container openstatus-workflows                                Healthy                                                                                      16.7s**
 ✔ Container openstatus-server                                   Healthy                                                                                      20.9s
 ✔ Container openstatus-checker                                  Started                                                                                      22.5s
 ✔ Container openstatus-status-page                              Started                                                                                      22.9s
 ✔ Container openstatus-dashboard                                Started                                                                                      21.6s
 ✔ Container openstatus-private-location                         Started                                                                                      22.8s
```


The trade off however is that with `/data/` no longer being a binded mount, it is not "as easy" to see where the directory actually exists on the host, however using `docker inspect` reveals the path:
```bash
$ sudo docker inspect openstatus-workflows --format '{{json .Mounts}}' | jq
[
  {
    "Type": "volume",
    "Name": "openstatus-workflows-data",
    "Source": "/var/lib/docker/volumes/openstatus-workflows-data/_data",
    "Destination": "/app/data",
    "Driver": "local",
    "Mode": "rw",
    "RW": true,
    "Propagation": ""
  }
]
```

So e.g. in my case: `"/var/lib/docker/volumes/openstatus-workflows-data/_data"`

