### PR TITLE
refactor(services): parse rows with select schemas instead of type assertions

### DIFF
--- a/packages/services/src/api-key/list.ts
+++ b/packages/services/src/api-key/list.ts
@@ -1,9 +1,18 @@
 import { db as defaultDb, eq, inArray } from "@openstatus/db";
-import { apiKey, user } from "@openstatus/db/src/schema";
+import { apiKey, selectApiKeySchema, user } from "@openstatus/db/src/schema";
 
 import type { ServiceContext } from "../context";
 import type { ApiKey } from "../types";
 import type { ListApiKeysInput } from "./schemas";
+
+/**
+ * Public projection schema — derived from `selectApiKeySchema` so column /
+ * default changes flow through. Stripping `hashedToken` here means the
+ * bcrypt hash never reaches a list response, even by accident.
+ */
+const selectPublicApiKeySchema = selectApiKeySchema.omit({
+  hashedToken: true,
+});
 
 export type ApiKeyCreator = {
   id: number;
@@ -75,7 +84,7 @@ export async function listApiKeys(args: {
   // which would crash `listApiKeys` for those workspaces.
   if (creatorIds.length === 0) {
     return keys.map((key) => ({
-      ...(key as PublicApiKey),
+      ...selectPublicApiKeySchema.parse(key),
       createdBy: undefined,
     }));
   }
@@ -93,7 +102,7 @@ export async function listApiKeys(args: {
   const creatorsById = new Map(creators.map((c) => [c.id, c]));
 
   return keys.map((key) => ({
-    ...(key as PublicApiKey),
+    ...selectPublicApiKeySchema.parse(key),
     createdBy: creatorsById.get(key.createdById),
   }));
 }

--- a/packages/services/src/api-key/verify.ts
+++ b/packages/services/src/api-key/verify.ts
@@ -1,5 +1,5 @@
 import { db as defaultDb, eq } from "@openstatus/db";
-import { apiKey } from "@openstatus/db/src/schema";
+import { apiKey, selectApiKeySchema } from "@openstatus/db/src/schema";
 import {
   shouldUpdateLastUsed as checkShouldUpdateLastUsed,
   verifyApiKeyHash,
@@ -42,7 +42,7 @@ export async function verifyApiKey(
   if (!(await verifyApiKeyHash(parsed.token, key.hashedToken))) return null;
   if (key.expiresAt && key.expiresAt < new Date()) return null;
 
-  return key as ApiKey;
+  return selectApiKeySchema.parse(key);
 }
 
 /**

--- a/packages/services/src/invitation/create.ts
+++ b/packages/services/src/invitation/create.ts
@@ -1,5 +1,9 @@
 import { and, eq, gte, isNull } from "@openstatus/db";
-import { invitation, usersToWorkspaces } from "@openstatus/db/src/schema";
+import {
+  invitation,
+  selectInvitationSchema,
+  usersToWorkspaces,
+} from "@openstatus/db/src/schema";
 
 import { emitAudit } from "../audit";
 import { type ServiceContext, withTransaction } from "../context";
@@ -92,6 +96,6 @@ export async function createInvitation(args: {
       metadata: { email: input.email },
     });
 
-    return row as Invitation;
+    return selectInvitationSchema.parse(row);
   });
 }

--- a/packages/services/src/invitation/list.ts
+++ b/packages/services/src/invitation/list.ts
@@ -32,7 +32,7 @@ export async function listInvitations(args: {
     ),
   });
 
-  return rows as Invitation[];
+  return rows.map((r) => selectInvitationSchema.parse(r));
 }
 
 export type InvitationWithWorkspace = Invitation & { workspace: Workspace };
@@ -68,5 +68,5 @@ export async function getInvitationByToken(args: {
 
   return selectInvitationSchema
     .extend({ workspace: selectWorkspaceSchema })
-    .parse(result) as InvitationWithWorkspace;
+    .parse(result);
 }

--- a/packages/services/src/maintenance/list.ts
+++ b/packages/services/src/maintenance/list.ts
@@ -13,6 +13,7 @@ import {
   maintenance,
   maintenancesToPageComponents,
   pageComponent,
+  selectPageComponentSchema,
 } from "@openstatus/db/src/schema";
 
 import type { DB, ServiceContext } from "../context";
@@ -59,8 +60,15 @@ async function enrichMaintenancesBatch(
   if (rows.length === 0) return [];
   const ids = rows.map((r) => r.id);
 
+  // Explicit column selection (not `select()`) keeps the row shape in our
+  // hands instead of relying on drizzle's auto-derived `row.<table_name>`
+  // keys, which are named after the JS variable and silently break on
+  // schema rename.
   const assocRows = await db
-    .select()
+    .select({
+      maintenanceId: maintenancesToPageComponents.maintenanceId,
+      component: pageComponent,
+    })
     .from(pageComponent)
     .innerJoin(
       maintenancesToPageComponents,
@@ -71,12 +79,10 @@ async function enrichMaintenancesBatch(
 
   const componentsByMaintenance = new Map<number, PageComponent[]>();
   for (const row of assocRows) {
-    const mId = (row.maintenance_to_page_component as { maintenanceId: number })
-      .maintenanceId;
-    const component = row.page_component as unknown as PageComponent;
-    const arr = componentsByMaintenance.get(mId);
+    const component = selectPageComponentSchema.parse(row.component);
+    const arr = componentsByMaintenance.get(row.maintenanceId);
     if (arr) arr.push(component);
-    else componentsByMaintenance.set(mId, [component]);
+    else componentsByMaintenance.set(row.maintenanceId, [component]);
   }
 
   return rows.map((r) => {

--- a/packages/services/src/monitor/list.ts
+++ b/packages/services/src/monitor/list.ts
@@ -18,7 +18,11 @@ import {
   notificationsToMonitors,
   privateLocation,
   privateLocationToMonitors,
+  selectIncidentSchema,
   selectMonitorSchema,
+  selectMonitorTagSchema,
+  selectNotificationSchema,
+  selectPrivateLocationSchema,
 } from "@openstatus/db/src/schema";
 
 import type { DB, ServiceContext } from "../context";
@@ -64,9 +68,16 @@ async function enrichMonitorsBatch(
   if (rows.length === 0) return [];
   const ids = rows.map((r) => r.id);
 
+  // Explicit column selection (not `select()`) keeps the join row shape in
+  // our hands instead of relying on drizzle's auto-derived `row.<table_name>`
+  // keys, which are named after the JS variable and silently break on
+  // schema rename.
   const [tagRows, incidentRows, notifRows, locRows] = await Promise.all([
     db
-      .select()
+      .select({
+        monitorId: monitorTagsToMonitors.monitorId,
+        tag: monitorTag,
+      })
       .from(monitorTag)
       .innerJoin(
         monitorTagsToMonitors,
@@ -94,7 +105,10 @@ async function enrichMonitorsBatch(
       .all(),
     include.notifications
       ? db
-          .select()
+          .select({
+            monitorId: notificationsToMonitors.monitorId,
+            notification,
+          })
           .from(notification)
           .innerJoin(
             notificationsToMonitors,
@@ -107,10 +121,13 @@ async function enrichMonitorsBatch(
             ),
           )
           .all()
-      : Promise.resolve([] as never[]),
+      : Promise.resolve([]),
     include.privateLocations
       ? db
-          .select()
+          .select({
+            monitorId: privateLocationToMonitors.monitorId,
+            location: privateLocation,
+          })
           .from(privateLocation)
           .innerJoin(
             privateLocationToMonitors,
@@ -123,48 +140,41 @@ async function enrichMonitorsBatch(
             ),
           )
           .all()
-      : Promise.resolve([] as never[]),
+      : Promise.resolve([]),
   ]);
 
   const tagsByMonitor = new Map<number, MonitorTag[]>();
-  for (const row of tagRows as Array<{
-    monitor_tag: MonitorTag;
-    monitor_tag_to_monitor: { monitorId: number };
-  }>) {
-    const mId = row.monitor_tag_to_monitor.monitorId;
-    const arr = tagsByMonitor.get(mId);
-    if (arr) arr.push(row.monitor_tag);
-    else tagsByMonitor.set(mId, [row.monitor_tag]);
+  for (const row of tagRows) {
+    const tag = selectMonitorTagSchema.parse(row.tag);
+    const arr = tagsByMonitor.get(row.monitorId);
+    if (arr) arr.push(tag);
+    else tagsByMonitor.set(row.monitorId, [tag]);
   }
 
   const incidentsByMonitor = new Map<number, Incident[]>();
-  for (const row of incidentRows as Incident[]) {
+  for (const row of incidentRows) {
     if (row.monitorId == null) continue;
+    const incident = selectIncidentSchema.parse(row);
     const arr = incidentsByMonitor.get(row.monitorId);
-    if (arr) arr.push(row);
-    else incidentsByMonitor.set(row.monitorId, [row]);
+    if (arr) arr.push(incident);
+    else incidentsByMonitor.set(row.monitorId, [incident]);
   }
 
   const notifsByMonitor = new Map<number, Notification[]>();
-  for (const row of notifRows as Array<{
-    notification: Notification;
-    notifications_to_monitors: { monitorId: number };
-  }>) {
-    const mId = row.notifications_to_monitors.monitorId;
-    const arr = notifsByMonitor.get(mId);
-    if (arr) arr.push(row.notification);
-    else notifsByMonitor.set(mId, [row.notification]);
+  for (const row of notifRows) {
+    const parsed = selectNotificationSchema.parse(row.notification);
+    const arr = notifsByMonitor.get(row.monitorId);
+    if (arr) arr.push(parsed);
+    else notifsByMonitor.set(row.monitorId, [parsed]);
   }
 
   const locsByMonitor = new Map<number, PrivateLocation[]>();
-  for (const row of locRows as Array<{
-    private_location: PrivateLocation;
-    private_location_to_monitor: { monitorId: number };
-  }>) {
-    const mId = row.private_location_to_monitor.monitorId;
-    const arr = locsByMonitor.get(mId);
-    if (arr) arr.push(row.private_location);
-    else locsByMonitor.set(mId, [row.private_location]);
+  for (const row of locRows) {
+    if (row.monitorId == null) continue;
+    const parsed = selectPrivateLocationSchema.parse(row.location);
+    const arr = locsByMonitor.get(row.monitorId);
+    if (arr) arr.push(parsed);
+    else locsByMonitor.set(row.monitorId, [parsed]);
   }
 
   return rows.map((r) => ({

--- a/packages/services/src/notification/list.ts
+++ b/packages/services/src/notification/list.ts
@@ -43,8 +43,14 @@ async function enrichNotificationsBatch(
   if (rows.length === 0) return [];
   const ids = rows.map((r) => r.id);
 
+  // Explicit column selection on the join — keeps the row shape in our
+  // hands instead of relying on drizzle's auto-derived `row.<table_name>`
+  // keys (named after the JS variable, fragile to schema renames).
   const assocRows = await db
-    .select()
+    .select({
+      notificationId: notificationsToMonitors.notificationId,
+      monitor,
+    })
     .from(monitor)
     .innerJoin(
       notificationsToMonitors,
@@ -60,15 +66,11 @@ async function enrichNotificationsBatch(
     .all();
 
   const monitorsByNotification = new Map<number, Monitor[]>();
-  for (const row of assocRows as Array<{
-    monitor: typeof monitor.$inferSelect;
-    notifications_to_monitors: { notificationId: number };
-  }>) {
-    const nId = row.notifications_to_monitors.notificationId;
+  for (const row of assocRows) {
     const parsed = selectMonitorSchema.parse(row.monitor);
-    const arr = monitorsByNotification.get(nId);
+    const arr = monitorsByNotification.get(row.notificationId);
     if (arr) arr.push(parsed);
-    else monitorsByNotification.set(nId, [parsed]);
+    else monitorsByNotification.set(row.notificationId, [parsed]);
   }
 
   return rows.map((r) => ({

--- a/packages/services/src/page-component/list.ts
+++ b/packages/services/src/page-component/list.ts
@@ -89,8 +89,15 @@ async function enrichPageComponentsBatch(
             )
             .all()
         : Promise.resolve([] as never[]),
+      // Explicit column selection on join queries — keeps the row shape
+      // in our hands instead of relying on drizzle's auto-derived
+      // `row.<table_name>` keys (named after the JS variable, fragile to
+      // schema renames).
       db
-        .select()
+        .select({
+          pageComponentId: statusReportsToPageComponents.pageComponentId,
+          report: statusReport,
+        })
         .from(statusReport)
         .innerJoin(
           statusReportsToPageComponents,
@@ -104,7 +111,10 @@ async function enrichPageComponentsBatch(
         )
         .all(),
       db
-        .select()
+        .select({
+          pageComponentId: maintenancesToPageComponents.pageComponentId,
+          maintenance,
+        })
         .from(maintenance)
         .innerJoin(
           maintenancesToPageComponents,
@@ -120,43 +130,29 @@ async function enrichPageComponentsBatch(
     ]);
 
   const monitorById = new Map<number, Monitor>();
-  for (const m of monitorRows as Array<typeof monitor.$inferSelect>) {
+  for (const m of monitorRows) {
     monitorById.set(m.id, selectMonitorSchema.parse(m));
   }
 
   const groupById = new Map<number, PageComponentGroupRow>();
-  for (const g of groupRows as PageComponentGroupRow[]) {
+  for (const g of groupRows) {
     groupById.set(g.id, selectPageComponentGroupSchema.parse(g));
   }
 
   const statusReportsByComponent = new Map<number, StatusReport[]>();
-  for (const row of statusReportRows as Array<{
-    status_report: typeof statusReport.$inferSelect;
-    status_report_to_page_component: {
-      pageComponentId: number;
-      createdAt: Date | null;
-    };
-  }>) {
-    const cId = row.status_report_to_page_component.pageComponentId;
-    const parsed = selectStatusReportSchema.parse(row.status_report);
-    const arr = statusReportsByComponent.get(cId);
+  for (const row of statusReportRows) {
+    const parsed = selectStatusReportSchema.parse(row.report);
+    const arr = statusReportsByComponent.get(row.pageComponentId);
     if (arr) arr.push(parsed);
-    else statusReportsByComponent.set(cId, [parsed]);
+    else statusReportsByComponent.set(row.pageComponentId, [parsed]);
   }
 
   const maintenancesByComponent = new Map<number, Maintenance[]>();
-  for (const row of maintenanceRows as Array<{
-    maintenance: typeof maintenance.$inferSelect;
-    maintenance_to_page_component: {
-      pageComponentId: number;
-      createdAt: Date | null;
-    };
-  }>) {
-    const cId = row.maintenance_to_page_component.pageComponentId;
+  for (const row of maintenanceRows) {
     const parsed = selectMaintenanceSchema.parse(row.maintenance);
-    const arr = maintenancesByComponent.get(cId);
+    const arr = maintenancesByComponent.get(row.pageComponentId);
     if (arr) arr.push(parsed);
-    else maintenancesByComponent.set(cId, [parsed]);
+    else maintenancesByComponent.set(row.pageComponentId, [parsed]);
   }
 
   return rows.map((r) => ({

--- a/packages/services/src/status-report/list.ts
+++ b/packages/services/src/status-report/list.ts
@@ -12,6 +12,7 @@ import {
 import {
   pageComponent,
   page as pageTable,
+  selectPageComponentSchema,
   selectPageSchema,
   statusReport,
   statusReportUpdate,
@@ -112,7 +113,7 @@ async function enrichReportsBatch(
     .all();
   const componentsByReport = new Map<number, PageComponent[]>();
   for (const row of assocRows) {
-    const component = row.component as unknown as PageComponent;
+    const component = selectPageComponentSchema.parse(row.component);
     const arr = componentsByReport.get(row.reportId);
     if (arr) arr.push(component);
     else componentsByReport.set(row.reportId, [component]);
@@ -135,9 +136,10 @@ async function enrichReportsBatch(
     ]);
     const siblingsByPageId = new Map<number, PageComponent[]>();
     for (const c of pageSiblings) {
-      const arr = siblingsByPageId.get(c.pageId);
-      if (arr) arr.push(c as unknown as PageComponent);
-      else siblingsByPageId.set(c.pageId, [c as unknown as PageComponent]);
+      const parsed = selectPageComponentSchema.parse(c);
+      const arr = siblingsByPageId.get(parsed.pageId);
+      if (arr) arr.push(parsed);
+      else siblingsByPageId.set(parsed.pageId, [parsed]);
     }
     for (const p of pageRows) {
       pageById.set(p.id, {


### PR DESCRIPTION
## Summary
- Service return values now flow through `selectXSchema.parse(...)` instead of `as Type` / `as unknown as Type` casts, so the schema's column transforms (comma-joined strings → arrays, JSON columns, prefaults) actually run at the service boundary.
- Join queries switched to explicit `.select({...})` aliases so the row shape stops depending on drizzle's auto-derived `row.<table_name>` keys, which silently break on schema renames.
- Touches: `api-key/{list,verify}`, `invitation/{create,list}`, `maintenance/list`, `monitor/list`, `notification/list`, `page-component/list`, `status-report/list`. All 139 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)