### PR TITLE
chore: Fix Sentry Disable Logger Warning

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -34,7 +34,11 @@ const sentryConfig = {
   transpileClientSDK: false,
 
   // Tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
+  webpack: {
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
 };
 
 export default withSentryConfig(nextConfig, sentryConfig);

--- a/apps/status-page/next.config.ts
+++ b/apps/status-page/next.config.ts
@@ -72,7 +72,11 @@ const sentryConfig = {
   transpileClientSDK: false,
 
   // Tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
+  webpack: {
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
 };
 
 export default withSentryConfig(nextConfig, sentryConfig);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -250,7 +250,11 @@ const sentryConfig = {
   transpileClientSDK: false,
 
   // Tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
+  webpack: {
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
 };
 
 export default withSentryConfig(nextConfig, sentryConfig);


### PR DESCRIPTION
  - Replaced deprecated disableLogger: true with webpack.treeshake.removeDebugLogging: true in all three apps (dashboard, status-page, web)                                                                                                                   
  - Resolves the @sentry/nextjs deprecation warning: "disableLogger is deprecated and will be removed in a future version. Use webpack.treeshake.removeDebugLogging instead."                                                                                 
                                                                                                                                                                                                                                                              
  Test plan                                                                                                                                                                                                                                                   

  - Verify no disableLogger deprecation warning appears during build                                                                                                                                                                                          
  - Verify production builds still tree-shake Sentry debug logging