### PR TITLE
fix: prevent crash when status report has no updates

### DIFF
--- a/apps/dashboard/src/components/data-table/status-report-updates/data-table.tsx
+++ b/apps/dashboard/src/components/data-table/status-report-updates/data-table.tsx
@@ -83,7 +83,9 @@ export function DataTable({
               <Tooltip>
                 <FormSheetStatusReportUpdate
                   defaultValues={{
-                    status: getNextStatus(updates[updates.length - 1].status),
+                    status: getNextStatus(
+                      updates[updates.length - 1]?.status ?? "investigating",
+                    ),
                   }}
                   onSubmit={async (values) => {
                     await createStatusReportUpdateMutation.mutateAsync({

--- a/apps/dashboard/src/components/data-table/status-reports/columns.tsx
+++ b/apps/dashboard/src/components/data-table/status-reports/columns.tsx
@@ -127,7 +127,8 @@ export const columns: ColumnDef<StatusReport>[] = [
   {
     id: "startedAt",
     accessorFn: (row) =>
-      row.updates.sort((a, b) => a.date.getTime() - b.date.getTime())[0]?.date,
+      row.updates.sort((a, b) => a.date.getTime() - b.date.getTime())[0]
+        ?.date ?? row.createdAt,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Started At" />
     ),

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/events/(list)/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/events/(list)/page.tsx
@@ -63,11 +63,12 @@ export default function Page() {
               const firstUpdate = updates[updates.length - 1];
               const lastUpdate = updates[0];
               // NOTE: updates are sorted descending by date
-              const startedAt = firstUpdate.date;
+              const startedAt =
+                firstUpdate?.date ?? report.createdAt ?? new Date();
               // HACKY: LEGACY: only resolved via report and not via report update
               const isReportResolvedOnly =
                 report.status === "resolved" &&
-                lastUpdate.status !== "resolved";
+                lastUpdate?.status !== "resolved";
               return (
                 <StatusEvent key={report.id}>
                   <StatusEventAside>

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/events/(view)/report/[id]/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/events/(view)/report/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function ReportPage() {
 
   // HACKY: LEGACY: only resolved via report and not via report update
   const isReportResolvedOnly =
-    report.status === "resolved" && lastUpdate.status !== "resolved";
+    report.status === "resolved" && lastUpdate?.status !== "resolved";
 
   return (
     <div className="flex flex-col gap-4">
@@ -54,7 +54,9 @@ export default function ReportPage() {
       </div>
       <StatusEvent>
         <StatusEventAside>
-          <StatusEventDate date={firstUpdate.date} />
+          <StatusEventDate
+            date={firstUpdate?.date ?? report.createdAt ?? new Date()}
+          />
         </StatusEventAside>
         <StatusEventContent hoverable={false}>
           <StatusEventTitle className="inline-flex gap-1">

--- a/apps/status-page/src/components/status-page/status-feed.tsx
+++ b/apps/status-page/src/components/status-page/status-feed.tsx
@@ -26,6 +26,7 @@ import {
 type StatusReport = {
   id: number;
   title: string;
+  createdAt?: Date | null;
   affected: string[];
   updates: {
     date: Date;
@@ -68,7 +69,10 @@ export function StatusFeed({
       title: report.title,
       type: "report" as const,
       // FIXME: we have a flicker here when the report is updated
-      startDate: report.updates[report.updates.length - 1]?.date || new Date(),
+      startDate:
+        report.updates[report.updates.length - 1]?.date ??
+        report.createdAt ??
+        new Date(),
       data: report,
     })),
     ...maintenances.map((maintenance) => ({


### PR DESCRIPTION
## Summary
- Dashboard and status page crash when a status report exists but all its updates have been deleted
- Added null-safe access (`?.`) for update array elements across 5 files
- Falls back to `report.createdAt` for date display when no updates exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)