### PR TITLE
fix: replace explicit any in Slack postToWebhook (biome-ignore)

### DIFF
--- a/packages/notifications/slack/src/index.ts
+++ b/packages/notifications/slack/src/index.ts
@@ -11,7 +11,10 @@ import {
   buildRecoveryBlocks,
 } from "./blocks";
 
-const postToWebhook = async (body: Record<string, unknown>, webhookUrl: string) => {
+const postToWebhook = async (
+  body: Record<string, unknown>,
+  webhookUrl: string,
+) => {
   if (!webhookUrl || webhookUrl.trim() === "") {
     throw new Error("Slack webhook URL is required");
   }

--- a/packages/notifications/slack/src/index.ts
+++ b/packages/notifications/slack/src/index.ts
@@ -11,8 +11,7 @@ import {
   buildRecoveryBlocks,
 } from "./blocks";
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-const postToWebhook = async (body: any, webhookUrl: string) => {
+const postToWebhook = async (body: Record<string, unknown>, webhookUrl: string) => {
   if (!webhookUrl || webhookUrl.trim() === "") {
     throw new Error("Slack webhook URL is required");
   }


### PR DESCRIPTION
## Summary

Addresses #826

Removes a `biome-ignore lint/suspicious/noExplicitAny` suppressions by replacing `any` with `Record<string, unknown>` in `packages/notifications/slack/src/index.ts`.

The `body` parameter in `postToWebhook` was typed as `any` but is only passed to `JSON.stringify()`, which accepts any type. All callers already pass plain objects (`{ attachments: [...] }`), which are compatible with `Record<string, unknown>`.

## Changes

- Removed `// biome-ignore lint/suspicious/noExplicitAny` comment
- Changed `body: any` → `body: Record<string, unknown>`

## Test plan

- [ ] Verify `biome check` no longer reports `noExplicitAny` for this file
- [ ] Verify TypeScript compilation passes