### PR TITLE
fix(subscribers): query active subscriber for subscribe/unsubscribe

### DIFF
--- a/apps/server/src/routes/rpc/services/status-page/__tests__/status-page.test.ts
+++ b/apps/server/src/routes/rpc/services/status-page/__tests__/status-page.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { db, eq, sql } from "@openstatus/db";
+import { and, db, eq, isNull, sql } from "@openstatus/db";
 import {
   monitor,
   page,
@@ -1920,6 +1920,78 @@ describe("StatusPageService.UnsubscribeFromPage", () => {
     );
 
     expect(res.status).toBe(400);
+  });
+
+  test("unsubscribes the ACTIVE subscriber when a prior unsubscribed row exists", async () => {
+    const email = `${TEST_PREFIX}-unsub-active@example.com`;
+
+    // Seed an old unsubscribed row (simulates a user who subscribed, verified,
+    // and unsubscribed in the past).
+    const oldRow = await db
+      .insert(pageSubscriber)
+      .values({
+        pageId: testPageId,
+        email,
+        channelType: "email",
+        token: crypto.randomUUID(),
+        acceptedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30),
+        unsubscribedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
+      })
+      .returning()
+      .get();
+
+    // Create a new ACTIVE subscription for the same email.
+    const activeRow = await db
+      .insert(pageSubscriber)
+      .values({
+        pageId: testPageId,
+        email,
+        channelType: "email",
+        token: crypto.randomUUID(),
+        acceptedAt: new Date(),
+      })
+      .returning()
+      .get();
+
+    // Unsubscribe by email — must target the ACTIVE row.
+    const res = await connectRequest(
+      "UnsubscribeFromPage",
+      {
+        pageId: String(testPageId),
+        email,
+      },
+      { "x-openstatus-key": "1" },
+    );
+    expect(res.status).toBe(200);
+
+    const refreshedActive = await db
+      .select()
+      .from(pageSubscriber)
+      .where(eq(pageSubscriber.id, activeRow.id))
+      .get();
+    expect(refreshedActive?.unsubscribedAt).not.toBeNull();
+
+    // No remaining active rows for this email on this page.
+    const stillActive = await db
+      .select()
+      .from(pageSubscriber)
+      .where(
+        and(
+          eq(pageSubscriber.pageId, testPageId),
+          eq(pageSubscriber.email, email),
+          isNull(pageSubscriber.unsubscribedAt),
+        ),
+      )
+      .all();
+    expect(stillActive.length).toBe(0);
+
+    // Cleanup
+    await db
+      .delete(pageSubscriber)
+      .where(eq(pageSubscriber.id, oldRow.id));
+    await db
+      .delete(pageSubscriber)
+      .where(eq(pageSubscriber.id, activeRow.id));
   });
 });
 

--- a/apps/server/src/routes/rpc/services/status-page/__tests__/status-page.test.ts
+++ b/apps/server/src/routes/rpc/services/status-page/__tests__/status-page.test.ts
@@ -1986,12 +1986,8 @@ describe("StatusPageService.UnsubscribeFromPage", () => {
     expect(stillActive.length).toBe(0);
 
     // Cleanup
-    await db
-      .delete(pageSubscriber)
-      .where(eq(pageSubscriber.id, oldRow.id));
-    await db
-      .delete(pageSubscriber)
-      .where(eq(pageSubscriber.id, activeRow.id));
+    await db.delete(pageSubscriber).where(eq(pageSubscriber.id, oldRow.id));
+    await db.delete(pageSubscriber).where(eq(pageSubscriber.id, activeRow.id));
   });
 });
 

--- a/apps/server/src/routes/rpc/services/status-page/index.ts
+++ b/apps/server/src/routes/rpc/services/status-page/index.ts
@@ -973,7 +973,9 @@ export const statusPageServiceImpl: ServiceImpl<typeof StatusPageService> = {
         .where(
           and(
             eq(pageSubscriber.pageId, pageData.id),
-            eq(pageSubscriber.email, req.identifier.value),
+            eq(pageSubscriber.email, req.identifier.value.toLowerCase()),
+            eq(pageSubscriber.channelType, "email"),
+            isNull(pageSubscriber.unsubscribedAt),
           ),
         )
         .get();

--- a/apps/server/src/routes/rpc/services/status-page/index.ts
+++ b/apps/server/src/routes/rpc/services/status-page/index.ts
@@ -9,6 +9,7 @@ import {
   inArray,
   isNull,
   lte,
+  sql,
 } from "@openstatus/db";
 import {
   maintenance,
@@ -973,7 +974,7 @@ export const statusPageServiceImpl: ServiceImpl<typeof StatusPageService> = {
         .where(
           and(
             eq(pageSubscriber.pageId, pageData.id),
-            eq(pageSubscriber.email, req.identifier.value.toLowerCase()),
+            sql`LOWER(${pageSubscriber.email}) = ${req.identifier.value.toLowerCase()}`,
             eq(pageSubscriber.channelType, "email"),
             isNull(pageSubscriber.unsubscribedAt),
           ),

--- a/apps/server/src/routes/v1/pageSubscribers/post.test.ts
+++ b/apps/server/src/routes/v1/pageSubscribers/post.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 
 import { app } from "@/index";
-import { db, eq } from "@openstatus/db";
+import { and, db, eq, isNull } from "@openstatus/db";
 import { pageSubscriber } from "@openstatus/db/src/schema";
 import { PageSubscriberSchema } from "./schema";
 
@@ -50,4 +50,137 @@ test("no auth key should return 401", async () => {
   });
 
   expect(res.status).toBe(401);
+});
+
+test("re-subscribing after unsubscribe succeeds and does not leave duplicate active rows", async () => {
+  const email = "resubscribe-after-unsubscribe@openstatus.dev";
+
+  // Clean any pre-existing rows from a previous run
+  await db
+    .delete(pageSubscriber)
+    .where(
+      and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)),
+    );
+
+  // 1. Subscribe
+  const firstRes = await app.request("/v1/page_subscriber/1/update", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+  expect(firstRes.status).toBe(200);
+  const first = PageSubscriberSchema.parse(await firstRes.json());
+
+  // 2. Mark the subscriber as accepted + unsubscribed (simulates the
+  // user verifying, then later unsubscribing via one-click).
+  await db
+    .update(pageSubscriber)
+    .set({ acceptedAt: new Date(), unsubscribedAt: new Date() })
+    .where(eq(pageSubscriber.id, first.id));
+
+  // 3. Subscribe the same email again — should succeed.
+  const secondRes = await app.request("/v1/page_subscriber/1/update", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+  expect(secondRes.status).toBe(200);
+
+  // There must be exactly one ACTIVE row (unsubscribedAt IS NULL) for the email.
+  const active = await db
+    .select()
+    .from(pageSubscriber)
+    .where(
+      and(
+        eq(pageSubscriber.email, email),
+        eq(pageSubscriber.pageId, 1),
+        isNull(pageSubscriber.unsubscribedAt),
+      ),
+    )
+    .all();
+  expect(active.length).toBe(1);
+
+  // Cleanup
+  await db
+    .delete(pageSubscriber)
+    .where(
+      and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)),
+    );
+});
+
+test("subscribing when an active subscription already exists returns 409", async () => {
+  const email = "already-active@openstatus.dev";
+
+  await db
+    .delete(pageSubscriber)
+    .where(
+      and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)),
+    );
+
+  const firstRes = await app.request("/v1/page_subscriber/1/update", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+  expect(firstRes.status).toBe(200);
+  const first = PageSubscriberSchema.parse(await firstRes.json());
+
+  // Second subscribe with an already-active (but pending) entry should conflict.
+  const secondRes = await app.request("/v1/page_subscriber/1/update", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+  expect(secondRes.status).toBe(409);
+
+  await db.delete(pageSubscriber).where(eq(pageSubscriber.id, first.id));
+});
+
+test("subscribing is case-insensitive on email", async () => {
+  const email = "Case.Sensitive@OpenStatus.dev";
+
+  await db
+    .delete(pageSubscriber)
+    .where(
+      and(
+        eq(pageSubscriber.email, email.toLowerCase()),
+        eq(pageSubscriber.pageId, 1),
+      ),
+    );
+
+  const firstRes = await app.request("/v1/page_subscriber/1/update", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+  expect(firstRes.status).toBe(200);
+  const first = PageSubscriberSchema.parse(await firstRes.json());
+
+  // Same email in different case — should conflict.
+  const secondRes = await app.request("/v1/page_subscriber/1/update", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email: email.toUpperCase() }),
+  });
+  expect(secondRes.status).toBe(409);
+
+  await db.delete(pageSubscriber).where(eq(pageSubscriber.id, first.id));
 });

--- a/apps/server/src/routes/v1/pageSubscribers/post.test.ts
+++ b/apps/server/src/routes/v1/pageSubscribers/post.test.ts
@@ -58,9 +58,7 @@ test("re-subscribing after unsubscribe succeeds and does not leave duplicate act
   // Clean any pre-existing rows from a previous run
   await db
     .delete(pageSubscriber)
-    .where(
-      and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)),
-    );
+    .where(and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)));
 
   // 1. Subscribe
   const firstRes = await app.request("/v1/page_subscriber/1/update", {
@@ -109,9 +107,7 @@ test("re-subscribing after unsubscribe succeeds and does not leave duplicate act
   // Cleanup
   await db
     .delete(pageSubscriber)
-    .where(
-      and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)),
-    );
+    .where(and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)));
 });
 
 test("subscribing when an active subscription already exists returns 409", async () => {
@@ -119,9 +115,7 @@ test("subscribing when an active subscription already exists returns 409", async
 
   await db
     .delete(pageSubscriber)
-    .where(
-      and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)),
-    );
+    .where(and(eq(pageSubscriber.email, email), eq(pageSubscriber.pageId, 1)));
 
   const firstRes = await app.request("/v1/page_subscriber/1/update", {
     method: "POST",

--- a/apps/server/src/routes/v1/pageSubscribers/post.ts
+++ b/apps/server/src/routes/v1/pageSubscribers/post.ts
@@ -3,7 +3,7 @@ import { createRoute } from "@hono/zod-openapi";
 import { OpenStatusApiError, openApiErrorResponses } from "@/libs/errors";
 import { trackMiddleware } from "@/libs/middlewares";
 import { Events } from "@openstatus/analytics";
-import { and, eq, isNotNull } from "@openstatus/db";
+import { and, eq, isNull, sql } from "@openstatus/db";
 import { db } from "@openstatus/db/src/db";
 import { page, pageSubscriber } from "@openstatus/db/src/schema";
 import { SubscribeEmail, sendEmail } from "@openstatus/emails";
@@ -68,15 +68,17 @@ export function registerPostPageSubscriber(api: typeof pageSubscribersApi) {
       });
     }
 
+    const normalizedEmail = input.email.toLowerCase();
+
     const alreadySubscribed = await db
       .select()
       .from(pageSubscriber)
       .where(
         and(
-          eq(pageSubscriber.email, input.email),
+          sql`LOWER(${pageSubscriber.email}) = ${normalizedEmail}`,
           eq(pageSubscriber.pageId, Number(id)),
-          isNotNull(pageSubscriber.acceptedAt),
-          isNotNull(pageSubscriber.unsubscribedAt),
+          eq(pageSubscriber.channelType, "email"),
+          isNull(pageSubscriber.unsubscribedAt),
         ),
       )
       .get();
@@ -95,7 +97,7 @@ export function registerPostPageSubscriber(api: typeof pageSubscribersApi) {
       .insert(pageSubscriber)
       .values({
         pageId: _page.id,
-        email: input.email,
+        email: normalizedEmail,
         token,
         expiresAt,
       })
@@ -110,7 +112,7 @@ export function registerPostPageSubscriber(api: typeof pageSubscribersApi) {
         page: _page.title,
       }),
       from: "OpenStatus <notification@notifications.openstatus.dev>",
-      to: [input.email],
+      to: [normalizedEmail],
       subject: "Verify your subscription",
     });
 


### PR DESCRIPTION
When an email had both an active and an unsubscribed row for the same
page (which can happen legitimately after a resubscribe), two bugs
broke the flow:

- v1 POST /page_subscriber/{id}/update only looked for rows with
  unsubscribedAt IS NOT NULL, so it never detected an active duplicate
  and inserted a second active row. Case differences in the email
  address could also bypass the check and then fail the partial unique
  index.
- RPC UnsubscribeFromPage (by email) fetched the first row matching
  (pageId, email) and updated it, which could target an already
  unsubscribed row and leave the active one untouched, making users
  unable to unsubscribe.

Both queries now filter by channelType = 'email' and
unsubscribedAt IS NULL, matching the partial unique index, and compare
emails case-insensitively. Emails are also stored lowercased on insert.

Adds regression tests for:
- resubscribe after unsubscribe produces exactly one active row
- subscribing while an active row exists returns 409
- case-insensitive duplicate detection
- unsubscribe targets the active row when a prior unsubscribed row
  exists for the same email

https://claude.ai/code/session_0168c5f3tYmM3U4fwspwkTri