### PR TITLE
fix: force-dynamic sitemap to unblock docker build

### DIFF
--- a/apps/status-page/src/app/sitemap.ts
+++ b/apps/status-page/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import { db, eq } from "@openstatus/db";
 import { page } from "@openstatus/db/src/schema";
 import type { MetadataRoute } from "next";
 
+export const dynamic = "force-dynamic";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const pages = await db
     .select({


### PR DESCRIPTION
## Summary
- Next.js was prerendering `/sitemap.xml` at build time, which queries the `page` table. In Docker builds the `libsql` hostname only resolves at runtime, so the prerender errored with `getaddrinfo ENOTFOUND libsql` and failed the whole image build.
- Adding `export const dynamic = "force-dynamic"` to `apps/status-page/src/app/sitemap.ts` defers the query to request time.

## Test plan
- [ ] Docker build for `apps/status-page` completes successfully
- [ ] `/sitemap.xml` returns the expected entries at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)