### PR TITLE
fix: preserve redirect URL for invited users through onboarding

### DIFF
--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -1,8 +1,27 @@
 import { getQueryClient, trpc } from "@/lib/trpc/server";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import type { SearchParams } from "nuqs";
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
+
+function tryRedirectToCallback(callbackUrl: string | null): void {
+  if (!callbackUrl) return;
+  try {
+    const target = new URL(callbackUrl, "http://_");
+    const safe =
+      (target.protocol === "http:" || target.protocol === "https:") &&
+      target.pathname.startsWith("/") &&
+      !target.pathname.startsWith("//") &&
+      target.pathname !== "/" &&
+      target.pathname !== "/login";
+    if (safe) {
+      redirect(`${target.pathname}${target.search}${target.hash}`);
+    }
+  } catch {
+    // malformed — fall through
+  }
+}
 
 export default async function Page({
   searchParams,
@@ -13,21 +32,16 @@ export default async function Page({
 
   // Same-origin-only redirect: strip host, reject non-HTTP and `//…`
   // (protocol-relative). `/` and `/login` are app-specific UX skips.
-  if (params.callbackUrl) {
-    try {
-      const target = new URL(params.callbackUrl, "http://_");
-      const safe =
-        (target.protocol === "http:" || target.protocol === "https:") &&
-        target.pathname.startsWith("/") &&
-        !target.pathname.startsWith("//") &&
-        target.pathname !== "/" &&
-        target.pathname !== "/login";
-      if (safe) {
-        redirect(`${target.pathname}${target.search}${target.hash}`);
-      }
-    } catch {
-      // malformed — fall through
-    }
+  // First check query params, then fallback to cookie set by middleware.
+  tryRedirectToCallback(params.callbackUrl);
+
+  // Fallback: check auth-redirect cookie for invite flows where Auth.js
+  // didn't pass the callbackUrl properly. The cookie has a 10-minute TTL
+  // and will expire naturally.
+  const cookieStore = await cookies();
+  const authRedirect = cookieStore.get("auth-redirect")?.value;
+  if (authRedirect) {
+    tryRedirectToCallback(authRedirect);
   }
 
   const queryClient = getQueryClient();

--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -7,6 +7,7 @@ import { searchParamsCache } from "./search-params";
 
 function tryRedirectToCallback(callbackUrl: string | null): void {
   if (!callbackUrl) return;
+  let safePath: string | null = null;
   try {
     const target = new URL(callbackUrl, "http://_");
     const safe =
@@ -16,10 +17,14 @@ function tryRedirectToCallback(callbackUrl: string | null): void {
       target.pathname !== "/" &&
       target.pathname !== "/login";
     if (safe) {
-      redirect(`${target.pathname}${target.search}${target.hash}`);
+      safePath = `${target.pathname}${target.search}${target.hash}`;
     }
   } catch {
     // malformed — fall through
+  }
+  // redirect() throws NEXT_REDIRECT; must be outside the try/catch above.
+  if (safePath) {
+    redirect(safePath);
   }
 }
 

--- a/apps/dashboard/src/lib/auth/index.ts
+++ b/apps/dashboard/src/lib/auth/index.ts
@@ -21,8 +21,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       : [GitHubProvider, GoogleProvider],
   callbacks: {
     async redirect({ url, baseUrl }) {
-      // Allow relative URLs
-      if (url.startsWith("/")) {
+      // Allow relative URLs, but not protocol-relative `//evil.com` which the
+      // browser would resolve off-origin.
+      if (url.startsWith("/") && !url.startsWith("//")) {
         return `${baseUrl}${url}`;
       }
       // Same-origin absolute URLs only — compare parsed origins, not a string

--- a/apps/dashboard/src/lib/auth/index.ts
+++ b/apps/dashboard/src/lib/auth/index.ts
@@ -21,14 +21,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       : [GitHubProvider, GoogleProvider],
   callbacks: {
     async redirect({ url, baseUrl }) {
-      // For new users being redirected to onboarding, ensure the original
-      // callback URL is preserved so invite links work properly
-      if (url.startsWith(baseUrl)) {
-        return url;
-      }
       // Allow relative URLs
       if (url.startsWith("/")) {
         return `${baseUrl}${url}`;
+      }
+      // Same-origin absolute URLs only — compare parsed origins, not a string
+      // prefix, so `https://<baseUrl>.evil.com` cannot pass as trusted.
+      // Preserves the original callback URL so invite links keep working.
+      try {
+        if (new URL(url).origin === new URL(baseUrl).origin) {
+          return url;
+        }
+      } catch {
+        // malformed url — fall through to baseUrl
       }
       return baseUrl;
     },

--- a/apps/dashboard/src/lib/auth/index.ts
+++ b/apps/dashboard/src/lib/auth/index.ts
@@ -20,6 +20,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       ? [GitHubProvider, GoogleProvider, ResendProvider]
       : [GitHubProvider, GoogleProvider],
   callbacks: {
+    async redirect({ url, baseUrl }) {
+      // For new users being redirected to onboarding, ensure the original
+      // callback URL is preserved so invite links work properly
+      if (url.startsWith(baseUrl)) {
+        return url;
+      }
+      // Allow relative URLs
+      if (url.startsWith("/")) {
+        return `${baseUrl}${url}`;
+      }
+      return baseUrl;
+    },
     async signIn(params) {
       // We keep updating the user info when we loggin in
 

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -26,7 +26,10 @@ export default auth(async (req) => {
       console.log("User not authenticated, redirecting to login");
     }
     const newURL = new URL("/login", req.url);
-    const encodedSearchParams = `${url.pathname}${url.search}`;
+    // Only worth preserving a non-root destination; tryRedirectToCallback
+    // rejects "/" anyway, so storing it would be a no-op redirect.
+    const encodedSearchParams =
+      url.pathname === "/" ? null : `${url.pathname}${url.search}`;
 
     if (encodedSearchParams) {
       newURL.searchParams.append("redirectTo", encodedSearchParams);

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -94,10 +94,17 @@ export default auth(async (req) => {
     response.cookies.delete("workspace-slug");
   }
 
-  // auth-redirect is single-use; the onboarding Server Component reads it but
-  // can't mutate cookies, so clear it here once authenticated. Prevents a
-  // stale back-button hit on /onboarding redirecting again.
-  if (req.auth && req.cookies.has("auth-redirect")) {
+  // auth-redirect is single-use and consumed by the /onboarding Server
+  // Component. Middleware response-cookie writes are reflected into the same
+  // request's cookies(), so deleting it on the /onboarding request itself
+  // would race (and lose) that read. Clear it on the next authenticated
+  // request instead: by then onboarding has redirected to the target, the
+  // cookie's job is done, and the stale back-button re-redirect is killed.
+  if (
+    req.auth &&
+    url.pathname !== "/onboarding" &&
+    req.cookies.has("auth-redirect")
+  ) {
     response.cookies.delete("auth-redirect");
   }
 

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -48,10 +48,21 @@ export default auth(async (req) => {
 
   if (req.auth && url.pathname === "/login") {
     const redirectTo = url.searchParams.get("redirectTo");
-    console.log("User authenticated, redirecting to", redirectTo);
     if (redirectTo) {
-      const redirectToUrl = new URL(redirectTo, req.url);
-      return NextResponse.redirect(redirectToUrl);
+      // Same-origin only: rebuild from path/search/hash so an absolute
+      // redirectTo (e.g. https://evil.com) can't become an open redirect.
+      const target = new URL(redirectTo, req.nextUrl.origin);
+      if (
+        (target.protocol === "http:" || target.protocol === "https:") &&
+        !target.pathname.startsWith("//")
+      ) {
+        const safe = new URL(
+          `${target.pathname}${target.search}${target.hash}`,
+          req.nextUrl.origin,
+        );
+        console.log("User authenticated, redirecting to", safe);
+        return NextResponse.redirect(safe);
+      }
     }
   }
 
@@ -81,7 +92,5 @@ export default auth(async (req) => {
 });
 
 export const config = {
-  matcher: [
-    "/((?!api|assets|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
-  ],
+  matcher: ["/((?!api|assets|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"],
 };

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -30,7 +30,20 @@ export default auth(async (req) => {
       newURL.searchParams.append("redirectTo", encodedSearchParams);
     }
 
-    return NextResponse.redirect(newURL);
+    const response = NextResponse.redirect(newURL);
+    // Store the redirect URL in a cookie for new users who go through onboarding.
+    // Auth.js may not reliably pass callbackUrl to pages.newUser, so we use a
+    // cookie as a fallback to ensure invite links work correctly.
+    if (encodedSearchParams) {
+      response.cookies.set("auth-redirect", encodedSearchParams, {
+        path: "/",
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 60 * 10, // 10 minutes
+      });
+    }
+    return response;
   }
 
   if (req.auth && url.pathname === "/login") {

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -22,7 +22,9 @@ export default auth(async (req) => {
   }
 
   if (!req.auth && url.pathname !== "/login") {
-    console.log("User not authenticated, redirecting to login");
+    if (process.env.NODE_ENV === "development") {
+      console.log("User not authenticated, redirecting to login");
+    }
     const newURL = new URL("/login", req.url);
     const encodedSearchParams = `${url.pathname}${url.search}`;
 
@@ -60,8 +62,12 @@ export default auth(async (req) => {
           `${target.pathname}${target.search}${target.hash}`,
           req.nextUrl.origin,
         );
-        console.log("User authenticated, redirecting to", safe);
-        return NextResponse.redirect(safe);
+        if (process.env.NODE_ENV === "development") {
+          console.log("User authenticated, redirecting to", safe);
+        }
+        const res = NextResponse.redirect(safe);
+        res.cookies.delete("auth-redirect");
+        return res;
       }
     }
   }
@@ -86,6 +92,13 @@ export default auth(async (req) => {
 
   if (!req.auth && hasWorkspaceSlug) {
     response.cookies.delete("workspace-slug");
+  }
+
+  // auth-redirect is single-use; the onboarding Server Component reads it but
+  // can't mutate cookies, so clear it here once authenticated. Prevents a
+  // stale back-button hit on /onboarding redirecting again.
+  if (req.auth && req.cookies.has("auth-redirect")) {
+    response.cookies.delete("auth-redirect");
   }
 
   return response;

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -92,5 +92,7 @@ export default auth(async (req) => {
 });
 
 export const config = {
-  matcher: ["/((?!api|assets|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"],
+  matcher: [
+    "/((?!api|assets|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+  ],
 };


### PR DESCRIPTION
When an invited user signs up, Auth.js may not reliably pass the callbackUrl to the onboarding page. This fix adds a fallback cookie mechanism to ensure invite links work correctly for new users.

- Store redirect URL in auth-redirect cookie when redirecting to login
- Check cookie in onboarding page if callbackUrl param is missing
- Cookie expires after 10 minutes to avoid stale redirects

Slack thread: https://openstatus.slack.com/archives/C05G0TXU9MF/p1779104198296469?thread_ts=1779102641.409419&cid=C05G0TXU9MF

https://claude.ai/code/session_01SQ2T7BibYH39J5w18q1XMA