### PR TITLE
fix: remove unused variables and biome-ignore suppressions

### DIFF
--- a/apps/web/src/app/api/checker/cron/10m/route.ts
+++ b/apps/web/src/app/api/checker/cron/10m/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (isAuthorizedDomain(req.url)) {
     const { cronCompleted, cronFailed } = runSentryCron("10-m-cron");
     try {
-      await cron({ periodicity: "10m", req });
+      await cron({ periodicity: "10m" });
       await cronCompleted();
     } catch (_error) {
       await cronFailed();

--- a/apps/web/src/app/api/checker/cron/1h/route.ts
+++ b/apps/web/src/app/api/checker/cron/1h/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (isAuthorizedDomain(req.url)) {
     const { cronCompleted, cronFailed } = runSentryCron("1-h-cron");
     try {
-      await cron({ periodicity: "1h", req });
+      await cron({ periodicity: "1h" });
       await cronCompleted();
     } catch (_error) {
       await cronFailed();

--- a/apps/web/src/app/api/checker/cron/1m/route.ts
+++ b/apps/web/src/app/api/checker/cron/1m/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (isAuthorizedDomain(req.url)) {
     const { cronCompleted, cronFailed } = runSentryCron("1-m-cron");
     try {
-      await cron({ periodicity: "1m", req });
+      await cron({ periodicity: "1m" });
       await cronCompleted();
     } catch (_error) {
       await cronFailed();

--- a/apps/web/src/app/api/checker/cron/30m/route.ts
+++ b/apps/web/src/app/api/checker/cron/30m/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (isAuthorizedDomain(req.url)) {
     const { cronCompleted, cronFailed } = runSentryCron("30-m-cron");
     try {
-      await cron({ periodicity: "30m", req });
+      await cron({ periodicity: "30m" });
       await cronCompleted();
     } catch (_error) {
       await cronFailed();

--- a/apps/web/src/app/api/checker/cron/30s/route.ts
+++ b/apps/web/src/app/api/checker/cron/30s/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (isAuthorizedDomain(req.url)) {
     const { cronCompleted, cronFailed } = runSentryCron("30-s-cron");
     try {
-      await cron({ periodicity: "30s", req });
+      await cron({ periodicity: "30s" });
       await cronCompleted();
     } catch (_error) {
       await cronFailed();

--- a/apps/web/src/app/api/checker/cron/5m/route.ts
+++ b/apps/web/src/app/api/checker/cron/5m/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (isAuthorizedDomain(req.url)) {
     const { cronCompleted, cronFailed } = runSentryCron("5-m-cron");
     try {
-      await cron({ periodicity: "5m", req });
+      await cron({ periodicity: "5m" });
       await cronCompleted();
     } catch (_error) {
       await cronFailed();

--- a/apps/web/src/app/api/checker/cron/_cron.ts
+++ b/apps/web/src/app/api/checker/cron/_cron.ts
@@ -1,6 +1,5 @@
 import { CloudTasksClient } from "@google-cloud/tasks";
 import type { google } from "@google-cloud/tasks/build/protos/protos";
-import type { NextRequest } from "next/server";
 import { z } from "zod";
 
 import { and, db, eq, gte, isNotNull, lte, notInArray } from "@openstatus/db";
@@ -41,9 +40,7 @@ export const isAuthorizedDomain = (url: string) => {
 
 export const cron = async ({
   periodicity,
-  // biome-ignore lint/correctness/noUnusedVariables: <explanation>
-  req,
-}: z.infer<typeof periodicityAvailable> & { req: NextRequest }) => {
+}: z.infer<typeof periodicityAvailable>) => {
   const client = new CloudTasksClient({
     projectId: env.GCP_PROJECT_ID,
     credentials: {

--- a/packages/db/src/schema/monitors/validation.ts
+++ b/packages/db/src/schema/monitors/validation.ts
@@ -11,10 +11,6 @@ export const monitorMethodsSchema = z.enum(monitorMethods);
 export const monitorStatusSchema = z.enum(monitorStatus);
 export const monitorJobTypesSchema = z.enum(monitorJobTypes);
 
-// TODO: shared function
-// biome-ignore lint/correctness/noUnusedVariables: <explanation>
-function stringToArrayProcess<T>(_string: T) {}
-
 const regionsToArraySchema = z.preprocess((val) => {
   if (String(val).length > 0) {
     return String(val).split(",");


### PR DESCRIPTION
## Summary

Focused first step toward resolving #826. This PR removes `biome-ignore lint/correctness/noUnusedVariables` suppressions by deleting the underlying dead code instead of silencing the lint rule.

- **`packages/db/src/schema/monitors/validation.ts`**: Remove unused `stringToArrayProcess` function (empty body, had a TODO but was never implemented or called)
- **`apps/web/src/app/api/checker/cron/_cron.ts`**: Remove unused `req` parameter from the `cron` function signature, along with the now-unnecessary `NextRequest` import
- **`apps/web/src/app/api/checker/cron/{1m,5m,10m,30m,30s,1h}/route.ts`**: Stop passing `req` to `cron()` since the parameter was removed

### What's NOT in this PR

The `examples.ts` file in `packages/tinybird/src/audit-log/` also has `noUnusedVariables` suppressions, but those are on intentionally-defined example/scratch functions with commented-out calls — removing them would defeat the file's purpose. Skipped to keep this PR conservative.

Other biome-ignore categories (`noArrayIndexKey`, `useExhaustiveDependencies`, `noForEach`, etc.) will follow in separate PRs to keep reviews small and focused.

## Test plan

- [ ] Verify the cron routes still compile and work correctly (the `req` parameter was never read inside `cron()`)
- [ ] Verify `validation.ts` still exports all needed schemas (the removed function was dead code with an empty body)