### PR TITLE
docs: add architecture analysis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
       <a href="https://github.com/openstatushq/openstatus/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
       <a href="https://github.com/openstatushq/openstatus/stargazers"><img src="https://img.shields.io/github/stars/openstatushq/openstatus?style=social" alt="GitHub stars"></a>
       <a href="https://www.openstatus.dev/discord"><img src="https://img.shields.io/discord/1129008226264940625?color=7289da&logo=discord&logoColor=white" alt="Discord"></a>
+      <a href="https://codesea.app/repo/openstatushq/openstatus"><img src="https://codesea.app/badge/openstatushq/openstatus.svg" alt="Architecture Analysis"></a>
 </p>
 
 ## About openstatus


### PR DESCRIPTION
Hi team — I ran an architecture analysis of openstatus and wanted to share the result, plus offer a README badge if it's useful.

**Analysis page:** https://codesea.app/repo/openstatushq/openstatus

CodeSea maps how codebases work as systems — data flow stages, data models with concrete shapes, runtime behavior (feedback loops, control points), and hidden assumptions the code relies on but doesn't validate. The goal is making the architecture legible to new contributors without them having to read every file first.

**The badge:**

![badge](https://codesea.app/badge/openstatushq/openstatus.svg)

I matched your existing HTML badge format and added it at the end of your badge row. It's a static SVG from our CDN — no JS, no tracking, no runtime JavaScript.

If anything in the analysis is wrong or missing, I'd genuinely want to know — we're working on getting system analysis right, and openstatus is a clean example to learn from.

Happy to close this PR if the badge isn't a fit.