### PR TITLE
fix: handle cannot_reply_to_message error in slack agent

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -55,8 +55,8 @@
     "nanoid": "5.0.7",
     "percentile": "1.6.0",
     "validator": "13.12.0",
-    "@slack/web-api": "^7.8.0",
-    "@ai-sdk/anthropic": "^1.2.0",
+    "@slack/web-api": "7.15.0",
+    "@ai-sdk/anthropic": "1.2.0",
     "ai": "6.0.94",
     "zod": "4.1.13"
   },

--- a/apps/server/src/routes/slack/handler.test.ts
+++ b/apps/server/src/routes/slack/handler.test.ts
@@ -26,16 +26,24 @@ mock.module("./workspace-resolver", () => ({
   },
 }));
 
-let slackMessages: Array<{ method: string; args: unknown }> = [];
+let slackMessages: Array<{ method: string; args: Record<string, unknown> }> = [];
+let postMessageOverride:
+  | ((args: Record<string, unknown>) => Promise<{ ts: string }>)
+  | null = null;
+let updateOverride:
+  | ((args: Record<string, unknown>) => Promise<{ ts: string }>)
+  | null = null;
 
 mock.module("@slack/web-api", () => ({
   WebClient: class {
     chat = {
-      postMessage: (args: unknown) => {
+      postMessage: (args: Record<string, unknown>) => {
+        if (postMessageOverride) return postMessageOverride(args);
         slackMessages.push({ method: "postMessage", args });
         return Promise.resolve({ ts: "msg.ts" });
       },
-      update: (args: unknown) => {
+      update: (args: Record<string, unknown>) => {
+        if (updateOverride) return updateOverride(args);
         slackMessages.push({ method: "update", args });
         return Promise.resolve({ ts: "msg.ts" });
       },
@@ -49,12 +57,25 @@ mock.module("@slack/web-api", () => ({
   },
 }));
 
+let runAgentOverride: (() => Promise<{ text: string; toolResults: never[] }>) | null =
+  null;
+
 mock.module("./agent", () => ({
-  runAgent: () =>
-    Promise.resolve({
+  runAgent: () => {
+    if (runAgentOverride) return runAgentOverride();
+    return Promise.resolve({
       text: "Here is my response",
       toolResults: [],
-    }),
+    });
+  },
+}));
+
+mock.module("./confirmation-store", () => ({
+  store: () => Promise.resolve("test-action-id"),
+  get: () => Promise.resolve(undefined),
+  consume: () => Promise.resolve(undefined),
+  findByThread: () => Promise.resolve(undefined),
+  replace: () => Promise.resolve(),
 }));
 
 const { handleSlackEvent } = await import("./handler");
@@ -94,6 +115,9 @@ describe("handleSlackEvent", () => {
 
   beforeEach(() => {
     slackMessages = [];
+    postMessageOverride = null;
+    updateOverride = null;
+    runAgentOverride = null;
   });
 
   test("responds to url_verification challenge", async () => {
@@ -335,6 +359,46 @@ describe("handleSlackEvent", () => {
     expect(slackMessages.length).toBe(0);
   });
 
+  test("ignores channel_join system messages", async () => {
+    const res = await signAndPost(app, {
+      type: "event_callback",
+      team_id: "T_KNOWN",
+      event_id: `evt_join_${Date.now()}`,
+      event: {
+        type: "message",
+        subtype: "channel_join",
+        text: "<@U1> has joined the channel",
+        user: "U1",
+        channel: "C1",
+        ts: `${Date.now()}.10`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(slackMessages.length).toBe(0);
+  });
+
+  test("ignores channel_leave system messages", async () => {
+    const res = await signAndPost(app, {
+      type: "event_callback",
+      team_id: "T_KNOWN",
+      event_id: `evt_leave_${Date.now()}`,
+      event: {
+        type: "message",
+        subtype: "channel_leave",
+        text: "<@U1> has left the channel",
+        user: "U1",
+        channel: "C1",
+        ts: `${Date.now()}.11`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(slackMessages.length).toBe(0);
+  });
+
   test("ignores events with no event payload", async () => {
     const res = await signAndPost(app, {
       type: "event_callback",
@@ -345,5 +409,130 @@ describe("handleSlackEvent", () => {
     expect(res.status).toBe(200);
     await new Promise((r) => setTimeout(r, 50));
     expect(slackMessages.length).toBe(0);
+  });
+
+  test("falls back to top-level message on cannot_reply_to_message", async () => {
+    let callCount = 0;
+    postMessageOverride = (args: Record<string, unknown>) => {
+      callCount++;
+      if (callCount === 1) {
+        const err = new Error("An API error occurred: cannot_reply_to_message");
+        Object.assign(err, {
+          code: "slack_webapi_platform_error",
+          data: { ok: false, error: "cannot_reply_to_message" },
+        });
+        return Promise.reject(err);
+      }
+      slackMessages.push({ method: "postMessage", args });
+      return Promise.resolve({ ts: "fallback.ts" });
+    };
+
+    const res = await signAndPost(app, {
+      type: "event_callback",
+      team_id: "T_KNOWN",
+      event_id: `evt_cantreply_${Date.now()}`,
+      event: {
+        type: "app_mention",
+        text: "<@UBOT> hello",
+        user: "U1",
+        channel: "C1",
+        ts: `${Date.now()}.20`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const fallbackPost = slackMessages.find(
+      (m) => m.method === "postMessage" && !m.args.thread_ts,
+    );
+    expect(fallbackPost).toBeDefined();
+  });
+
+  test("returns early on non-recoverable postMessage error", async () => {
+    postMessageOverride = () => {
+      const err = new Error("An API error occurred: channel_not_found");
+      Object.assign(err, {
+        code: "slack_webapi_platform_error",
+        data: { ok: false, error: "channel_not_found" },
+      });
+      return Promise.reject(err);
+    };
+
+    const res = await signAndPost(app, {
+      type: "event_callback",
+      team_id: "T_KNOWN",
+      event_id: `evt_channotfound_${Date.now()}`,
+      event: {
+        type: "app_mention",
+        text: "<@UBOT> hello",
+        user: "U1",
+        channel: "C1",
+        ts: `${Date.now()}.21`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const updateMessages = slackMessages.filter((m) => m.method === "update");
+    expect(updateMessages.length).toBe(0);
+  });
+
+  test("shows error message when runAgent throws", async () => {
+    runAgentOverride = () => Promise.reject(new Error("agent exploded"));
+
+    const res = await signAndPost(app, {
+      type: "event_callback",
+      team_id: "T_KNOWN",
+      event_id: `evt_agenterr_${Date.now()}`,
+      event: {
+        type: "app_mention",
+        text: "<@UBOT> hello",
+        user: "U1",
+        channel: "C1",
+        ts: `${Date.now()}.30`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const errorUpdate = slackMessages.find(
+      (m) =>
+        m.method === "update" &&
+        typeof m.args.text === "string" &&
+        m.args.text.includes("Something went wrong"),
+    );
+    expect(errorUpdate).toBeDefined();
+  });
+
+  test("does not throw when both runAgent and error update fail", async () => {
+    runAgentOverride = () => Promise.reject(new Error("agent exploded"));
+    updateOverride = () => {
+      const err = new Error("An API error occurred: channel_not_found");
+      Object.assign(err, {
+        code: "slack_webapi_platform_error",
+        data: { ok: false, error: "channel_not_found" },
+      });
+      return Promise.reject(err);
+    };
+
+    const res = await signAndPost(app, {
+      type: "event_callback",
+      team_id: "T_KNOWN",
+      event_id: `evt_doublefail_${Date.now()}`,
+      event: {
+        type: "app_mention",
+        text: "<@UBOT> hello",
+        user: "U1",
+        channel: "C1",
+        ts: `${Date.now()}.31`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 100));
+    // No unhandled rejection — the .catch() in the error handler swallows it
   });
 });

--- a/apps/server/src/routes/slack/handler.test.ts
+++ b/apps/server/src/routes/slack/handler.test.ts
@@ -26,7 +26,8 @@ mock.module("./workspace-resolver", () => ({
   },
 }));
 
-let slackMessages: Array<{ method: string; args: Record<string, unknown> }> = [];
+let slackMessages: Array<{ method: string; args: Record<string, unknown> }> =
+  [];
 let postMessageOverride:
   | ((args: Record<string, unknown>) => Promise<{ ts: string }>)
   | null = null;
@@ -57,8 +58,9 @@ mock.module("@slack/web-api", () => ({
   },
 }));
 
-let runAgentOverride: (() => Promise<{ text: string; toolResults: never[] }>) | null =
-  null;
+let runAgentOverride:
+  | (() => Promise<{ text: string; toolResults: never[] }>)
+  | null = null;
 
 mock.module("./agent", () => ({
   runAgent: () => {

--- a/apps/server/src/routes/slack/handler.ts
+++ b/apps/server/src/routes/slack/handler.ts
@@ -83,7 +83,13 @@ export async function handleSlackEvent(c: Context) {
   }
 
   const promise = processEvent(body);
-  promise.catch((err) => logger.error("slack event processing error", { error: err, teamId: body.team_id, eventId: body.event_id }));
+  promise.catch((err) =>
+    logger.error("slack event processing error", {
+      error: err,
+      teamId: body.team_id,
+      eventId: body.event_id,
+    }),
+  );
 
   return c.json({ ok: true });
 }
@@ -97,7 +103,12 @@ async function processEvent(body: SlackEvent) {
     if (teamId) {
       await db
         .delete(integration)
-        .where(and(eq(integration.name, "slack-agent"), eq(integration.externalId, teamId)));
+        .where(
+          and(
+            eq(integration.name, "slack-agent"),
+            eq(integration.externalId, teamId),
+          ),
+        );
       logger.info("slack integration cleaned up", { teamId });
     }
     return;
@@ -150,7 +161,11 @@ async function processEvent(body: SlackEvent) {
     thinkingTs = thinkingMsg.ts;
   } catch (err) {
     if (isSlackPlatformError(err, "cannot_reply_to_message")) {
-      logger.warn("slack cannot reply to message, falling back to top-level", { channel: event.channel, teamId, threadTs });
+      logger.warn("slack cannot reply to message, falling back to top-level", {
+        channel: event.channel,
+        teamId,
+        threadTs,
+      });
       try {
         const fallbackMsg = await slack.chat.postMessage({
           channel: event.channel,
@@ -158,17 +173,29 @@ async function processEvent(body: SlackEvent) {
         });
         thinkingTs = fallbackMsg.ts;
       } catch (fallbackErr) {
-        logger.error("slack failed to post fallback thinking message", { error: fallbackErr, channel: event.channel, teamId });
+        logger.error("slack failed to post fallback thinking message", {
+          error: fallbackErr,
+          channel: event.channel,
+          teamId,
+        });
         return;
       }
     } else {
-      logger.error("slack failed to post thinking message", { error: err, channel: event.channel, teamId, threadTs });
+      logger.error("slack failed to post thinking message", {
+        error: err,
+        channel: event.channel,
+        teamId,
+        threadTs,
+      });
       return;
     }
   }
 
   if (!thinkingTs) {
-    logger.error("slack thinking message returned no ts", { channel: event.channel, teamId });
+    logger.error("slack thinking message returned no ts", {
+      channel: event.channel,
+      teamId,
+    });
     return;
   }
 
@@ -180,14 +207,26 @@ async function processEvent(body: SlackEvent) {
         ts: event.thread_ts,
         limit: 100,
       });
-      thread = ((replies.messages ?? []) as ThreadMessage[]).filter((msg) => msg.ts !== thinkingTs);
+      thread = ((replies.messages ?? []) as ThreadMessage[]).filter(
+        (msg) => msg.ts !== thinkingTs,
+      );
     } else {
       thread = [{ user: event.user, text: event.text, ts: event.ts }];
     }
 
-    logger.info("slack agent invoked", { teamId, channel: event.channel, threadTs, messageCount: thread.length });
+    logger.info("slack agent invoked", {
+      teamId,
+      channel: event.channel,
+      threadTs,
+      messageCount: thread.length,
+    });
 
-    const result = await runAgent(resolved.workspace, thread, botUserId, event.text);
+    const result = await runAgent(
+      resolved.workspace,
+      thread,
+      botUserId,
+      event.text,
+    );
 
     logger.info("slack agent completed", {
       teamId,
@@ -205,7 +244,12 @@ async function processEvent(body: SlackEvent) {
     );
 
     if (confirmationResult) {
-      logger.info("slack confirmation requested", { teamId, channel: event.channel, threadTs, toolName: confirmationResult.toolName });
+      logger.info("slack confirmation requested", {
+        teamId,
+        channel: event.channel,
+        threadTs,
+        toolName: confirmationResult.toolName,
+      });
       await handleConfirmation(
         slack,
         event.channel,
@@ -222,10 +266,19 @@ async function processEvent(body: SlackEvent) {
         ts: thinkingTs,
         text: result.text || "Done!",
       });
-      logger.info("slack response sent", { teamId, channel: event.channel, threadTs });
+      logger.info("slack response sent", {
+        teamId,
+        channel: event.channel,
+        threadTs,
+      });
     }
   } catch (err) {
-    logger.error("slack agent error", { error: err, channel: event.channel, teamId, threadTs });
+    logger.error("slack agent error", {
+      error: err,
+      channel: event.channel,
+      teamId,
+      threadTs,
+    });
     if (thinkingTs) {
       await slack.chat
         .update({
@@ -234,7 +287,11 @@ async function processEvent(body: SlackEvent) {
           text: ":x: Something went wrong. Please try again.",
         })
         .catch((updateErr: unknown) => {
-          logger.error("slack failed to update error message", { error: updateErr, channel: event.channel, thinkingTs });
+          logger.error("slack failed to update error message", {
+            error: updateErr,
+            channel: event.channel,
+            thinkingTs,
+          });
         });
     }
   }
@@ -255,7 +312,8 @@ async function handleConfirmation(
     params: Record<string, unknown>;
   };
 
-  const actionType = confirmationResult.toolName as PendingAction["action"]["type"];
+  const actionType =
+    confirmationResult.toolName as PendingAction["action"]["type"];
   const action = { type: actionType, params } as PendingAction["action"];
 
   const existing = await findByThread(threadTs);

--- a/apps/server/src/routes/slack/handler.ts
+++ b/apps/server/src/routes/slack/handler.ts
@@ -1,12 +1,16 @@
+import { getLogger } from "@logtape/logtape";
 import { and, db, eq } from "@openstatus/db";
 import { integration } from "@openstatus/db/src/schema";
 import { WebClient } from "@slack/web-api";
 import type { Context } from "hono";
+import { z } from "zod";
 import { runAgent } from "./agent";
 import { buildConfirmationBlocks } from "./blocks";
 import { findByThread, replace, store } from "./confirmation-store";
 import type { PendingAction } from "./confirmation-store";
 import { resolveWorkspace } from "./workspace-resolver";
+
+const logger = getLogger("api-server");
 
 const processedEvents = new Map<string, number>();
 
@@ -20,28 +24,47 @@ function dedup(eventId: string): boolean {
   return false;
 }
 
-interface SlackEvent {
-  type: string;
-  event?: {
-    type: string;
-    text?: string;
-    user?: string;
-    channel?: string;
-    channel_type?: string;
-    ts?: string;
-    thread_ts?: string;
-    bot_id?: string;
-  };
-  event_id?: string;
-  team_id?: string;
-  challenge?: string;
-}
+const slackEventSchema = z.object({
+  type: z.string(),
+  event: z
+    .object({
+      type: z.string(),
+      subtype: z.string().optional(),
+      text: z.string().optional(),
+      user: z.string().optional(),
+      channel: z.string().optional(),
+      channel_type: z.string().optional(),
+      ts: z.string().optional(),
+      thread_ts: z.string().optional(),
+      bot_id: z.string().optional(),
+    })
+    .optional(),
+  event_id: z.string().optional(),
+  team_id: z.string().optional(),
+  challenge: z.string().optional(),
+});
 
-interface ThreadMessage {
-  user?: string;
-  bot_id?: string;
-  text?: string;
-  ts?: string;
+type SlackEvent = z.infer<typeof slackEventSchema>;
+
+const threadMessageSchema = z.object({
+  user: z.string().optional(),
+  bot_id: z.string().optional(),
+  text: z.string().optional(),
+  ts: z.string().optional(),
+});
+
+type ThreadMessage = z.infer<typeof threadMessageSchema>;
+
+const slackPlatformErrorSchema = z.object({
+  code: z.literal("slack_webapi_platform_error"),
+  data: z.object({
+    error: z.string(),
+  }),
+});
+
+function isSlackPlatformError(err: unknown, errorCode: string): boolean {
+  const parsed = slackPlatformErrorSchema.safeParse(err);
+  return parsed.success && parsed.data.data.error === errorCode;
 }
 
 export async function handleSlackEvent(c: Context) {
@@ -60,7 +83,7 @@ export async function handleSlackEvent(c: Context) {
   }
 
   const promise = processEvent(body);
-  promise.catch((err) => console.error("[slack] event processing error:", err));
+  promise.catch((err) => logger.error("slack event processing error", { error: err, teamId: body.team_id, eventId: body.event_id }));
 
   return c.json({ ok: true });
 }
@@ -74,13 +97,8 @@ async function processEvent(body: SlackEvent) {
     if (teamId) {
       await db
         .delete(integration)
-        .where(
-          and(
-            eq(integration.name, "slack-agent"),
-            eq(integration.externalId, teamId),
-          ),
-        );
-      console.log(`[slack] cleaned up integration for team ${teamId}`);
+        .where(and(eq(integration.name, "slack-agent"), eq(integration.externalId, teamId)));
+      logger.info("slack integration cleaned up", { teamId });
     }
     return;
   }
@@ -88,12 +106,21 @@ async function processEvent(body: SlackEvent) {
   if (event.type !== "app_mention" && event.type !== "message") return;
   if (event.type === "message" && event.bot_id) return;
 
+  const ignoredSubtypes = [
+    "channel_join",
+    "channel_leave",
+    "channel_topic",
+    "channel_purpose",
+    "channel_name",
+  ];
+  if (event.subtype && ignoredSubtypes.includes(event.subtype)) return;
+
   const teamId = body.team_id;
   if (!teamId || !event.channel || !event.ts) return;
 
   const resolved = await resolveWorkspace(teamId);
   if (!resolved) {
-    console.warn(`[slack] no integration found for team ${teamId}`);
+    logger.warn("slack integration not found", { teamId });
     return;
   }
 
@@ -105,15 +132,43 @@ async function processEvent(body: SlackEvent) {
     if (!event.text?.includes(`<@${botUserId}>`)) return;
   }
 
-  const thinkingMsg = await slack.chat.postMessage({
+  logger.info("slack event received", {
+    teamId,
     channel: event.channel,
-    thread_ts: threadTs,
-    text: ":hourglass_flowing_sand: Thinking...",
+    eventType: event.type,
+    threadTs,
+    user: event.user,
   });
-  const thinkingTs = thinkingMsg.ts;
+
+  let thinkingTs: string | undefined;
+  try {
+    const thinkingMsg = await slack.chat.postMessage({
+      channel: event.channel,
+      thread_ts: threadTs,
+      text: ":hourglass_flowing_sand: Thinking...",
+    });
+    thinkingTs = thinkingMsg.ts;
+  } catch (err) {
+    if (isSlackPlatformError(err, "cannot_reply_to_message")) {
+      logger.warn("slack cannot reply to message, falling back to top-level", { channel: event.channel, teamId, threadTs });
+      try {
+        const fallbackMsg = await slack.chat.postMessage({
+          channel: event.channel,
+          text: ":hourglass_flowing_sand: Thinking...",
+        });
+        thinkingTs = fallbackMsg.ts;
+      } catch (fallbackErr) {
+        logger.error("slack failed to post fallback thinking message", { error: fallbackErr, channel: event.channel, teamId });
+        return;
+      }
+    } else {
+      logger.error("slack failed to post thinking message", { error: err, channel: event.channel, teamId, threadTs });
+      return;
+    }
+  }
 
   if (!thinkingTs) {
-    console.error("[slack] failed to post thinking message — no ts returned");
+    logger.error("slack thinking message returned no ts", { channel: event.channel, teamId });
     return;
   }
 
@@ -125,19 +180,21 @@ async function processEvent(body: SlackEvent) {
         ts: event.thread_ts,
         limit: 100,
       });
-      thread = ((replies.messages ?? []) as ThreadMessage[]).filter(
-        (msg) => msg.ts !== thinkingTs,
-      );
+      thread = ((replies.messages ?? []) as ThreadMessage[]).filter((msg) => msg.ts !== thinkingTs);
     } else {
       thread = [{ user: event.user, text: event.text, ts: event.ts }];
     }
 
-    const result = await runAgent(
-      resolved.workspace,
-      thread,
-      botUserId,
-      event.text,
-    );
+    logger.info("slack agent invoked", { teamId, channel: event.channel, threadTs, messageCount: thread.length });
+
+    const result = await runAgent(resolved.workspace, thread, botUserId, event.text);
+
+    logger.info("slack agent completed", {
+      teamId,
+      channel: event.channel,
+      threadTs,
+      toolCalls: result.toolResults.map((tr) => tr.toolName),
+    });
 
     const confirmationResult = result.toolResults.find(
       (tr) =>
@@ -148,6 +205,7 @@ async function processEvent(body: SlackEvent) {
     );
 
     if (confirmationResult) {
+      logger.info("slack confirmation requested", { teamId, channel: event.channel, threadTs, toolName: confirmationResult.toolName });
       await handleConfirmation(
         slack,
         event.channel,
@@ -164,14 +222,21 @@ async function processEvent(body: SlackEvent) {
         ts: thinkingTs,
         text: result.text || "Done!",
       });
+      logger.info("slack response sent", { teamId, channel: event.channel, threadTs });
     }
   } catch (err) {
-    console.error("[slack] agent error:", err);
-    await slack.chat.update({
-      channel: event.channel,
-      ts: thinkingTs,
-      text: ":x: Something went wrong. Please try again.",
-    });
+    logger.error("slack agent error", { error: err, channel: event.channel, teamId, threadTs });
+    if (thinkingTs) {
+      await slack.chat
+        .update({
+          channel: event.channel,
+          ts: thinkingTs,
+          text: ":x: Something went wrong. Please try again.",
+        })
+        .catch((updateErr: unknown) => {
+          logger.error("slack failed to update error message", { error: updateErr, channel: event.channel, thinkingTs });
+        });
+    }
   }
 }
 
@@ -190,8 +255,7 @@ async function handleConfirmation(
     params: Record<string, unknown>;
   };
 
-  const actionType =
-    confirmationResult.toolName as PendingAction["action"]["type"];
+  const actionType = confirmationResult.toolName as PendingAction["action"]["type"];
   const action = { type: actionType, params } as PendingAction["action"];
 
   const existing = await findByThread(threadTs);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,8 +417,8 @@ importers:
   apps/server:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^1.2.0
-        version: 1.2.12(zod@4.1.13)
+        specifier: 1.2.0
+        version: 1.2.0(zod@4.1.13)
       '@bufbuild/protobuf':
         specifier: 2.10.2
         version: 2.10.2
@@ -528,8 +528,8 @@ importers:
         specifier: 0.8.5
         version: 0.8.5(hono@4.11.3)
       '@slack/web-api':
-        specifier: ^7.8.0
-        version: 7.14.1
+        specifier: 7.15.0
+        version: 7.15.0
       '@t3-oss/env-core':
         specifier: 0.13.10
         version: 0.13.10(typescript@5.9.3)(zod@4.1.13)
@@ -2241,8 +2241,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@1.2.12':
-    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+  '@ai-sdk/anthropic@1.2.0':
+    resolution: {integrity: sha512-VMm+wAx7FhSMSjqJv7Zeu3GVxzUdohmWoFpzDCWiODpxPGFHw0d0spDR3sVpk5KcyGRJfebGd86ZtpFLCnagOQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -2253,8 +2253,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@2.2.8':
-    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+  '@ai-sdk/provider-utils@2.2.0':
+    resolution: {integrity: sha512-RX5BnDSqudjvZjwwpROcxVQElyX7rUn/xImBgaZLXekSGqq8f7/tefqDcQiRbDZjuCd4CVIfhrK8y/Pta8cPfQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
@@ -2265,8 +2265,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+  '@ai-sdk/provider@1.1.0':
+    resolution: {integrity: sha512-0M+qjp+clUD0R1E5eWQFhxEvWLNaOtGQRUaBn8CUABnSKredagq92hUS9VjOzGsTm37xLfpaxl97AVtbeOsHew==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
@@ -6440,16 +6440,16 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@slack/logger@4.0.0':
-    resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
+  '@slack/logger@4.0.1':
+    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
-  '@slack/types@2.20.0':
-    resolution: {integrity: sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==}
+  '@slack/types@2.20.1':
+    resolution: {integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/web-api@7.14.1':
-    resolution: {integrity: sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==}
+  '@slack/web-api@7.15.0':
+    resolution: {integrity: sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@smithy/abort-controller@2.2.0':
@@ -12240,10 +12240,10 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@1.2.12(zod@4.1.13)':
+  '@ai-sdk/anthropic@1.2.0(zod@4.1.13)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.13)
+      '@ai-sdk/provider': 1.1.0
+      '@ai-sdk/provider-utils': 2.2.0(zod@4.1.13)
       zod: 4.1.13
 
   '@ai-sdk/gateway@3.0.52(zod@4.1.13)':
@@ -12253,9 +12253,10 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.1.13
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.1.13)':
+  '@ai-sdk/provider-utils@2.2.0(zod@4.1.13)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider': 1.1.0
+      eventsource-parser: 3.0.6
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 4.1.13
@@ -12267,7 +12268,7 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.1.13
 
-  '@ai-sdk/provider@1.1.3':
+  '@ai-sdk/provider@1.1.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -16876,16 +16877,16 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@slack/logger@4.0.0':
+  '@slack/logger@4.0.1':
     dependencies:
       '@types/node': 24.0.8
 
-  '@slack/types@2.20.0': {}
+  '@slack/types@2.20.1': {}
 
-  '@slack/web-api@7.14.1':
+  '@slack/web-api@7.15.0':
     dependencies:
-      '@slack/logger': 4.0.0
-      '@slack/types': 2.20.0
+      '@slack/logger': 4.0.1
+      '@slack/types': 2.20.1
       '@types/node': 24.0.8
       '@types/retry': 0.12.0
       axios: 1.13.5


### PR DESCRIPTION
The slack agent crashed with an unhandled `cannot_reply_to_message` error when trying to thread-reply to system messages (channel_join, channel_leave, etc.) that don't support threading.

Changes:
- Filter out system message subtypes (channel_join/leave/topic/purpose/name) early in processEvent before any Slack API calls
- Wrap the "Thinking..." postMessage in try/catch with fallback to top-level message on `cannot_reply_to_message`
- Guard the error-handler's chat.update behind thinkingTs check with .catch() to prevent secondary unhandled rejections
- Replace interfaces with zod schemas for SlackEvent, ThreadMessage, and slack platform error detection
- Replace all console.log/warn/error with structured logger (getLogger from @logtape/logtape) with contextual properties (teamId, channel, threadTs)
- Add info-level logs at key milestones: event received, agent invoked, agent completed, confirmation requested, response sent