### PR TITLE
fix(server): bind services + importers packages in dofigen

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -41,6 +41,8 @@ RUN \
     --mount=type=bind,target=packages/assertions/package.json,source=packages/assertions/package.json \
     --mount=type=bind,target=packages/theme-store/package.json,source=packages/theme-store/package.json \
     --mount=type=bind,target=packages/locales/package.json,source=packages/locales/package.json \
+    --mount=type=bind,target=packages/services/package.json,source=packages/services/package.json \
+    --mount=type=bind,target=packages/importers/package.json,source=packages/importers/package.json \
     --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
     bun install --production --frozen-lockfile --verbose
 
@@ -62,11 +64,11 @@ COPY \
 RUN bun build --compile --sourcemap src/index.ts --outfile=app
 
 # runtime
-FROM debian@sha256:4333240150a6924f878e05ec2c998aec95238010e0e4d2fec6161c90128c4652 AS runtime
+FROM debian@sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f AS runtime
 LABEL \
     io.dofigen.version="2.7.0" \
     org.opencontainers.image.authors="OpenStatus Team" \
-    org.opencontainers.image.base.digest="sha256:4333240150a6924f878e05ec2c998aec95238010e0e4d2fec6161c90128c4652" \
+    org.opencontainers.image.base.digest="sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f" \
     org.opencontainers.image.base.name="docker.io/debian:bullseye-slim" \
     org.opencontainers.image.description="REST API server with Hono framework for OpenStatus" \
     org.opencontainers.image.source="https://github.com/openstatusHQ/openstatus" \

--- a/apps/server/dofigen.lock
+++ b/apps/server/dofigen.lock
@@ -15,8 +15,8 @@ effective: |
         path: oven/bun
         digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       label:
-        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
         org.opencontainers.image.stage: install
+        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
         org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       workdir: /app/
       run:
@@ -86,14 +86,18 @@ effective: |
         source: packages/theme-store/package.json
       - target: packages/locales/package.json
         source: packages/locales/package.json
+      - target: packages/services/package.json
+        source: packages/services/package.json
+      - target: packages/importers/package.json
+        source: packages/importers/package.json
     build:
       fromImage:
         path: oven/bun
         digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
       label:
-        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
         org.opencontainers.image.stage: build
         org.opencontainers.image.base.digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+        org.opencontainers.image.base.name: docker.io/oven/bun:1.3.6
       workdir: /app/apps/server
       env:
         NODE_ENV: production
@@ -109,16 +113,16 @@ effective: |
       - bun build --compile --sourcemap src/index.ts --outfile=app
   fromImage:
     path: debian
-    digest: sha256:4333240150a6924f878e05ec2c998aec95238010e0e4d2fec6161c90128c4652
+    digest: sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f
   label:
-    org.opencontainers.image.authors: OpenStatus Team
-    org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
-    org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
     io.dofigen.version: 2.7.0
-    org.opencontainers.image.description: REST API server with Hono framework for OpenStatus
-    org.opencontainers.image.base.digest: sha256:4333240150a6924f878e05ec2c998aec95238010e0e4d2fec6161c90128c4652
-    org.opencontainers.image.vendor: OpenStatus
+    org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
+    org.opencontainers.image.base.digest: sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f
+    org.opencontainers.image.base.name: docker.io/debian:bullseye-slim
     org.opencontainers.image.title: OpenStatus Server
+    org.opencontainers.image.description: REST API server with Hono framework for OpenStatus
+    org.opencontainers.image.vendor: OpenStatus
+    org.opencontainers.image.authors: OpenStatus Team
   user:
     user: '1000'
     group: '1000'
@@ -145,17 +149,17 @@ effective: |
     retries: 3
 images:
   docker.io:
-    library:
-      debian:
-        bullseye-slim:
-          digest: sha256:4333240150a6924f878e05ec2c998aec95238010e0e4d2fec6161c90128c4652
     oven:
       bun:
         1.3.6:
           digest: sha256:f20d9cf365ab35529384f1717687c739c92e6f39157a35a95ef06f4049a10e4a
+    library:
+      debian:
+        bullseye-slim:
+          digest: sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f
 resources:
   dofigen.yml:
-    hash: 733fba04030ad149a064b72cece51b1e515655e1b723263c61c881e301e388da
+    hash: 0b4934ac4087020f7814554afb8423bb611e051830041107fdecd32afaa8dc28
     content: |
       # Files to exclude from Docker context
       ignore:
@@ -208,6 +212,8 @@ resources:
             - packages/assertions/package.json
             - packages/theme-store/package.json
             - packages/locales/package.json
+            - packages/services/package.json
+            - packages/importers/package.json
           run: bun install --production --frozen-lockfile --verbose
           cache:
             - /root/.bun/install/cache

--- a/apps/server/dofigen.yml
+++ b/apps/server/dofigen.yml
@@ -49,6 +49,8 @@ builders:
       - packages/assertions/package.json
       - packages/theme-store/package.json
       - packages/locales/package.json
+      - packages/services/package.json
+      - packages/importers/package.json
     run: bun install --production --frozen-lockfile --verbose
     cache:
       - /root/.bun/install/cache


### PR DESCRIPTION
## Summary

Stacked on #2101. Adds `packages/services/package.json` and `packages/importers/package.json` to the `install` stage bind list in `apps/server/dofigen.yml` so `bun install --frozen-lockfile` can resolve the workspace dep graph inside the Docker build.

Without this fix:
- The moment main receives \`@openstatus/services\` as a dep of \`apps/server\` (via #2101, the status-report migration), the Docker install stage fails with a missing workspace package.
- \`@openstatus/importers\` becomes a transitive dep of \`@openstatus/services\` later in the stack (via #2111, the import-domain migration), so binding it proactively here avoids a second dofigen touch-up PR later.

\`packages/importers\` already exists in the repo and isn't used by \`apps/server\` directly at this commit, so binding it early is a no-op for bun until services starts pulling it in downstream.

## Why this branches from #2101 and not from main

At the time of writing, none of the services-migration stack (#2100–#2112) has merged yet. Main has no \`packages/services/\` directory, so a bind entry for it would point at nothing. The fix has to ride with the PR that first requires it — that's #2101.

## Why not amend #2101 directly

Force-pushing #2101 would require rebasing all ten downstream PRs. This sidecar PR stacks on top of #2101 instead: it inherits the services scaffolding it needs, adds the dofigen entries, and merges right after #2101 lands on main without touching any other stacked PR.

## Files

- \`apps/server/dofigen.yml\` — adds two bind entries.
- \`apps/server/Dockerfile\` — regenerated by \`dofigen update\`.
- \`apps/server/dofigen.lock\` — regenerated by \`dofigen update\`.

## Out of scope

Other apps (\`apps/dashboard\`, \`apps/status-page\`, \`apps/workflows\`, \`apps/private-location\`) have their own \`dofigen.yml\` files and likely need similar updates (\`packages/api\` now transitively depends on \`@openstatus/services\`). Those are separate fixes per your scope.

## Test plan
- [ ] Merge order: #2101 → this PR → #2103 → … → #2112.
- [ ] Confirm \`dofigen gen\` output matches the committed Dockerfile (i.e. no drift from yml).
- [ ] Optional: build apps/server image locally against this branch to confirm install stage succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)