### PR TITLE
fix: flaky ci tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ apps/web/tsconfig.tsbuildinfo
 openstatus-test.db
 openstatus-test.db-shm
 openstatus-test.db-wal
+dev.db*
 
 #webstorm
 .idea

--- a/apps/server/src/routes/mcp/handler.test.ts
+++ b/apps/server/src/routes/mcp/handler.test.ts
@@ -210,6 +210,7 @@ describe("MCP transport", () => {
  */
 describe("MCP transport — audit stamping", () => {
   const E2E_PREFIX = "mcp-handler-test";
+  const E2E_SLUG_SUFFIX = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   let e2ePageId: number | null = null;
   const createdReports: number[] = [];
 
@@ -220,7 +221,7 @@ describe("MCP transport — audit stamping", () => {
         workspaceId: SEEDED_WORKSPACE_TEAM_ID,
         title: `${E2E_PREFIX}-page`,
         description: "e2e page",
-        slug: `${E2E_PREFIX}-page-slug`,
+        slug: `${E2E_PREFIX}-page-slug-${E2E_SLUG_SUFFIX}`,
         customDomain: "",
       })
       .returning()

--- a/packages/api/src/router/import.test.ts
+++ b/packages/api/src/router/import.test.ts
@@ -340,7 +340,7 @@ test("run creates page, components, and groups in DB", async () => {
 
   // Clean up for next tests
   await cleanup();
-});
+}, 15_000);
 
 test("run with existing pageId imports into that page", async () => {
   const result = await caller.import.run({
@@ -373,7 +373,7 @@ test("run with existing pageId imports into that page", async () => {
   expect(matchingComps.length).toBe(MOCK_COMPONENTS.length);
 
   await cleanup();
-});
+}, 15_000);
 
 test("re-run skips already-imported resources (idempotency)", async () => {
   // First run
@@ -409,7 +409,7 @@ test("re-run skips already-imported resources (idempotency)", async () => {
   expect(allGroupsSkipped).toBe(true);
 
   await cleanup();
-});
+}, 15_000);
 
 test("run with includeStatusReports creates status reports", async () => {
   const result = await caller.import.run({
@@ -460,7 +460,7 @@ test("run with includeStatusReports creates status reports", async () => {
   expect(createdMaintIds.length).toBeGreaterThan(0);
 
   await cleanup();
-});
+}, 15_000);
 
 // ---------------------------------------------------------------------------
 // Limit warnings (go through the caller with custom workspace limits to

--- a/packages/api/src/router/maintenance.test.ts
+++ b/packages/api/src/router/maintenance.test.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
   const p = await db
     .insert(page)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       title: "Maintenance IDOR Test Page",
       description: "Page for maintenance IDOR testing",
       slug: "maintenance-idor-test-page",
@@ -41,7 +41,7 @@ beforeAll(async () => {
   const component = await db
     .insert(pageComponent)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       pageId: otherWorkspacePageId,
       name: "Other workspace component",
       type: "static",
@@ -55,7 +55,7 @@ beforeAll(async () => {
   const m = await db
     .insert(maintenance)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       title: "Other workspace maintenance",
       message: "Scheduled maintenance",
       pageId: 1,

--- a/packages/api/src/router/monitor.test.ts
+++ b/packages/api/src/router/monitor.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
   const otherLoc = await db
     .insert(privateLocation)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       name: "Other workspace private location",
       token: "monitor-test-other-token",
     })

--- a/packages/api/src/router/notification.test.ts
+++ b/packages/api/src/router/notification.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
       provider: "email",
       name: "workspace 2 idor test notification",
       data: '{"email":"test@openstatus.dev"}',
-      workspaceId: 2,
+      workspaceId: 3,
     })
     .returning()
     .get();

--- a/packages/api/src/router/pageComponent.test.ts
+++ b/packages/api/src/router/pageComponent.test.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
   const m = await db
     .insert(monitor)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       name: "Other workspace monitor",
       jobType: "http",
       periodicity: "1m",

--- a/packages/api/src/router/privateLocation.test.ts
+++ b/packages/api/src/router/privateLocation.test.ts
@@ -16,7 +16,7 @@ beforeAll(async () => {
   const otherLoc = await db
     .insert(privateLocation)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       name: "Other workspace location",
       token: "test-token-idor",
     })

--- a/packages/api/src/router/statusReport.test.ts
+++ b/packages/api/src/router/statusReport.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
   const p = await db
     .insert(page)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       title: "IDOR Test Page",
       description: "Page for IDOR testing",
       slug: "idor-test-page",
@@ -44,7 +44,7 @@ beforeAll(async () => {
   const component = await db
     .insert(pageComponent)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       pageId: otherWorkspacePageId,
       name: "Other workspace component",
       type: "static",
@@ -56,7 +56,7 @@ beforeAll(async () => {
   const report = await db
     .insert(statusReport)
     .values({
-      workspaceId: 2,
+      workspaceId: 3,
       title: "Other workspace report",
       status: "investigating",
       pageId: otherWorkspacePageId,


### PR DESCRIPTION
## Summary (from Claude)

Three flaky tests, mostly one root cause: api/router IDOR tests committed pages into workspace 2 (free, status-pages:1), tripping `services/page.test.ts` quota assertion when packages ran in parallel.

  - `api/router/*.test.ts` × 6: move IDOR pages to workspace 3 (team plan, no quota). Solid fix.
  - `packages/api/router/import.test.ts`: bump 4 heavy tests to 15s (Bun default 5s). Solid fix.
  - `apps/server/.../mcp/handler.test.ts`: per-run slug suffix. Defensive — guards against a slug collision from an interrupted prior run, but the actual root cause of the original failure isn't determinable from the log (test reached line 278, so beforeAll succeeded — slug collision would have failed earlier). May need a follow-up if it still flakes.