### PR TITLE
Fix status page edit link to use components route

### DIFF
--- a/apps/status-page/src/components/status-page/floating-button.tsx
+++ b/apps/status-page/src/components/status-page/floating-button.tsx
@@ -325,7 +325,7 @@ export function FloatingButton({
               <a
                 href={
                   pageId
-                    ? `https://app.openstatus.dev/status-pages/${pageId}/edit?type=${barType}&value=${cardType}&uptime=${showUptime}&theme=${communityTheme}`
+                    ? `https://app.openstatus.dev/status-pages/${pageId}/components?type=${barType}&value=${cardType}&uptime=${showUptime}&theme=${communityTheme}`
                     : "https://app.openstatus.dev/status-pages"
                 }
                 target="_blank"


### PR DESCRIPTION
## Summary
Updated the floating button link to navigate to the correct status page components editor route instead of the edit route.

## Changes
- Changed the status page edit URL from `/status-pages/{pageId}/edit` to `/status-pages/{pageId}/components`
- The link now correctly directs users to the components management page while preserving all query parameters (type, value, uptime, theme)

## Details
This fix ensures that when users click the edit button on the floating action button, they are taken to the proper components editor interface rather than a generic edit page. All existing query parameters for customization (bar type, card type, uptime display, and theme) are maintained in the navigation.

https://claude.ai/code/session_0141uK6DJbhE3Vef8m8nrb4W