### PR TITLE
fix: scope region metrics to monitor's configured regions

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/overview/client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/overview/client.tsx
@@ -27,7 +27,6 @@ import { mapRegionMetrics } from "@/data/metrics.client";
 import { periodToFromDate } from "@/data/metrics.client";
 import type { RegionMetric } from "@/data/region-metrics";
 import { useTRPC } from "@/lib/trpc/client";
-import { monitorRegions } from "@openstatus/db/src/schema/constants";
 import {
   Tabs,
   TabsContent,
@@ -69,24 +68,20 @@ export function Client() {
     enabled: !!monitor,
   } as const;
 
-  const { data: regionTimeline, isLoading } = useQuery(regionTimelineQuery);
+  const { data: regionTimeline } = useQuery(regionTimelineQuery);
 
   const regionMetrics: RegionMetric[] = React.useMemo(() => {
     return mapRegionMetrics(
       regionTimeline,
-      // NOTE: while loading, we show the selected regions with empty data,
-      // once the data is loaded, we show all the regions that we get from TB
-      isLoading
-        ? monitor?.regions ?? []
-        : [
-            ...monitorRegions,
-            ...(monitor?.privateLocations?.map((location) =>
-              location.id.toString(),
-            ) ?? []),
-          ],
+      [
+        ...(monitor?.regions ?? []),
+        ...(monitor?.privateLocations?.map((location) =>
+          location.id.toString(),
+        ) ?? []),
+      ],
       percentile,
     );
-  }, [regionTimeline, monitor, percentile, isLoading]);
+  }, [regionTimeline, monitor, percentile]);
 
   const regionColumns = useMemo(
     () => getRegionColumns(monitor?.privateLocations ?? []),


### PR DESCRIPTION
Small fix for #725 — the monitors overview page was showing all 40+ possible regions in the Regions table, even if a monitor only checks from 1 or 2.

The root cause was straightforward: after data loads, the code was passing `monitorRegions` (the full list of every possible region) to the metrics display instead of `monitor.regions` (just the ones this monitor is configured to use).

One-variable swap, plus cleanup of the now-unused import and a loading-state conditional that was no longer needed.

Closes #725