### PR TITLE
chore: add developer tooling row to compare pages

### DIFF
--- a/apps/web/src/content/pages/compare/atlassian-statuspage.mdx
+++ b/apps/web/src/content/pages/compare/atlassian-statuspage.mdx
@@ -53,6 +53,7 @@ Additionally, OpsGenie — Atlassian's incident management product often used al
 | Subscribers         | Unlimited        | 100 (scales with cost)      |
 | Custom Themes       | Included         | $399/mo plan                |
 | Team members        | Unlimited        | Restricted                  |
+| Developer tooling   | CLI, Terraform, GitHub Actions | No official   |
 | 3 status pages      | $70/mo           | $99/mo                      |
 
 The starting prices look similar, but Atlassian Statuspage's $29/month plan only includes 100 subscribers and no monitoring. To get custom styling, you need the $399/month plan. And you still need to pay for a separate monitoring tool on top of that. Openstatus includes monitoring, unlimited subscribers, and theming from $30/month.

--- a/apps/web/src/content/pages/compare/instatus.mdx
+++ b/apps/web/src/content/pages/compare/instatus.mdx
@@ -48,6 +48,7 @@ The practical difference: with Instatus, your status page and your monitoring li
 | Starter/paid            | $30/mo                                                          | $20/mo                                         |
 | What's included         | 20 monitors + 28 regions + status page + unlimited team members | 1 custom-domain status page + basic monitoring |
 | Additional status pages | $20/mo each                                                     | Included in higher plans                       |
+| Developer tooling       | CLI, Terraform, GitHub Actions                                  | No                                             |
 
 Instatus is $10/month cheaper on the base plan, but it does not include the depth of monitoring openstatus offers. If you're already paying for a separate monitoring tool alongside Instatus, openstatus replaces both at a lower combined cost.
 


### PR DESCRIPTION
## Summary
- Adds a "Developer tooling" row to the Atlassian Statuspage and Instatus pricing tables, mirroring the row already present on the Status.io compare page
- Atlassian cell uses "No official" to reflect that community Terraform providers and CLIs exist, even though Atlassian ships none directly
- Instatus cell stays "No" (verified against their help docs — no Terraform, CLI, or GitHub Actions support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)