### PR TITLE
feat(web): add "How it works" section to marketing landing page

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -1,3 +1,4 @@
+import { HowItWorks } from "@/components/marketing/how-it-works";
 import { CustomMDX } from "@/content/mdx";
 import { getHomePage } from "@/content/utils";
 import { defaultMetadata } from "@/lib/metadata/shared-metadata";
@@ -27,17 +28,22 @@ export default function Page() {
   ]);
 
   return (
-    <div className="prose dark:prose-invert max-w-none">
-      <script
-        type="application/ld+json"
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: jsonLd
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(jsonLDGraph).replace(/</g, "\\u003c"),
-        }}
-      />
-      <h1>{homePage.metadata.title}</h1>
-      <p className="text-lg">{homePage.metadata.description}</p>
-      <CustomMDX source={homePage.content} />
-    </div>
+    <>
+      <div className="prose dark:prose-invert max-w-none">
+        <script
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: jsonLd
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(jsonLDGraph).replace(/</g, "\\u003c"),
+          }}
+        />
+        <h1>{homePage.metadata.title}</h1>
+        <p className="text-lg">{homePage.metadata.description}</p>
+      </div>
+      <HowItWorks />
+      <div className="prose dark:prose-invert max-w-none">
+        <CustomMDX source={homePage.content} />
+      </div>
+    </>
   );
 }

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -43,7 +43,7 @@ export function HowItWorks() {
           {/* Connecting line for desktop */}
           <div
             aria-hidden="true"
-            className="absolute left-0 right-0 top-12 hidden h-px border-t border-dashed border-border md:block"
+            className="absolute left-0 right-0 top-12 hidden h-px border-t-2 border-dashed border-success/50 md:block"
             style={{
               left: "calc(16.67% + 24px)",
               right: "calc(16.67% + 24px)",
@@ -53,7 +53,7 @@ export function HowItWorks() {
           {steps.map((step, index) => (
             <div key={step.step} className="relative flex flex-col items-center">
               {/* Numbered badge */}
-              <div className="relative z-10 mb-6 flex h-12 w-12 items-center justify-center rounded-full border border-border bg-background text-sm font-medium text-foreground shadow-sm">
+              <div className="relative z-10 mb-6 flex h-12 w-12 items-center justify-center rounded-full border-2 border-success bg-success/10 text-sm font-semibold text-success shadow-sm">
                 {step.step}
               </div>
 
@@ -61,7 +61,7 @@ export function HowItWorks() {
               {index < steps.length - 1 && (
                 <div
                   aria-hidden="true"
-                  className="absolute right-0 top-12 hidden -translate-y-1/2 translate-x-1/2 text-muted-foreground md:block"
+                  className="absolute right-0 top-12 hidden -translate-y-1/2 translate-x-1/2 md:block"
                 >
                   <svg
                     width="16"
@@ -69,12 +69,12 @@ export function HowItWorks() {
                     viewBox="0 0 16 16"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
-                    className="text-border"
+                    className="text-success"
                   >
                     <path
                       d="M6 4L10 8L6 12"
                       stroke="currentColor"
-                      strokeWidth="1.5"
+                      strokeWidth="2"
                       strokeLinecap="round"
                       strokeLinejoin="round"
                     />
@@ -84,8 +84,8 @@ export function HowItWorks() {
 
               {/* Card content */}
               <div className="flex flex-1 flex-col items-center rounded-lg border border-border bg-card p-6 text-center shadow-sm">
-                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-muted">
-                  <step.icon className="h-5 w-5 text-foreground" />
+                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-success/10">
+                  <step.icon className="h-5 w-5 text-success" />
                 </div>
                 <h3 className="mb-2 font-medium text-foreground">{step.title}</h3>
                 <p className="text-sm text-muted-foreground">{step.description}</p>

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -43,7 +43,7 @@ export function HowItWorks() {
           {/* Connecting line for desktop */}
           <div
             aria-hidden="true"
-            className="absolute left-0 right-0 top-12 hidden h-px border-t-2 border-dashed border-success/50 md:block"
+            className="absolute left-0 right-0 top-12 hidden h-px border-t border-dashed border-border md:block"
             style={{
               left: "calc(16.67% + 24px)",
               right: "calc(16.67% + 24px)",
@@ -69,12 +69,12 @@ export function HowItWorks() {
                     viewBox="0 0 16 16"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
-                    className="text-success"
+                    className="text-muted-foreground/50"
                   >
                     <path
                       d="M6 4L10 8L6 12"
                       stroke="currentColor"
-                      strokeWidth="2"
+                      strokeWidth="1.5"
                       strokeLinecap="round"
                       strokeLinejoin="round"
                     />

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -1,0 +1,99 @@
+import { Bell, Globe, Monitor } from "lucide-react";
+
+const steps = [
+  {
+    step: 1,
+    title: "Add your monitors",
+    description:
+      "Connect your websites and APIs in seconds. Set your check frequency and regions.",
+    icon: Monitor,
+  },
+  {
+    step: 2,
+    title: "Get notified instantly",
+    description:
+      "Receive alerts via email, Slack, or SMS the moment downtime is detected.",
+    icon: Bell,
+  },
+  {
+    step: 3,
+    title: "Share your status",
+    description:
+      "Publish a beautiful public status page to keep your users informed.",
+    icon: Globe,
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section className="bg-muted/50 py-16 md:py-24">
+      <div className="mx-auto max-w-5xl px-4">
+        {/* Header */}
+        <div className="mb-12 text-center md:mb-16">
+          <h2 className="text-2xl font-medium tracking-tight text-foreground md:text-3xl">
+            How it works
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
+            Get up and running with OpenStatus in three simple steps
+          </p>
+        </div>
+
+        {/* Steps */}
+        <div className="relative grid gap-8 md:grid-cols-3 md:gap-6">
+          {/* Connecting line for desktop */}
+          <div
+            aria-hidden="true"
+            className="absolute left-0 right-0 top-12 hidden h-px border-t border-dashed border-border md:block"
+            style={{
+              left: "calc(16.67% + 24px)",
+              right: "calc(16.67% + 24px)",
+            }}
+          />
+
+          {steps.map((step, index) => (
+            <div key={step.step} className="relative flex flex-col items-center">
+              {/* Numbered badge */}
+              <div className="relative z-10 mb-6 flex h-12 w-12 items-center justify-center rounded-full border border-border bg-background text-sm font-medium text-foreground shadow-sm">
+                {step.step}
+              </div>
+
+              {/* Arrow between steps on desktop */}
+              {index < steps.length - 1 && (
+                <div
+                  aria-hidden="true"
+                  className="absolute right-0 top-12 hidden -translate-y-1/2 translate-x-1/2 text-muted-foreground md:block"
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="text-border"
+                  >
+                    <path
+                      d="M6 4L10 8L6 12"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </div>
+              )}
+
+              {/* Card content */}
+              <div className="flex flex-1 flex-col items-center rounded-lg border border-border bg-card p-6 text-center shadow-sm">
+                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+                  <step.icon className="h-5 w-5 text-foreground" />
+                </div>
+                <h3 className="mb-2 font-medium text-foreground">{step.title}</h3>
+                <p className="text-sm text-muted-foreground">{step.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -53,7 +53,7 @@ export function HowItWorks() {
           {steps.map((step, index) => (
             <div key={step.step} className="relative flex flex-col items-center">
               {/* Numbered badge */}
-              <div className="relative z-10 mb-6 flex h-12 w-12 items-center justify-center rounded-full border-2 border-success bg-success/10 text-sm font-semibold text-success shadow-sm">
+              <div className="relative z-10 mb-6 flex h-12 w-12 items-center justify-center rounded-full border-2 border-success bg-success/10 text-sm font-semibold text-success">
                 {step.step}
               </div>
 
@@ -83,7 +83,7 @@ export function HowItWorks() {
               )}
 
               {/* Card content */}
-              <div className="flex flex-1 flex-col items-center rounded-lg border border-border bg-card p-6 text-center shadow-sm">
+              <div className="flex flex-1 flex-col items-center rounded-lg border border-border bg-background p-6 text-center">
                 <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-success/10">
                   <step.icon className="h-5 w-5 text-success" />
                 </div>


### PR DESCRIPTION
## Summary
Adds a new "How it works" section to the marketing landing page
(apps/web) to help visitors quickly understand the OpenStatus workflow.

## What changed
- Created apps/web/src/components/marketing/how-it-works.tsx
- Imported and placed the section in apps/web/src/app/(marketing)/page.tsx
  between the Hero section and the Features section

## Type of change
- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring

## Details
The section includes 3 steps:
1. Add your monitors
2. Get notified instantly
3. Share your status page

Built using the existing stack: Next.js + Tailwind CSS + shadcn/ui + lucide-react.
Fully responsive and dark/light mode compatible.

## Screenshots
<img width="1382" height="738" alt="image" src="https://github.com/user-attachments/assets/bf01ee0e-abef-4cd7-a116-69e30fa0dc53" />

## Checklist
- [x] Follows existing coding conventions and style guide
- [x] Uses existing shadcn/ui components
- [x] Dark/light mode compatible
- [x] Mobile responsive
- [x] No new dependencies added