### PR TITLE
docs: add learn more link to locale form and mark translations as paid-only

### DIFF
--- a/apps/dashboard/src/components/forms/status-page/form-locale.tsx
+++ b/apps/dashboard/src/components/forms/status-page/form-locale.tsx
@@ -223,7 +223,11 @@ export function FormLocale({
           <FormCardFooter>
             <FormCardFooterInfo>
               When the locale switcher is enabled, visitors can choose their
-              preferred language.
+              preferred language. Learn more about{" "}
+              <Link href="https://docs.openstatus.dev/reference/status-page/#translations-i18n">
+                Translations
+              </Link>
+              .
             </FormCardFooterInfo>
             {locked ? (
               <Button type="button" asChild>

--- a/apps/docs/src/content/docs/guides/how-to-translate-status-page.mdx
+++ b/apps/docs/src/content/docs/guides/how-to-translate-status-page.mdx
@@ -5,6 +5,10 @@ description: Enable multiple languages on your status page and contribute new tr
 
 OpenStatus status pages support multiple languages. You can configure which locales are available per page and set a default language. Visitors can switch between languages using a built-in locale switcher.
 
+:::note
+Translations are available on paid plans only.
+:::
+
 ## Supported locales
 
 Currently supported languages:

--- a/apps/docs/src/content/docs/reference/status-page.mdx
+++ b/apps/docs/src/content/docs/reference/status-page.mdx
@@ -87,7 +87,7 @@ ssh [slug]@ssh.openstatus.dev
 
 ### Translations (i18n)
 
-**Type:** Per-page configuration
+**Type:** Per-page configuration (paid plans only)
 
 Enables multi-language support for your status page. You can set a default locale and optionally enable a locale switcher so visitors can choose their preferred language.
 


### PR DESCRIPTION
## Summary
- Added a "Learn more about Translations" link in the locale form footer pointing to the reference docs
- Updated docs to indicate translations are a paid-only feature (reference page + guide callout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)