### PR TITLE
Add "type": "http" to MCP server configuration examples

### DIFF
--- a/apps/docs/src/content/docs/reference/mcp-server.mdx
+++ b/apps/docs/src/content/docs/reference/mcp-server.mdx
@@ -79,6 +79,7 @@ Add the server to `~/Library/Application Support/Claude/claude_desktop_config.js
 {
   "mcpServers": {
     "openstatus": {
+      "type": "http",
       "url": "https://api.openstatus.dev/mcp",
       "headers": {
         "x-openstatus-key": "os_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -97,6 +98,7 @@ In Cursor, open **Settings → MCP → Add Server**:
 ```json
 {
   "openstatus": {
+    "type": "http",
     "url": "https://api.openstatus.dev/mcp",
     "headers": {
       "x-openstatus-key": "os_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/apps/web/public/.well-known/agent-skills/openstatus-mcp/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/openstatus-mcp/SKILL.md
@@ -15,6 +15,7 @@ Add this to your MCP client config (Claude Desktop, Cursor, ChatGPT custom conne
 {
   "mcpServers": {
     "openstatus": {
+      "type": "http",
       "url": "https://api.openstatus.dev/mcp",
       "headers": {
         "x-openstatus-key": "os_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/apps/web/src/content/pages/product/tooling/mcp-server.mdx
+++ b/apps/web/src/content/pages/product/tooling/mcp-server.mdx
@@ -23,6 +23,7 @@ The openstatus MCP server connects Claude Desktop, ChatGPT, Cursor, and any othe
 {
   "mcpServers": {
     "openstatus": {
+      "type": "http",
       "url": "https://api.openstatus.dev/mcp",
       "headers": {
         "x-openstatus-key": "os_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
## Summary
Updated MCP server configuration examples across documentation to include the `"type": "http"` field in the server configuration object.

## Changes
- Added `"type": "http"` field to the openstatus MCP server configuration in:
  - `apps/docs/src/content/docs/reference/mcp-server.mdx` (Claude Desktop and Cursor examples)
  - `apps/web/public/.well-known/agent-skills/openstatus-mcp/SKILL.md`
  - `apps/web/src/content/pages/product/tooling/mcp-server.mdx`

## Details
The `"type": "http"` field explicitly specifies that the MCP server uses HTTP transport. This ensures consistency with MCP client configuration standards and provides clarity for users setting up the openstatus MCP server across different platforms (Claude Desktop, Cursor, ChatGPT, etc.).

https://claude.ai/code/session_01BX9w66dZxS15w1ZnyFCWyg