### PR TITLE
Preserve pageId when clearing status report component associations

### DIFF
--- a/apps/dashboard/src/components/data-table/status-reports/data-table-row-actions.tsx
+++ b/apps/dashboard/src/components/data-table/status-reports/data-table-row-actions.tsx
@@ -140,8 +140,6 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
             (page?.pageComponentGroups?.length ?? 0) > 0;
           await updateStatusReportMutation.mutateAsync({
             id: row.original.id,
-            // Skip the field on pages with no components — sending [] would
-            // otherwise clear associations the user never saw a UI for.
             pageComponents: hasComponents ? values.pageComponents : undefined,
             title: values.title,
             status: values.status,

--- a/apps/dashboard/src/components/data-table/status-reports/data-table-row-actions.tsx
+++ b/apps/dashboard/src/components/data-table/status-reports/data-table-row-actions.tsx
@@ -135,9 +135,14 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
           pageComponents: row.original.pageComponents?.map((c) => c.id) ?? [],
         }}
         onSubmit={async (values) => {
+          const hasComponents =
+            (page?.pageComponents?.length ?? 0) > 0 ||
+            (page?.pageComponentGroups?.length ?? 0) > 0;
           await updateStatusReportMutation.mutateAsync({
             id: row.original.id,
-            pageComponents: values.pageComponents,
+            // Skip the field on pages with no components — sending [] would
+            // otherwise clear associations the user never saw a UI for.
+            pageComponents: hasComponents ? values.pageComponents : undefined,
             title: values.title,
             status: values.status,
           });

--- a/apps/server/src/routes/rpc/handlers/status-report/__tests__/status-report.test.ts
+++ b/apps/server/src/routes/rpc/handlers/status-report/__tests__/status-report.test.ts
@@ -1127,7 +1127,7 @@ describe("StatusReportService.UpdateStatusReport", () => {
     );
   });
 
-  test("clears pageId when removing all components", async () => {
+  test("clears component associations but preserves pageId when removing all components", async () => {
     // Create a temporary status report for this test
     const tempReport = await db
       .insert(statusReport)
@@ -1159,13 +1159,21 @@ describe("StatusReportService.UpdateStatusReport", () => {
 
       expect(res.status).toBe(200);
 
-      // Verify the pageId is now null
       const afterReport = await db
         .select()
         .from(statusReport)
         .where(eq(statusReport.id, tempReport.id))
         .get();
-      expect(afterReport?.pageId).toBeNull();
+      // pageId stays — clearing components no longer orphans the report
+      // from its page (would otherwise hide it from the dashboard list).
+      expect(afterReport?.pageId).toBe(1);
+
+      const afterAssoc = await db
+        .select()
+        .from(statusReportsToPageComponents)
+        .where(eq(statusReportsToPageComponents.statusReportId, tempReport.id))
+        .all();
+      expect(afterAssoc).toHaveLength(0);
     } finally {
       // Clean up
       await db

--- a/apps/server/src/routes/rpc/handlers/status-report/__tests__/status-report.test.ts
+++ b/apps/server/src/routes/rpc/handlers/status-report/__tests__/status-report.test.ts
@@ -1164,8 +1164,6 @@ describe("StatusReportService.UpdateStatusReport", () => {
         .from(statusReport)
         .where(eq(statusReport.id, tempReport.id))
         .get();
-      // pageId stays — clearing components no longer orphans the report
-      // from its page (would otherwise hide it from the dashboard list).
       expect(afterReport?.pageId).toBe(1);
 
       const afterAssoc = await db

--- a/packages/api/src/router/statusReport.ts
+++ b/packages/api/src/router/statusReport.ts
@@ -50,7 +50,7 @@ const updateStatusReportUpdateTRPCInput = z.object({
 
 const updateStatusTRPCInput = z.object({
   id: z.number(),
-  pageComponents: z.array(z.number()),
+  pageComponents: z.array(z.number()).optional(),
   title: z.string(),
   status: CreateStatusReportInput.shape.status,
 });

--- a/packages/services/src/status-report/__tests__/status-report.test.ts
+++ b/packages/services/src/status-report/__tests__/status-report.test.ts
@@ -332,6 +332,10 @@ describe("updateStatusReport", () => {
         .where(eq(statusReportsToPageComponents.statusReportId, report.id))
         .all();
       expect(assoc).toHaveLength(0);
+      // Clearing components must not orphan the report from its page —
+      // the dashboard list filters by pageId, so nulling it would make
+      // the report disappear (looking like a delete to the user).
+      expect(updated.pageId).toBe(testPageId);
     });
   });
 });

--- a/packages/services/src/status-report/__tests__/status-report.test.ts
+++ b/packages/services/src/status-report/__tests__/status-report.test.ts
@@ -332,9 +332,6 @@ describe("updateStatusReport", () => {
         .where(eq(statusReportsToPageComponents.statusReportId, report.id))
         .all();
       expect(assoc).toHaveLength(0);
-      // Clearing components must not orphan the report from its page —
-      // the dashboard list filters by pageId, so nulling it would make
-      // the report disappear (looking like a delete to the user).
       expect(updated.pageId).toBe(testPageId);
     });
   });

--- a/packages/services/src/status-report/update.ts
+++ b/packages/services/src/status-report/update.ts
@@ -25,10 +25,7 @@ import {
  *
  * A non-empty set moves the report to whatever page those components live
  * on. Mixed-page inputs are rejected upstream by `validatePageComponentIds`
- * (all ids must share a page). An empty set deliberately does not null
- * `pageId` — a report with no components on a page is still a report on
- * that page, and silently orphaning it on save makes the dashboard's "edit
- * report" sheet look like a delete on pages with no components.
+ * (all ids must share a page).
  */
 export async function updateStatusReport(args: {
   ctx: ServiceContext;
@@ -56,9 +53,6 @@ export async function updateStatusReport(args: {
         pageComponentIds: input.pageComponentIds,
       });
 
-      // A non-empty set moves the report to that page; an empty set leaves
-      // pageId untouched (clearing associations should not orphan the
-      // report from its page).
       if (validated.pageId !== null) {
         updateValues.pageId = validated.pageId;
       }

--- a/packages/services/src/status-report/update.ts
+++ b/packages/services/src/status-report/update.ts
@@ -20,14 +20,15 @@ import {
 /**
  * Update status-report metadata (title / status) and optionally replace the
  * full set of page-component associations. Passing
- * `pageComponentIds: []` clears the associations (and nulls `pageId`);
- * omitting the field leaves both untouched.
+ * `pageComponentIds: []` clears the associations but leaves `pageId`
+ * untouched; omitting the field leaves both untouched.
  *
- * The report's `pageId` follows its components: when the caller supplies
- * a new set of associations the report moves to whatever page those
- * components live on. Mixed-page inputs are rejected upstream by
- * `validatePageComponentIds` (all ids must share a page), so the only
- * states here are "one page" or "no components".
+ * A non-empty set moves the report to whatever page those components live
+ * on. Mixed-page inputs are rejected upstream by `validatePageComponentIds`
+ * (all ids must share a page). An empty set deliberately does not null
+ * `pageId` — a report with no components on a page is still a report on
+ * that page, and silently orphaning it on save makes the dashboard's "edit
+ * report" sheet look like a delete on pages with no components.
  */
 export async function updateStatusReport(args: {
   ctx: ServiceContext;
@@ -55,12 +56,12 @@ export async function updateStatusReport(args: {
         pageComponentIds: input.pageComponentIds,
       });
 
-      // `pageId` follows the association set: a new non-empty set moves
-      // the report to that page; an empty set nulls it. This is the
-      // behavior the Connect `UpdateStatusReport` tests have encoded
-      // since the original handler — no caller today wants a "report
-      // pinned to page X regardless of its components" guarantee.
-      updateValues.pageId = validated.pageId;
+      // A non-empty set moves the report to that page; an empty set leaves
+      // pageId untouched (clearing associations should not orphan the
+      // report from its page).
+      if (validated.pageId !== null) {
+        updateValues.pageId = validated.pageId;
+      }
 
       await updatePageComponentAssociations({
         tx,


### PR DESCRIPTION
## Summary
Changed the behavior when removing all component associations from a status report to preserve the report's `pageId` instead of nullifying it. This aligns with the use case where reports should remain pinned to a page even when temporarily without components.

## Key Changes
- **Service logic**: Modified `updateStatusReport` to only update `pageId` when a non-empty component set is provided, preserving the existing `pageId` when clearing associations
- **API schema**: Made `pageComponents` optional in the TRPC input to allow omitting the field entirely
- **Dashboard UI**: Updated the form submission logic to only send `pageComponents` when the page actually has components available, preventing unnecessary updates
- **Tests**: Updated test expectations to verify that `pageId` is preserved (remains 1) when clearing all component associations, while confirming the associations themselves are properly cleared

## Implementation Details
The change distinguishes between two scenarios:
1. **Clearing associations** (`pageComponentIds: []`): Removes all component links but leaves `pageId` untouched
2. **Omitting the field**: Leaves both associations and `pageId` untouched

This provides better control over report state management and prevents unintended side effects when managing component associations.

https://claude.ai/code/session_019AtzNQDHFN4QBttmTr31Fw