### PR TITLE
feat(web) add "How it works" section to marketing landing page.

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -1,3 +1,4 @@
+import { HowItWorks } from "@/components/marketing/how-it-works";
 import { CustomMDX } from "@/content/mdx";
 import { getHomePage } from "@/content/utils";
 import { defaultMetadata } from "@/lib/metadata/shared-metadata";
@@ -27,7 +28,7 @@ export default function Page() {
   ]);
 
   return (
-    <div className="prose dark:prose-invert max-w-none">
+    <>
       <script
         type="application/ld+json"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: jsonLd
@@ -35,9 +36,19 @@ export default function Page() {
           __html: JSON.stringify(jsonLDGraph).replace(/</g, "\\u003c"),
         }}
       />
-      <h1>{homePage.metadata.title}</h1>
-      <p className="text-lg">{homePage.metadata.description}</p>
-      <CustomMDX source={homePage.content} />
-    </div>
+      {/* Hero */}
+      <div className="prose dark:prose-invert max-w-none">
+        <h1>{homePage.metadata.title}</h1>
+        <p className="text-lg">{homePage.metadata.description}</p>
+      </div>
+
+      {/* How it works — between Hero and Features */}
+      <HowItWorks />
+
+      {/* Features and remaining MDX content */}
+      <div className="prose dark:prose-invert max-w-none">
+        <CustomMDX source={homePage.content} />
+      </div>
+    </>
   );
 }

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -1,0 +1,159 @@
+import { Bell, Globe, Monitor } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface Step {
+  number: number;
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+const steps: Step[] = [
+  {
+    number: 1,
+    icon: Monitor,
+    title: "Add your monitors",
+    description:
+      "Connect your websites and APIs in seconds. Set your check frequency and regions.",
+  },
+  {
+    number: 2,
+    icon: Bell,
+    title: "Get notified instantly",
+    description:
+      "Receive alerts via email, Slack, or SMS the moment downtime is detected.",
+  },
+  {
+    number: 3,
+    icon: Globe,
+    title: "Share your status",
+    description:
+      "Publish a beautiful public status page to keep your users informed.",
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section
+      aria-labelledby="how-it-works-heading"
+      className="-mx-4 w-[calc(100%+2rem)] border-y border-border bg-muted/40"
+    >
+      <div className="mx-auto max-w-5xl px-4 py-12">
+        {/* Section heading */}
+        <div className="mb-10 text-center">
+          <h2
+            id="how-it-works-heading"
+            className="font-mono text-2xl font-medium tracking-tight text-foreground"
+          >
+            How it works
+          </h2>
+          <p className="mt-2 font-mono text-sm text-muted-foreground">
+            Up and running in three simple steps.
+          </p>
+        </div>
+
+        {/* Steps grid */}
+        <div className="relative grid grid-cols-1 gap-px border border-border bg-border sm:grid-cols-3">
+          {steps.map((step) => (
+            <StepCard key={step.number} step={step} />
+          ))}
+
+          {/* Dotted connector lines — visible only on sm+ between cards */}
+          <ConnectorLines />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StepCard({ step }: { step: Step }) {
+  const Icon = step.icon;
+  return (
+    <div className="relative flex flex-col gap-4 bg-background p-6 hover:bg-muted/60 transition-colors duration-150">
+      {/* Numbered badge */}
+      <div className="flex items-center justify-between">
+        <span
+          aria-hidden="true"
+          className="inline-flex h-6 w-6 items-center justify-center border border-border bg-muted font-mono text-xs font-semibold text-muted-foreground tabular-nums"
+        >
+          {step.number}
+        </span>
+        <Icon
+          className="h-5 w-5 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Text content */}
+      <div className="flex flex-col gap-1">
+        <h3 className="font-mono text-sm font-semibold text-foreground">
+          {step.title}
+        </h3>
+        <p className="font-mono text-xs leading-relaxed text-muted-foreground">
+          {step.description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders two dotted arrow connectors between the three step cards.
+ * Only visible at sm breakpoint and above where the cards sit side by side.
+ */
+function ConnectorLines() {
+  return (
+    <>
+      {/* Connector between step 1 and 2 */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 hidden sm:block"
+        style={{ left: "calc(33.333% - 1px)" }}
+      >
+        <DottedArrow />
+      </div>
+      {/* Connector between step 2 and 3 */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 hidden sm:block"
+        style={{ left: "calc(66.666% - 1px)" }}
+      >
+        <DottedArrow />
+      </div>
+    </>
+  );
+}
+
+function DottedArrow() {
+  return (
+    <div className="flex h-full w-8 -translate-x-1/2 items-center justify-center">
+      <svg
+        width="32"
+        height="16"
+        viewBox="0 0 32 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="text-border"
+        aria-hidden="true"
+      >
+        <line
+          x1="0"
+          y1="8"
+          x2="24"
+          y2="8"
+          stroke="currentColor"
+          strokeWidth="1"
+          strokeDasharray="3 3"
+        />
+        <polyline
+          points="20,4 28,8 20,12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -36,7 +36,7 @@ export function HowItWorks() {
   return (
     <section
       aria-labelledby="how-it-works-heading"
-      className="-mx-4 w-[calc(100%+2rem)] border-y border-border bg-muted/40"
+      className="-mx-4 w-[calc(100%+2rem)] border-y border-success/20 bg-success/5"
     >
       <div className="mx-auto max-w-5xl px-4 py-12">
         {/* Section heading */}
@@ -47,13 +47,13 @@ export function HowItWorks() {
           >
             How it works
           </h2>
-          <p className="mt-2 font-mono text-sm text-muted-foreground">
+          <p className="mt-2 font-mono text-sm text-success/70">
             Up and running in three simple steps.
           </p>
         </div>
 
         {/* Steps grid */}
-        <div className="relative grid grid-cols-1 gap-px border border-border bg-border sm:grid-cols-3">
+        <div className="relative grid grid-cols-1 gap-px border border-success/20 bg-border sm:grid-cols-3">
           {steps.map((step) => (
             <StepCard key={step.number} step={step} />
           ))}
@@ -69,17 +69,17 @@ export function HowItWorks() {
 function StepCard({ step }: { step: Step }) {
   const Icon = step.icon;
   return (
-    <div className="relative flex flex-col gap-4 bg-background p-6 hover:bg-muted/60 transition-colors duration-150">
+    <div className="relative flex flex-col gap-4 bg-background p-6 hover:bg-success/5 transition-colors duration-150">
       {/* Numbered badge */}
       <div className="flex items-center justify-between">
         <span
           aria-hidden="true"
-          className="inline-flex h-6 w-6 items-center justify-center border border-border bg-muted font-mono text-xs font-semibold text-muted-foreground tabular-nums"
+          className="inline-flex h-6 w-6 items-center justify-center border border-success/40 bg-success/10 font-mono text-xs font-semibold text-success tabular-nums"
         >
           {step.number}
         </span>
         <Icon
-          className="h-5 w-5 shrink-0 text-muted-foreground"
+          className="h-5 w-5 shrink-0 text-success"
           aria-hidden="true"
         />
       </div>
@@ -133,7 +133,7 @@ function DottedArrow() {
         viewBox="0 0 32 16"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        className="text-border"
+        className="text-success/40"
         aria-hidden="true"
       >
         <line


### PR DESCRIPTION
## Add "How it Works" Section to Landing Page

### Summary

Added a new "How it Works" marketing section to the OpenStatus landing page that explains the product flow in three simple steps. The section is positioned between the Hero and Features sections.

### Changes

**New Component: `apps/web/src/components/marketing/how-it-works.tsx`**

- Created a reusable `HowItWorks` component with three step cards:

1. "Add your monitors" - Connect websites and APIs
2. "Get notified instantly" - Receive alerts via email, Slack, or SMS
3. "Share your status" - Publish a public status page



- Features:

- Numbered badges (1, 2, 3) on each card using the success color
- Lucide React icons (Monitor, Bell, Globe) aligned right
- Responsive grid: 1 column on mobile, 3 columns on desktop
- Dotted connector arrows between cards (desktop only)
- Full-bleed section with subtle green background and border
- Dark/light mode compatible using semantic design tokens





**Updated: `apps/web/src/app/(landing)/page.tsx`**

- Imported and integrated the new `HowItWorks` component
- Restructured page layout to place the component between Hero and Features sections
- Maintained existing prose styling and JSON-LD structured data


### Design Details

- Uses OpenStatus's green success color scheme (`--success: oklch(0.72 0.19 150)`)
- Monospace typography consistent with site design
- Border-grid card layout matching existing header pattern
- Accessible: proper heading hierarchy, ARIA labels, and semantic HTML