### PR TITLE
chore: move developer tooling row into feature comparison tables

### DIFF
--- a/apps/web/src/content/pages/compare/atlassian-statuspage.mdx
+++ b/apps/web/src/content/pages/compare/atlassian-statuspage.mdx
@@ -42,6 +42,7 @@ Additionally, OpsGenie — Atlassian's incident management product often used al
 | Subscriber-count billing   | Flat (unlimited) | Scales with subscribers |
 | Custom HTML/CSS            | Themes included  | $399/mo plan only       |
 | Team members               | Unlimited        | Restricted by plan      |
+| Developer tooling          | CLI, Terraform, GitHub Actions | No official |
 
 ## Pricing Comparison
 
@@ -53,7 +54,6 @@ Additionally, OpsGenie — Atlassian's incident management product often used al
 | Subscribers         | Unlimited        | 100 (scales with cost)      |
 | Custom Themes       | Included         | $399/mo plan                |
 | Team members        | Unlimited        | Restricted                  |
-| Developer tooling   | CLI, Terraform, GitHub Actions | No official   |
 | 3 status pages      | $70/mo           | $99/mo                      |
 
 The starting prices look similar, but Atlassian Statuspage's $29/month plan only includes 100 subscribers and no monitoring. To get custom styling, you need the $399/month plan. And you still need to pay for a separate monitoring tool on top of that. Openstatus includes monitoring, unlimited subscribers, and theming from $30/month.

--- a/apps/web/src/content/pages/compare/instatus.mdx
+++ b/apps/web/src/content/pages/compare/instatus.mdx
@@ -35,7 +35,7 @@ The practical difference: with Instatus, your status page and your monitoring li
 | Multi-region          | 28 regions                     | ~4 regions |
 | Monitoring as code    | Yes                            | No         |
 | OpenTelemetry export  | Yes                            | No         |
-| GitHub Action         | Yes                            | No         |
+| Developer tooling     | CLI, Terraform, GitHub Actions | No         |
 | Status page           | Yes                            | Yes        |
 | Unlimited subscribers | Yes                            | Yes        |
 | Team members          | Unlimited                      | Unlimited  |
@@ -48,7 +48,6 @@ The practical difference: with Instatus, your status page and your monitoring li
 | Starter/paid            | $30/mo                                                          | $20/mo                                         |
 | What's included         | 20 monitors + 28 regions + status page + unlimited team members | 1 custom-domain status page + basic monitoring |
 | Additional status pages | $20/mo each                                                     | Included in higher plans                       |
-| Developer tooling       | CLI, Terraform, GitHub Actions                                  | No                                             |
 
 Instatus is $10/month cheaper on the base plan, but it does not include the depth of monitoring openstatus offers. If you're already paying for a separate monitoring tool alongside Instatus, openstatus replaces both at a lower combined cost.
 

--- a/apps/web/src/content/pages/compare/statusio.mdx
+++ b/apps/web/src/content/pages/compare/statusio.mdx
@@ -35,7 +35,7 @@ For teams that want monitoring and status pages without stitching together two p
 | Multi-region               | 28 regions | Not applicable |
 | Monitoring as code         | Yes        | No             |
 | OpenTelemetry export       | Yes        | No             |
-| GitHub Action              | Yes        | No             |
+| Developer tooling          | CLI, Terraform, GitHub Actions | No |
 | Status page included       | Yes        | Yes            |
 | Private status pages       | Yes        | Yes            |
 | Team members               | Unlimited  | Restricted     |
@@ -48,7 +48,6 @@ For teams that want monitoring and status pages without stitching together two p
 | What's included     | Monitoring + status page + alerts | Status page only       |
 | Monitoring          | Built-in (28 regions)             | Requires separate tool |
 | Team members        | Unlimited on paid plans           | Limited by plan        |
-| Developer tooling   | CLI, Terraform, GitHub Actions    | No                     |
 | Self-hosting option | Yes (free)                        | No                     |
 
 Status.io costs nearly 3x more than openstatus's Starter plan — and doesn't include any monitoring. When you factor in the cost of a separate monitoring tool, the total cost difference grows even larger.


### PR DESCRIPTION
## Summary
- Surfaces the CLI / Terraform / GitHub Actions differentiator as a product capability instead of a pricing line item on the atlassian-statuspage, instatus, and statusio compare pages
- Consolidates the narrower \`GitHub Action\` row into the broader \`Developer tooling\` row on instatus and statusio to avoid duplicate claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)