### PR TITLE
refactor: Use `ghcr.io` by default for images in docker compose

### DIFF
--- a/docker-compose-lightweight.yaml
+++ b/docker-compose-lightweight.yaml
@@ -51,13 +51,12 @@ services:
                 condition: service_healthy
         restart: "no"
 
-
     dashboard:
         container_name: openstatus-dashboard
         build:
             context: .
             dockerfile: apps/dashboard/Dockerfile
-        image: openstatus/dashboard:latest
+        image: ghcr.io/openstatushq/openstatus-dashboard:latest
         networks:
             - openstatus
         ports:
@@ -87,7 +86,7 @@ services:
         build:
             context: .
             dockerfile: apps/status-page/Dockerfile
-        image: openstatus/status-page:latest
+        image: ghcr.io/openstatushq/openstatus-status-page:latest
         networks:
             - openstatus
         ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
         build:
             context: .
             dockerfile: apps/workflows/Dockerfile
-        image: openstatus/workflows:latest
+        image: ghcr.io/openstatushq/openstatus-workflows:latest
         networks:
             - openstatus
         ports:
@@ -87,7 +87,7 @@ services:
         build:
             context: .
             dockerfile: apps/server/Dockerfile
-        image: openstatus/server:latest
+        image: ghcr.io/openstatushq/openstatus-server:latest
         networks:
             - openstatus
         ports:
@@ -115,7 +115,7 @@ services:
         build:
             context: apps/private-location
             dockerfile: Dockerfile
-        image: openstatus/private-location:latest
+        image: ghcr.io/openstatushq/openstatus-private-location:latest
         networks:
             - openstatus
         ports:
@@ -150,7 +150,7 @@ services:
         build:
             context: .
             dockerfile: apps/dashboard/Dockerfile
-        image: openstatus/dashboard:latest
+        image: ghcr.io/openstatushq/openstatus-dashboard:latest
         networks:
             - openstatus
         ports:
@@ -182,7 +182,7 @@ services:
         build:
             context: .
             dockerfile: apps/status-page/Dockerfile
-        image: openstatus/status-page:latest
+        image: ghcr.io/openstatushq/openstatus-status-page:latest
         networks:
             - openstatus
         ports:


### PR DESCRIPTION
## Summary 

This is so that if a user wants to deploy openstatus on their server but doesn't want to build the images, it uses the docker compose images by default and gets a fully working deployment without too much setup.

I've seen that there is a dedicated compose file for that, so maybe this is the expected usage ?   