### PR TITLE
fix: typos in 2023-year-review and introducing-goatstack blog posts

### DIFF
--- a/apps/web/src/content/pages/blog/2023-year-review.mdx
+++ b/apps/web/src/content/pages/blog/2023-year-review.mdx
@@ -34,7 +34,7 @@ We wrote the first line of code for OpenStatus.
 
 **Middle of month**
 
-My tweet got a lot of traction, and and it gave us the motivation to continue to
+My tweet got a lot of traction, and it gave us the motivation to continue to
 build OpenStatus.
 
 **End of month**
@@ -81,7 +81,7 @@ We were not expecting such a good traction from the hacker news community
 
 **Middle of month**
 
-For some cost saving reasons, we decided to migrate our checker infrastucture
+For some cost saving reasons, we decided to migrate our checker infrastructure
 from Vercel to Fly.io.
 
 **End of month**
@@ -134,7 +134,7 @@ We have launched our deploy your own status page
   height={575}
 />
 
-**Number of page created per week**
+**Number of pages created per week**
 
 ## Other metrics
 
@@ -173,9 +173,9 @@ We have launched our deploy your own status page
   height={575}
 />
 
-**Monthly recuring revenue**
+**Monthly recurring revenue**
 
-# Let's talked about our 2023 year
+# Let's talk about our 2023 year
 
 ## What went well
 
@@ -191,9 +191,9 @@ We both reach more than 1000 followers on Twitter.
 ## What could have gone better
 
 We can brag about our MRR on Twitter but we are still not profitable. We are
-still not able to cover our costs despites a small MRR.
+still not able to cover our costs despite a small MRR.
 
-We could have listen more to our users. We could have done more to improve our
+We could have listened more to our users. We could have done more to improve our
 product. We should have done more users surveys.
 
 ## What went wrong

--- a/apps/web/src/content/pages/blog/introducing-goatstack.mdx
+++ b/apps/web/src/content/pages/blog/introducing-goatstack.mdx
@@ -93,7 +93,7 @@ To get started you need to have these  installed on your computer
 just init
 ```
 
-It will download all the dependancies.
+It will download all the dependencies.
 
 3. Open your IDE and update `packages/proto/goat/v1/goat.proto`
 Add new procedure in the GoatService


### PR DESCRIPTION
## Summary

Spotted a handful of typos while reading through the blog. All are in two posts — fixes are cosmetic only, no functional impact.

### `apps/web/src/content/pages/blog/2023-year-review.mdx`

- `and and it gave us` → `and it gave us`
- `infrastucture` → `infrastructure`
- `Number of page created per week` → `Number of pages created per week`
- `Monthly recuring revenue` → `Monthly recurring revenue`
- `Let's talked about our 2023 year` → `Let's talk about our 2023 year`
- `despites a small MRR` → `despite a small MRR`
- `could have listen more` → `could have listened more`

### `apps/web/src/content/pages/blog/introducing-goatstack.mdx`

- `dependancies` → `dependencies`

## Test plan

- [x] No code changes — MDX content only
- [x] Rendered pages still build