### PR TITLE
fix(import): mark skipped resources as partial progress

### DIFF
--- a/packages/api/src/service/import.test.ts
+++ b/packages/api/src/service/import.test.ts
@@ -362,6 +362,24 @@ describe("addLimitWarnings", () => {
   });
 });
 
+describe("summary status semantics", () => {
+  test("marks a phase partial when some resources are skipped", () => {
+    const resources = [
+      { sourceId: "1", name: "A", status: "created" as const },
+      { sourceId: "2", name: "B", status: "skipped" as const },
+    ];
+
+    const status = resources.every((r) => r.status === "failed")
+      ? "failed"
+      : resources.some((r) => r.status === "failed") ||
+          resources.some((r) => r.status === "skipped")
+        ? "partial"
+        : "completed";
+
+    expect(status).toBe("partial");
+  });
+});
+
 describe("clampPeriodicity", () => {
   const freePlan = allPlans.free.limits.periodicity as string[];
   const starterPlan = allPlans.starter.limits.periodicity as string[];

--- a/packages/api/src/service/import.test.ts
+++ b/packages/api/src/service/import.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { allPlans } from "@openstatus/db/src/schema/plan/config";
 import type { Limits } from "@openstatus/db/src/schema/plan/schema";
 import type { ImportSummary } from "@openstatus/importers";
-import { addLimitWarnings, clampPeriodicity } from "./import";
+import {
+  addLimitWarnings,
+  clampPeriodicity,
+  computePhaseStatus,
+} from "./import";
 
 function makeSummary(overrides?: Partial<ImportSummary>): ImportSummary {
   return {
@@ -362,21 +366,54 @@ describe("addLimitWarnings", () => {
   });
 });
 
-describe("summary status semantics", () => {
-  test("marks a phase partial when some resources are skipped", () => {
-    const resources = [
-      { sourceId: "1", name: "A", status: "created" as const },
-      { sourceId: "2", name: "B", status: "skipped" as const },
-    ];
+describe("computePhaseStatus", () => {
+  test("returns completed for empty resources", () => {
+    expect(computePhaseStatus([])).toBe("completed");
+  });
 
-    const status = resources.every((r) => r.status === "failed")
-      ? "failed"
-      : resources.some((r) => r.status === "failed") ||
-          resources.some((r) => r.status === "skipped")
-        ? "partial"
-        : "completed";
+  test("returns completed when all resources are created", () => {
+    expect(
+      computePhaseStatus([
+        { sourceId: "1", name: "A", status: "created" },
+        { sourceId: "2", name: "B", status: "created" },
+      ]),
+    ).toBe("completed");
+  });
 
-    expect(status).toBe("partial");
+  test("returns completed when all resources are skipped", () => {
+    expect(
+      computePhaseStatus([
+        { sourceId: "1", name: "A", status: "skipped" },
+        { sourceId: "2", name: "B", status: "skipped" },
+      ]),
+    ).toBe("completed");
+  });
+
+  test("returns partial when some resources are skipped", () => {
+    expect(
+      computePhaseStatus([
+        { sourceId: "1", name: "A", status: "created" },
+        { sourceId: "2", name: "B", status: "skipped" },
+      ]),
+    ).toBe("partial");
+  });
+
+  test("returns partial when some resources fail", () => {
+    expect(
+      computePhaseStatus([
+        { sourceId: "1", name: "A", status: "created" },
+        { sourceId: "2", name: "B", status: "failed" },
+      ]),
+    ).toBe("partial");
+  });
+
+  test("returns failed when all resources fail", () => {
+    expect(
+      computePhaseStatus([
+        { sourceId: "1", name: "A", status: "failed" },
+        { sourceId: "2", name: "B", status: "failed" },
+      ]),
+    ).toBe("failed");
   });
 });
 

--- a/packages/api/src/service/import.ts
+++ b/packages/api/src/service/import.ts
@@ -423,7 +423,8 @@ function computePhaseStatus(
   const allFailed = resources.every((r) => r.status === "failed");
   if (allFailed) return "failed";
   const hasFailed = resources.some((r) => r.status === "failed");
-  if (hasFailed) return "partial";
+  const hasSkipped = resources.some((r) => r.status === "skipped");
+  if (hasFailed || hasSkipped) return "partial";
   return "completed";
 }
 

--- a/packages/api/src/service/import.ts
+++ b/packages/api/src/service/import.ts
@@ -416,15 +416,20 @@ export function clampPeriodicity(requested: string, allowed: string[]): string {
 // Phase writers
 // ---------------------------------------------------------------------------
 
-function computePhaseStatus(
+export function computePhaseStatus(
   resources: ResourceResult[],
 ): PhaseResult["status"] {
   if (resources.length === 0) return "completed";
+
   const allFailed = resources.every((r) => r.status === "failed");
   if (allFailed) return "failed";
+
   const hasFailed = resources.some((r) => r.status === "failed");
   const hasSkipped = resources.some((r) => r.status === "skipped");
-  if (hasFailed || hasSkipped) return "partial";
+  const allSkipped = resources.every((r) => r.status === "skipped");
+
+  if (hasFailed || (hasSkipped && !allSkipped)) return "partial";
+
   return "completed";
 }
 
@@ -477,7 +482,7 @@ async function writePagePhase(
 
     resource.openstatusId = existingPageId;
     resource.status = "skipped";
-    phase.status = "completed";
+    phase.status = computePhaseStatus(phase.resources);
     return existingPageId;
   }
 
@@ -491,7 +496,7 @@ async function writePagePhase(
   if (existingBySlug) {
     resource.openstatusId = existingBySlug.id;
     resource.status = "skipped";
-    phase.status = "completed";
+    phase.status = computePhaseStatus(phase.resources);
     return existingBySlug.id;
   }
 
@@ -515,7 +520,7 @@ async function writePagePhase(
 
   resource.openstatusId = inserted.id;
   resource.status = "created";
-  phase.status = "completed";
+  phase.status = computePhaseStatus(phase.resources);
   return inserted.id;
 }
 


### PR DESCRIPTION
## Summary

Picks up an import result reporting issue where a phase can be marked as `completed` even when some resources were skipped.

- Ensures phases with a mix of created and skipped resources are reported as `partial`
- Keeps fully successful phases reported as `completed`
- Adds regression coverage for the skipped-resource case

## Fixes applied

- Updated `computePhaseStatus()` in `packages/api/src/service/import.ts`
- Treat skipped resources as partial progress instead of full completion
- Added test coverage in `packages/api/src/service/import.test.ts`

## Why

A phase with skipped resources is not fully complete. Reporting it as `partial` makes the import summary more accurate and easier to trust.

## Test plan

- [x] `pnpm exec biome check packages/api/src/service/import.ts packages/api/src/service/import.test.ts`
- [x] `pnpm exec bun test packages/api/src/service/import.test.ts`