### PR TITLE
Docs UI polish: design variants + micro-interactions

### DIFF
--- a/apps/web/src/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/(docs)/docs/[[...slug]]/page.tsx
@@ -135,8 +135,8 @@ export default async function DocsPage({
   return (
     <div className="flex gap-8">
       <div className="min-w-0 flex-1 space-y-8">
-        <DocsSubNav />
-        <article className="prose dark:prose-invert max-w-none font-sans">
+        <DocsSubNav title={doc.metadata.title} />
+        <article className="prose dark:prose-invert max-w-none">
           <h1>{doc.metadata.title}</h1>
           <CustomMDX source={doc.content} />
         </article>
@@ -146,7 +146,7 @@ export default async function DocsPage({
               href={`${EDIT_BASE}/${joined}.mdx`}
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-foreground"
+              className="transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
             >
               Edit this page on GitHub
             </a>

--- a/apps/web/src/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/(docs)/docs/[[...slug]]/page.tsx
@@ -135,7 +135,7 @@ export default async function DocsPage({
   return (
     <div className="flex gap-8">
       <div className="min-w-0 flex-1 space-y-8">
-        <DocsSubNav title={doc.metadata.title} />
+        <DocsSubNav />
         <article className="prose dark:prose-invert max-w-none">
           <h1>{doc.metadata.title}</h1>
           <CustomMDX source={doc.content} />
@@ -146,7 +146,7 @@ export default async function DocsPage({
               href={`${EDIT_BASE}/${joined}.mdx`}
               target="_blank"
               rel="noopener noreferrer"
-              className="transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+              className="ease transition-colors duration-150 hover:text-foreground motion-reduce:transition-none"
             >
               Edit this page on GitHub
             </a>

--- a/apps/web/src/app/(docs)/layout.tsx
+++ b/apps/web/src/app/(docs)/layout.tsx
@@ -8,7 +8,7 @@ export default function DocsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-4 font-mono">
+    <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-4 font-sans">
       <DocsHeader />
       <div className="flex flex-1 gap-8 px-4 py-4">
         <DocsSidebar className="hidden w-56 shrink-0 lg:block" />

--- a/apps/web/src/app/(landing)/content-pagination.tsx
+++ b/apps/web/src/app/(landing)/content-pagination.tsx
@@ -10,7 +10,7 @@ export function ContentPagination({
 }) {
   if (!prev && !next) return null;
   return (
-    <div className="grid grid-cols-2 gap-px border border-border bg-border [&>*]:bg-background [&>a]:p-4 [&>a]:hover:bg-muted">
+    <div className="grid grid-cols-2 gap-px border border-border bg-border [&>*]:bg-background [&>a]:p-4 [&>a]:transition-colors [&>a]:duration-150 [&>a]:ease [&>a]:motion-reduce:transition-none [&>a]:hover:bg-muted">
       {prev ? (
         <Link href={prev.href} className="no-underline! ">
           <span className="block text-muted-foreground">Previous</span>

--- a/apps/web/src/app/(landing)/content-pagination.tsx
+++ b/apps/web/src/app/(landing)/content-pagination.tsx
@@ -10,7 +10,7 @@ export function ContentPagination({
 }) {
   if (!prev && !next) return null;
   return (
-    <div className="grid grid-cols-2 gap-px border border-border bg-border [&>*]:bg-background [&>a]:p-4 [&>a]:transition-colors [&>a]:duration-150 [&>a]:ease [&>a]:motion-reduce:transition-none [&>a]:hover:bg-muted">
+    <div className="[&>a]:ease grid grid-cols-2 gap-px border border-border bg-border [&>*]:bg-background [&>a]:p-4 [&>a]:transition-colors [&>a]:duration-150 [&>a]:hover:bg-muted [&>a]:motion-reduce:transition-none">
       {prev ? (
         <Link href={prev.href} className="no-underline! ">
           <span className="block text-muted-foreground">Previous</span>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { OpenPanelComponent } from "@openpanel/nextjs";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import LocalFont from "next/font/local";
+import Script from "next/script";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { WebMcpProvider } from "@/components/webmcp-provider";
@@ -46,7 +47,7 @@ export default function RootLayout({
         className={`${
           inter.className
           // biome-ignore lint/nursery/useSortedClasses: <explanation>
-        } ${inter.variable} ${calSans.variable}`}
+        } ${inter.variable} ${calSans.variable} antialiased`}
       >
         <PlausibleProvider domain="openstatus.dev">
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
@@ -86,6 +87,7 @@ export default function RootLayout({
           }}
           richColors
         />
+        <Script src="https://ui.sh/ui-picker.js" />
       </body>
     </html>
   );

--- a/apps/web/src/content/cmdk.tsx
+++ b/apps/web/src/content/cmdk.tsx
@@ -189,7 +189,10 @@ const CONFIG: ConfigSection[] = [
   },
 ];
 
-export function CmdK({ defaultPage }: { defaultPage?: string } = {}) {
+export function CmdK({
+  defaultPage,
+  className,
+}: { defaultPage?: string; className?: string } = {}) {
   const [open, setOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const listRef = React.useRef<HTMLDivElement | null>(null);
@@ -295,6 +298,7 @@ export function CmdK({ defaultPage }: { defaultPage?: string } = {}) {
         className={cn(
           "flex w-full items-center text-left hover:bg-muted",
           open && "bg-muted!",
+          className,
         )}
         onClick={() => setOpen(true)}
       >

--- a/apps/web/src/content/copy-button.tsx
+++ b/apps/web/src/content/copy-button.tsx
@@ -11,7 +11,71 @@ import {
 } from "@openstatus/ui/components/ui/dropdown-menu";
 import { useCopyToClipboard } from "@openstatus/ui/hooks/use-copy-to-clipboard";
 import { cn } from "@openstatus/ui/lib/utils";
+import { ChevronDown } from "lucide-react";
 import { toast } from "sonner";
+
+function CopyIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeMiterlimit="10"
+      strokeLinecap="square"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M7 15L3 15L3 3L17 3L17 9" />
+      <path d="M7 9L7 21L21 21L21 9L7 9Z" />
+    </svg>
+  );
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="square"
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function AnimatedCopyIcon({ isCopied }: { isCopied: boolean }) {
+  return (
+    <span className="relative inline-flex size-4">
+      <CopyIcon
+        className={cn(
+          "absolute inset-0 transition-[opacity,transform,filter] duration-200 [transition-timing-function:cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none",
+          isCopied
+            ? "scale-[0.25] opacity-0 blur-[4px]"
+            : "scale-100 opacity-100 blur-0",
+        )}
+      />
+      <CheckIcon
+        className={cn(
+          "absolute inset-0 transition-[opacity,transform,filter] duration-200 [transition-timing-function:cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none",
+          isCopied
+            ? "scale-100 opacity-100 blur-0"
+            : "scale-[0.25] opacity-0 blur-[4px]",
+        )}
+      />
+    </span>
+  );
+}
 
 export function CopyButton({
   className,
@@ -74,29 +138,34 @@ export function CopyDropdownButton({
 
   return (
     <ButtonGroup
-      className={cn("rounded-none border-none p-4", className)}
+      className={cn("rounded-none border-none", className)}
       {...props}
     >
       <Button
         variant="ghost"
-        className="rounded-none p-4"
+        size="sm"
+        className="h-8 gap-1.5 rounded-none px-2 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
         onClick={handleCopyLink}
+        aria-label={isCopied ? "Link copied" : "Copy link"}
       >
-        {isCopied ? "[link copied]" : "[copy link]"}
+        <span className="relative top-px">
+          <AnimatedCopyIcon isCopied={isCopied} />
+        </span>
+        <span className="text-sm">
+          {isCopied ? "Copied" : "Copy link"}
+        </span>
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className="group rounded-none"
-            aria-label="Copy dropdown"
+            size="icon"
+            className="group h-8 w-6 rounded-none text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+            aria-label="More copy options"
           >
-            <span
-              className="relative top-[1px] shrink-0 origin-center text-[10px] text-muted-foreground transition duration-300 group-hover:text-foreground group-data-[state=open]:rotate-180 group-data-[state=open]:text-foreground"
-              aria-hidden="true"
-            >
-              ▲
-            </span>
+            <ChevronDown
+              className="size-3 transition-transform duration-200 ease-out group-data-[state=open]:rotate-180 motion-reduce:transition-none"
+            />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -110,7 +179,7 @@ export function CopyDropdownButton({
               className="rounded-none font-mono"
               onClick={handleCopyMarkdown}
             >
-              [copy markdown]
+              Copy as Markdown
             </DropdownMenuItem>
           </DropdownMenuGroup>
         </DropdownMenuContent>

--- a/apps/web/src/content/copy-button.tsx
+++ b/apps/web/src/content/copy-button.tsx
@@ -11,71 +11,7 @@ import {
 } from "@openstatus/ui/components/ui/dropdown-menu";
 import { useCopyToClipboard } from "@openstatus/ui/hooks/use-copy-to-clipboard";
 import { cn } from "@openstatus/ui/lib/utils";
-import { ChevronDown } from "lucide-react";
 import { toast } from "sonner";
-
-function CopyIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeMiterlimit="10"
-      strokeLinecap="square"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M7 15L3 15L3 3L17 3L17 9" />
-      <path d="M7 9L7 21L21 21L21 9L7 9Z" />
-    </svg>
-  );
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="square"
-      className={className}
-      aria-hidden="true"
-    >
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  );
-}
-
-function AnimatedCopyIcon({ isCopied }: { isCopied: boolean }) {
-  return (
-    <span className="relative inline-flex size-4">
-      <CopyIcon
-        className={cn(
-          "absolute inset-0 transition-[opacity,transform,filter] duration-200 [transition-timing-function:cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none",
-          isCopied
-            ? "scale-[0.25] opacity-0 blur-[4px]"
-            : "scale-100 opacity-100 blur-0",
-        )}
-      />
-      <CheckIcon
-        className={cn(
-          "absolute inset-0 transition-[opacity,transform,filter] duration-200 [transition-timing-function:cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none",
-          isCopied
-            ? "scale-100 opacity-100 blur-0"
-            : "scale-[0.25] opacity-0 blur-[4px]",
-        )}
-      />
-    </span>
-  );
-}
 
 export function CopyButton({
   className,
@@ -138,30 +74,29 @@ export function CopyDropdownButton({
 
   return (
     <ButtonGroup
-      className={cn("rounded-none border-none", className)}
+      className={cn("rounded-none border-none p-4", className)}
       {...props}
     >
       <Button
         variant="ghost"
-        size="sm"
-        className="h-8 gap-1.5 rounded-none px-2 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+        className="rounded-none p-4"
         onClick={handleCopyLink}
-        aria-label={isCopied ? "Link copied" : "Copy link"}
       >
-        <span className="relative top-px">
-          <AnimatedCopyIcon isCopied={isCopied} />
-        </span>
-        <span className="text-sm">{isCopied ? "Copied" : "Copy link"}</span>
+        {isCopied ? "[link copied]" : "[copy link]"}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            size="icon"
-            className="group h-8 w-6 rounded-none text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
-            aria-label="More copy options"
+            className="group rounded-none"
+            aria-label="Copy dropdown"
           >
-            <ChevronDown className="size-3 transition-transform duration-200 ease-out group-data-[state=open]:rotate-180 motion-reduce:transition-none" />
+            <span
+              className="relative top-[1px] shrink-0 origin-center font-sans text-[10px] text-muted-foreground transition duration-300 group-hover:text-foreground group-data-[state=open]:rotate-180 group-data-[state=open]:text-foreground"
+              aria-hidden="true"
+            >
+              ▲
+            </span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -175,7 +110,7 @@ export function CopyDropdownButton({
               className="rounded-none font-mono"
               onClick={handleCopyMarkdown}
             >
-              Copy as Markdown
+              [copy markdown]
             </DropdownMenuItem>
           </DropdownMenuGroup>
         </DropdownMenuContent>

--- a/apps/web/src/content/copy-button.tsx
+++ b/apps/web/src/content/copy-button.tsx
@@ -151,9 +151,7 @@ export function CopyDropdownButton({
         <span className="relative top-px">
           <AnimatedCopyIcon isCopied={isCopied} />
         </span>
-        <span className="text-sm">
-          {isCopied ? "Copied" : "Copy link"}
-        </span>
+        <span className="text-sm">{isCopied ? "Copied" : "Copy link"}</span>
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -163,9 +161,7 @@ export function CopyDropdownButton({
             className="group h-8 w-6 rounded-none text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
             aria-label="More copy options"
           >
-            <ChevronDown
-              className="size-3 transition-transform duration-200 ease-out group-data-[state=open]:rotate-180 motion-reduce:transition-none"
-            />
+            <ChevronDown className="size-3 transition-transform duration-200 ease-out group-data-[state=open]:rotate-180 motion-reduce:transition-none" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/apps/web/src/content/docs-footer.tsx
+++ b/apps/web/src/content/docs-footer.tsx
@@ -4,7 +4,7 @@ import { FooterStatus } from "./footer-status";
 
 export function DocsFooter() {
   return (
-    <footer>
+    <footer className="font-mono">
       <div className="grid gap-px border border-border bg-border sm:grid-cols-2 md:grid-cols-3 [&>*]:bg-background">
         <Link
           href="/cal"

--- a/apps/web/src/content/docs-header.tsx
+++ b/apps/web/src/content/docs-header.tsx
@@ -4,38 +4,15 @@ import { LogoWithContextMenu } from "./logo-with-context-menu";
 
 export function DocsHeader() {
   return (
-    <header className="border border-border">
-      <div className="flex items-stretch gap-8 px-4">
-        {/* Logo — same width as sidebar (w-56) */}
-        <div className="hidden w-56 shrink-0 items-center py-4 lg:flex">
-          <LogoWithContextMenu />
-        </div>
-        <div className="flex items-center py-4 lg:hidden">
-          <LogoWithContextMenu />
-        </div>
-
-        {/* Search — fills main content column */}
-        <div className="flex min-w-0 flex-1 items-center border-x border-border px-4 py-4 transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none max-lg:hidden">
-          <CmdK defaultPage="docs" />
-        </div>
-        <div className="flex items-center border-l border-border px-4 py-4 transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none lg:hidden">
-          <CmdK defaultPage="docs" />
-        </div>
-
-        {/* Dashboard — same width as TOC aside (w-56), auto on smaller */}
-        <Link
-          href="https://app.openstatus.dev/login"
-          className="hidden shrink-0 items-center py-4 text-sm text-blue-700 transition-colors duration-150 ease hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300 xl:flex xl:w-56 motion-reduce:transition-none"
-        >
-          Dashboard
-        </Link>
-        <Link
-          href="https://app.openstatus.dev/login"
-          className="flex items-center py-4 text-sm text-blue-700 transition-colors duration-150 ease hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300 xl:hidden motion-reduce:transition-none"
-        >
-          Dashboard
-        </Link>
-      </div>
+    <header className="grid grid-cols-3 gap-px border border-border bg-border font-mono lg:grid-cols-5 [&>*]:bg-background [&>*]:px-4 [&>*]:py-4 [&>*]:hover:bg-muted">
+      <LogoWithContextMenu />
+      <CmdK className="lg:col-span-3" />
+      <Link
+        href="https://app.openstatus.dev/login"
+        className="truncate text-blue-700 dark:text-blue-400"
+      >
+        Dashboard
+      </Link>
     </header>
   );
 }

--- a/apps/web/src/content/docs-header.tsx
+++ b/apps/web/src/content/docs-header.tsx
@@ -4,19 +4,38 @@ import { LogoWithContextMenu } from "./logo-with-context-menu";
 
 export function DocsHeader() {
   return (
-    <header className="grid grid-cols-3 gap-px border border-border bg-border md:grid-cols-6 [&>*]:bg-background [&>*]:px-4 [&>*]:py-4 [&>*]:hover:bg-muted">
-      <LogoWithContextMenu />
-      <div
-        aria-hidden
-        className="pointer-events-none hidden md:col-span-3 md:block"
-      />
-      <CmdK defaultPage="docs" />
-      <Link
-        href="https://app.openstatus.dev/login"
-        className="truncate text-blue-700 dark:text-blue-400"
-      >
-        Dashboard
-      </Link>
+    <header className="border border-border">
+      <div className="flex items-stretch gap-8 px-4">
+        {/* Logo — same width as sidebar (w-56) */}
+        <div className="hidden w-56 shrink-0 items-center py-4 lg:flex">
+          <LogoWithContextMenu />
+        </div>
+        <div className="flex items-center py-4 lg:hidden">
+          <LogoWithContextMenu />
+        </div>
+
+        {/* Search — fills main content column */}
+        <div className="flex min-w-0 flex-1 items-center border-x border-border px-4 py-4 transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none max-lg:hidden">
+          <CmdK defaultPage="docs" />
+        </div>
+        <div className="flex items-center border-l border-border px-4 py-4 transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none lg:hidden">
+          <CmdK defaultPage="docs" />
+        </div>
+
+        {/* Dashboard — same width as TOC aside (w-56), auto on smaller */}
+        <Link
+          href="https://app.openstatus.dev/login"
+          className="hidden shrink-0 items-center py-4 text-sm text-blue-700 transition-colors duration-150 ease hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300 xl:flex xl:w-56 motion-reduce:transition-none"
+        >
+          Dashboard
+        </Link>
+        <Link
+          href="https://app.openstatus.dev/login"
+          className="flex items-center py-4 text-sm text-blue-700 transition-colors duration-150 ease hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300 xl:hidden motion-reduce:transition-none"
+        >
+          Dashboard
+        </Link>
+      </div>
     </header>
   );
 }

--- a/apps/web/src/content/docs-sidebar.tsx
+++ b/apps/web/src/content/docs-sidebar.tsx
@@ -13,7 +13,30 @@ import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { type DocsNavSection, docsNav, isExternalItem } from "./docs.config";
 
-function NavSection({
+function CollapsibleList({
+  open,
+  children,
+  className,
+}: {
+  open: boolean;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
+        open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+      )}
+    >
+      <div className={cn("overflow-hidden", className)}>{children}</div>
+    </div>
+  );
+}
+
+// ─── Option A: Current (baseline) ───────────────────────────────────────────
+
+function NavSectionA({
   section,
   pathname,
   onNavigate,
@@ -27,7 +50,6 @@ function NavSection({
   );
   const [open, setOpen] = useState(!section.collapsed || containsActive);
 
-  // Auto-expand the section when navigating into one of its pages.
   useEffect(() => {
     if (containsActive) setOpen(true);
   }, [containsActive]);
@@ -37,14 +59,17 @@ function NavSection({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between py-1 font-medium text-foreground hover:bg-muted"
+        className="flex w-full items-center justify-between px-2 py-2 text-foreground transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none"
       >
-        {section.label}
+        <span className="font-medium">{section.label}</span>
         <ChevronRight
-          className={cn("size-4 transition-transform", open && "rotate-90")}
+          className={cn(
+            "size-4 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none",
+            open && "rotate-90",
+          )}
         />
       </button>
-      {open ? (
+      <CollapsibleList open={open}>
         <ul>
           {section.items.map((item) => {
             if (isExternalItem(item)) {
@@ -54,7 +79,7 @@ function NavSection({
                     href={item.link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    className="block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none"
                   >
                     {item.label}
                   </a>
@@ -69,7 +94,7 @@ function NavSection({
                   href={href}
                   onClick={onNavigate}
                   className={cn(
-                    "block py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground",
+                    "block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none",
                     active && "bg-muted text-foreground",
                   )}
                 >
@@ -79,12 +104,12 @@ function NavSection({
             );
           })}
         </ul>
-      ) : null}
+      </CollapsibleList>
     </div>
   );
 }
 
-function NavTree({
+function NavTreeA({
   pathname,
   onNavigate,
 }: {
@@ -92,9 +117,9 @@ function NavTree({
   onNavigate?: () => void;
 }) {
   return (
-    <nav aria-label="Docs" className="flex flex-col gap-2 text-sm">
+    <nav aria-label="Docs" className="flex flex-col gap-1 text-sm">
       {docsNav.map((section) => (
-        <NavSection
+        <NavSectionA
           key={section.label}
           section={section}
           pathname={pathname}
@@ -105,12 +130,339 @@ function NavTree({
   );
 }
 
+// ─── Option B: Padded + left border indicator ───────────────────────────────
+
+function NavSectionB({
+  section,
+  pathname,
+  onNavigate,
+}: {
+  section: DocsNavSection;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const containsActive = section.items.some(
+    (item) => !isExternalItem(item) && pathname === `/docs/${item.slug}`,
+  );
+  const [open, setOpen] = useState(!section.collapsed || containsActive);
+
+  useEffect(() => {
+    if (containsActive) setOpen(true);
+  }, [containsActive]);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between py-2 text-foreground transition-colors duration-150 ease motion-reduce:transition-none hover:text-foreground/70"
+      >
+        <span className="font-medium">{section.label}</span>
+        <ChevronRight
+          className={cn(
+            "size-3.5 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none",
+            open && "rotate-90",
+          )}
+        />
+      </button>
+      <CollapsibleList open={open}>
+        <ul className="ml-0.5 border-l border-border">
+          {section.items.map((item) => {
+            if (isExternalItem(item)) {
+              return (
+                <li key={item.link}>
+                  <a
+                    href={item.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              );
+            }
+            const href = `/docs/${item.slug}`;
+            const active = pathname === href;
+            return (
+              <li key={item.slug}>
+                <Link
+                  href={href}
+                  onClick={onNavigate}
+                  className={cn(
+                    "-ml-px block border-l border-transparent py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:border-foreground/30 hover:text-foreground motion-reduce:transition-none",
+                    active && "border-foreground text-foreground",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </CollapsibleList>
+    </div>
+  );
+}
+
+function NavTreeB({
+  pathname,
+  onNavigate,
+}: {
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <nav aria-label="Docs" className="flex flex-col gap-1 text-sm">
+      {docsNav.map((section) => (
+        <NavSectionB
+          key={section.label}
+          section={section}
+          pathname={pathname}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </nav>
+  );
+}
+
+// ─── Option C: Muted background active + rounded pill ───────────────────────
+
+function NavSectionC({
+  section,
+  pathname,
+  onNavigate,
+}: {
+  section: DocsNavSection;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const containsActive = section.items.some(
+    (item) => !isExternalItem(item) && pathname === `/docs/${item.slug}`,
+  );
+  const [open, setOpen] = useState(!section.collapsed || containsActive);
+
+  useEffect(() => {
+    if (containsActive) setOpen(true);
+  }, [containsActive]);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between py-2 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors duration-150 ease motion-reduce:transition-none"
+      >
+        {section.label}
+        <ChevronRight
+          className={cn(
+            "size-3 transition-transform duration-150 ease-out motion-reduce:transition-none",
+            open && "rotate-90",
+          )}
+        />
+      </button>
+      <CollapsibleList open={open}>
+        <ul className="mt-0.5 flex flex-col gap-0.5">
+          {section.items.map((item) => {
+            if (isExternalItem(item)) {
+              return (
+                <li key={item.link}>
+                  <a
+                    href={item.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none"
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              );
+            }
+            const href = `/docs/${item.slug}`;
+            const active = pathname === href;
+            return (
+              <li key={item.slug}>
+                <Link
+                  href={href}
+                  onClick={onNavigate}
+                  className={cn(
+                    "block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none",
+                    active && "bg-muted text-foreground",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </CollapsibleList>
+    </div>
+  );
+}
+
+function NavTreeC({
+  pathname,
+  onNavigate,
+}: {
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <nav aria-label="Docs" className="flex flex-col gap-2 text-sm">
+      {docsNav.map((section) => (
+        <NavSectionC
+          key={section.label}
+          section={section}
+          pathname={pathname}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </nav>
+  );
+}
+
+// ─── Option D: Indented with subtle background band ─────────────────────────
+
+function NavSectionD({
+  section,
+  pathname,
+  onNavigate,
+}: {
+  section: DocsNavSection;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const containsActive = section.items.some(
+    (item) => !isExternalItem(item) && pathname === `/docs/${item.slug}`,
+  );
+  const [open, setOpen] = useState(!section.collapsed || containsActive);
+
+  useEffect(() => {
+    if (containsActive) setOpen(true);
+  }, [containsActive]);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between py-2 text-foreground transition-colors duration-150 ease motion-reduce:transition-none hover:text-foreground/70"
+      >
+        <span className="font-medium">{section.label}</span>
+        <ChevronRight
+          className={cn(
+            "size-3.5 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none",
+            open && "rotate-90",
+          )}
+        />
+      </button>
+      <CollapsibleList open={open}>
+        <ul className="mt-0.5 flex flex-col">
+          {section.items.map((item) => {
+            if (isExternalItem(item)) {
+              return (
+                <li key={item.link}>
+                  <a
+                    href={item.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block border-l-2 border-transparent py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              );
+            }
+            const href = `/docs/${item.slug}`;
+            const active = pathname === href;
+            return (
+              <li key={item.slug}>
+                <Link
+                  href={href}
+                  onClick={onNavigate}
+                  className={cn(
+                    "block border-l-2 border-transparent py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:bg-muted/50 hover:text-foreground motion-reduce:transition-none",
+                    active && "border-foreground bg-muted/50 text-foreground",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </CollapsibleList>
+    </div>
+  );
+}
+
+function NavTreeD({
+  pathname,
+  onNavigate,
+}: {
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <nav aria-label="Docs" className="flex flex-col gap-1 text-sm">
+      {docsNav.map((section) => (
+        <NavSectionD
+          key={section.label}
+          section={section}
+          pathname={pathname}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </nav>
+  );
+}
+
+// ─── Picker-wrapped exports ─────────────────────────────────────────────────
+
+function NavTreePicker({
+  pathname,
+  onNavigate,
+}: {
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <div data-uidotsh-pick="Sidebar style" className="contents">
+      <div data-uidotsh-option="Flat (current)" className="contents">
+        <NavTreeA pathname={pathname} onNavigate={onNavigate} />
+      </div>
+      <div
+        data-uidotsh-option="Left border indicator"
+        className="contents"
+        hidden
+      >
+        <NavTreeB pathname={pathname} onNavigate={onNavigate} />
+      </div>
+      <div
+        data-uidotsh-option="Rounded pill highlight"
+        className="contents"
+        hidden
+      >
+        <NavTreeC pathname={pathname} onNavigate={onNavigate} />
+      </div>
+      <div
+        data-uidotsh-option="Indent + background band"
+        className="contents"
+        hidden
+      >
+        <NavTreeD pathname={pathname} onNavigate={onNavigate} />
+      </div>
+    </div>
+  );
+}
+
 export function DocsSidebar({ className }: { className?: string }) {
   const pathname = usePathname();
   return (
     <aside className={className}>
       <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
-        <NavTree pathname={pathname} />
+        <NavTreePicker pathname={pathname} />
       </div>
     </aside>
   );
@@ -122,19 +474,22 @@ export function DocsMobileNav({ className }: { className?: string }) {
   return (
     <div className={className}>
       <Sheet open={open} onOpenChange={setOpen}>
-        <SheetTrigger className="mb-4 flex items-center gap-2 border border-border px-3 py-2 text-sm hover:bg-muted">
+        <SheetTrigger className="mb-4 flex items-center gap-2 border border-border px-3 py-2 text-sm transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none">
           <Menu className="size-4" />
           Docs menu
         </SheetTrigger>
         <SheetContent
           side="left"
-          className="gap-0 rounded-none p-0 font-mono sm:w-96"
+          className="gap-0 rounded-none p-0 font-sans sm:w-96"
         >
           <SheetTitle className="border-border border-b p-4 font-medium">
             Documentation
           </SheetTitle>
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
-            <NavTree pathname={pathname} onNavigate={() => setOpen(false)} />
+            <NavTreePicker
+              pathname={pathname}
+              onNavigate={() => setOpen(false)}
+            />
           </div>
         </SheetContent>
       </Sheet>

--- a/apps/web/src/content/docs-sidebar.tsx
+++ b/apps/web/src/content/docs-sidebar.tsx
@@ -7,7 +7,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@openstatus/ui/components/ui/sheet";
-import { ChevronRight, Menu } from "lucide-react";
+import { Menu } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -34,9 +34,7 @@ function CollapsibleList({
   );
 }
 
-// ─── Option A: Current (baseline) ───────────────────────────────────────────
-
-function NavSectionA({
+function NavSection({
   section,
   pathname,
   onNavigate,
@@ -59,15 +57,18 @@ function NavSectionA({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between px-2 py-2 text-foreground transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none"
+        className="group ease flex w-full items-center justify-between px-2 py-2 text-foreground transition-colors duration-150 hover:bg-muted motion-reduce:transition-none"
       >
-        <span className="font-medium">{section.label}</span>
-        <ChevronRight
+        <span className="font-medium font-mono">{section.label}</span>
+        <span
           className={cn(
-            "size-4 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none",
-            open && "rotate-90",
+            "relative top-[1px] shrink-0 origin-center text-[10px] text-muted-foreground transition duration-300 group-hover:text-foreground motion-reduce:transition-none",
+            open && "rotate-180 text-foreground",
           )}
-        />
+          aria-hidden="true"
+        >
+          ▲
+        </span>
       </button>
       <CollapsibleList open={open}>
         <ul>
@@ -79,7 +80,7 @@ function NavSectionA({
                     href={item.link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none"
+                    className="ease block px-2 py-2 text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground motion-reduce:transition-none"
                   >
                     {item.label}
                   </a>
@@ -94,7 +95,7 @@ function NavSectionA({
                   href={href}
                   onClick={onNavigate}
                   className={cn(
-                    "block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none",
+                    "ease block px-2 py-2 text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground motion-reduce:transition-none",
                     active && "bg-muted text-foreground",
                   )}
                 >
@@ -109,7 +110,7 @@ function NavSectionA({
   );
 }
 
-function NavTreeA({
+function NavTree({
   pathname,
   onNavigate,
 }: {
@@ -119,7 +120,7 @@ function NavTreeA({
   return (
     <nav aria-label="Docs" className="flex flex-col gap-1 text-sm">
       {docsNav.map((section) => (
-        <NavSectionA
+        <NavSection
           key={section.label}
           section={section}
           pathname={pathname}
@@ -127,333 +128,6 @@ function NavTreeA({
         />
       ))}
     </nav>
-  );
-}
-
-// ─── Option B: Padded + left border indicator ───────────────────────────────
-
-function NavSectionB({
-  section,
-  pathname,
-  onNavigate,
-}: {
-  section: DocsNavSection;
-  pathname: string;
-  onNavigate?: () => void;
-}) {
-  const containsActive = section.items.some(
-    (item) => !isExternalItem(item) && pathname === `/docs/${item.slug}`,
-  );
-  const [open, setOpen] = useState(!section.collapsed || containsActive);
-
-  useEffect(() => {
-    if (containsActive) setOpen(true);
-  }, [containsActive]);
-
-  return (
-    <div>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between py-2 text-foreground transition-colors duration-150 ease motion-reduce:transition-none hover:text-foreground/70"
-      >
-        <span className="font-medium">{section.label}</span>
-        <ChevronRight
-          className={cn(
-            "size-3.5 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none",
-            open && "rotate-90",
-          )}
-        />
-      </button>
-      <CollapsibleList open={open}>
-        <ul className="ml-0.5 border-l border-border">
-          {section.items.map((item) => {
-            if (isExternalItem(item)) {
-              return (
-                <li key={item.link}>
-                  <a
-                    href={item.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
-                  >
-                    {item.label}
-                  </a>
-                </li>
-              );
-            }
-            const href = `/docs/${item.slug}`;
-            const active = pathname === href;
-            return (
-              <li key={item.slug}>
-                <Link
-                  href={href}
-                  onClick={onNavigate}
-                  className={cn(
-                    "-ml-px block border-l border-transparent py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:border-foreground/30 hover:text-foreground motion-reduce:transition-none",
-                    active && "border-foreground text-foreground",
-                  )}
-                >
-                  {item.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </CollapsibleList>
-    </div>
-  );
-}
-
-function NavTreeB({
-  pathname,
-  onNavigate,
-}: {
-  pathname: string;
-  onNavigate?: () => void;
-}) {
-  return (
-    <nav aria-label="Docs" className="flex flex-col gap-1 text-sm">
-      {docsNav.map((section) => (
-        <NavSectionB
-          key={section.label}
-          section={section}
-          pathname={pathname}
-          onNavigate={onNavigate}
-        />
-      ))}
-    </nav>
-  );
-}
-
-// ─── Option C: Muted background active + rounded pill ───────────────────────
-
-function NavSectionC({
-  section,
-  pathname,
-  onNavigate,
-}: {
-  section: DocsNavSection;
-  pathname: string;
-  onNavigate?: () => void;
-}) {
-  const containsActive = section.items.some(
-    (item) => !isExternalItem(item) && pathname === `/docs/${item.slug}`,
-  );
-  const [open, setOpen] = useState(!section.collapsed || containsActive);
-
-  useEffect(() => {
-    if (containsActive) setOpen(true);
-  }, [containsActive]);
-
-  return (
-    <div>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between py-2 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors duration-150 ease motion-reduce:transition-none"
-      >
-        {section.label}
-        <ChevronRight
-          className={cn(
-            "size-3 transition-transform duration-150 ease-out motion-reduce:transition-none",
-            open && "rotate-90",
-          )}
-        />
-      </button>
-      <CollapsibleList open={open}>
-        <ul className="mt-0.5 flex flex-col gap-0.5">
-          {section.items.map((item) => {
-            if (isExternalItem(item)) {
-              return (
-                <li key={item.link}>
-                  <a
-                    href={item.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none"
-                  >
-                    {item.label}
-                  </a>
-                </li>
-              );
-            }
-            const href = `/docs/${item.slug}`;
-            const active = pathname === href;
-            return (
-              <li key={item.slug}>
-                <Link
-                  href={href}
-                  onClick={onNavigate}
-                  className={cn(
-                    "block px-2 py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none",
-                    active && "bg-muted text-foreground",
-                  )}
-                >
-                  {item.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </CollapsibleList>
-    </div>
-  );
-}
-
-function NavTreeC({
-  pathname,
-  onNavigate,
-}: {
-  pathname: string;
-  onNavigate?: () => void;
-}) {
-  return (
-    <nav aria-label="Docs" className="flex flex-col gap-2 text-sm">
-      {docsNav.map((section) => (
-        <NavSectionC
-          key={section.label}
-          section={section}
-          pathname={pathname}
-          onNavigate={onNavigate}
-        />
-      ))}
-    </nav>
-  );
-}
-
-// ─── Option D: Indented with subtle background band ─────────────────────────
-
-function NavSectionD({
-  section,
-  pathname,
-  onNavigate,
-}: {
-  section: DocsNavSection;
-  pathname: string;
-  onNavigate?: () => void;
-}) {
-  const containsActive = section.items.some(
-    (item) => !isExternalItem(item) && pathname === `/docs/${item.slug}`,
-  );
-  const [open, setOpen] = useState(!section.collapsed || containsActive);
-
-  useEffect(() => {
-    if (containsActive) setOpen(true);
-  }, [containsActive]);
-
-  return (
-    <div>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between py-2 text-foreground transition-colors duration-150 ease motion-reduce:transition-none hover:text-foreground/70"
-      >
-        <span className="font-medium">{section.label}</span>
-        <ChevronRight
-          className={cn(
-            "size-3.5 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none",
-            open && "rotate-90",
-          )}
-        />
-      </button>
-      <CollapsibleList open={open}>
-        <ul className="mt-0.5 flex flex-col">
-          {section.items.map((item) => {
-            if (isExternalItem(item)) {
-              return (
-                <li key={item.link}>
-                  <a
-                    href={item.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block border-l-2 border-transparent py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
-                  >
-                    {item.label}
-                  </a>
-                </li>
-              );
-            }
-            const href = `/docs/${item.slug}`;
-            const active = pathname === href;
-            return (
-              <li key={item.slug}>
-                <Link
-                  href={href}
-                  onClick={onNavigate}
-                  className={cn(
-                    "block border-l-2 border-transparent py-2 pl-3 text-muted-foreground transition-colors duration-150 ease hover:bg-muted/50 hover:text-foreground motion-reduce:transition-none",
-                    active && "border-foreground bg-muted/50 text-foreground",
-                  )}
-                >
-                  {item.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </CollapsibleList>
-    </div>
-  );
-}
-
-function NavTreeD({
-  pathname,
-  onNavigate,
-}: {
-  pathname: string;
-  onNavigate?: () => void;
-}) {
-  return (
-    <nav aria-label="Docs" className="flex flex-col gap-1 text-sm">
-      {docsNav.map((section) => (
-        <NavSectionD
-          key={section.label}
-          section={section}
-          pathname={pathname}
-          onNavigate={onNavigate}
-        />
-      ))}
-    </nav>
-  );
-}
-
-// ─── Picker-wrapped exports ─────────────────────────────────────────────────
-
-function NavTreePicker({
-  pathname,
-  onNavigate,
-}: {
-  pathname: string;
-  onNavigate?: () => void;
-}) {
-  return (
-    <div data-uidotsh-pick="Sidebar style" className="contents">
-      <div data-uidotsh-option="Flat (current)" className="contents">
-        <NavTreeA pathname={pathname} onNavigate={onNavigate} />
-      </div>
-      <div
-        data-uidotsh-option="Left border indicator"
-        className="contents"
-        hidden
-      >
-        <NavTreeB pathname={pathname} onNavigate={onNavigate} />
-      </div>
-      <div
-        data-uidotsh-option="Rounded pill highlight"
-        className="contents"
-        hidden
-      >
-        <NavTreeC pathname={pathname} onNavigate={onNavigate} />
-      </div>
-      <div
-        data-uidotsh-option="Indent + background band"
-        className="contents"
-        hidden
-      >
-        <NavTreeD pathname={pathname} onNavigate={onNavigate} />
-      </div>
-    </div>
   );
 }
 
@@ -462,7 +136,7 @@ export function DocsSidebar({ className }: { className?: string }) {
   return (
     <aside className={className}>
       <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
-        <NavTreePicker pathname={pathname} />
+        <NavTree pathname={pathname} />
       </div>
     </aside>
   );
@@ -474,7 +148,7 @@ export function DocsMobileNav({ className }: { className?: string }) {
   return (
     <div className={className}>
       <Sheet open={open} onOpenChange={setOpen}>
-        <SheetTrigger className="mb-4 flex items-center gap-2 border border-border px-3 py-2 text-sm transition-colors duration-150 ease hover:bg-muted motion-reduce:transition-none">
+        <SheetTrigger className="ease mb-4 font-mono flex items-center gap-2 border border-border px-3 py-2 text-sm transition-colors duration-150 hover:bg-muted motion-reduce:transition-none">
           <Menu className="size-4" />
           Docs menu
         </SheetTrigger>
@@ -486,10 +160,7 @@ export function DocsMobileNav({ className }: { className?: string }) {
             Documentation
           </SheetTitle>
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
-            <NavTreePicker
-              pathname={pathname}
-              onNavigate={() => setOpen(false)}
-            />
+            <NavTree pathname={pathname} onNavigate={() => setOpen(false)} />
           </div>
         </SheetContent>
       </Sheet>

--- a/apps/web/src/content/docs-sub-nav.tsx
+++ b/apps/web/src/content/docs-sub-nav.tsx
@@ -1,34 +1,186 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Fragment } from "react";
 import { CopyDropdownButton } from "./copy-button";
 
+function capitalize(str: string) {
+  return str
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+// ─── Option A: Pipe separator (current) ─────────────────────────────────────
+
+function BreadcrumbA({ segments }: { segments: string[] }) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex items-center gap-1 text-sm text-muted-foreground">
+        {segments.map((segment, index) => (
+          <Fragment key={segment}>
+            <li>
+              <Link
+                href={`/${segments.slice(0, index + 1).join("/")}`}
+                className="py-1 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+              >
+                {capitalize(segment)}
+              </Link>
+            </li>
+            {index < segments.length - 1 ? (
+              <li aria-hidden>
+                <span className="text-muted-foreground/40">|</span>
+              </li>
+            ) : null}
+          </Fragment>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+// ─── Option B: Chevron separator with current page ──────────────────────────
+
+function BreadcrumbB({
+  segments,
+  currentPage,
+}: { segments: string[]; currentPage: string }) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex items-center gap-1 text-sm text-muted-foreground">
+        {segments.map((segment, index) => (
+          <Fragment key={segment}>
+            <li>
+              <Link
+                href={`/${segments.slice(0, index + 1).join("/")}`}
+                className="py-1 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+              >
+                {capitalize(segment)}
+              </Link>
+            </li>
+            <li aria-hidden>
+              <ChevronRight className="size-3 text-muted-foreground/50" />
+            </li>
+          </Fragment>
+        ))}
+        <li>
+          <span className="py-1 text-foreground">{currentPage}</span>
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+// ─── Option C: Slash separator with current page ────────────────────────────
+
+function BreadcrumbC({
+  segments,
+  currentPage,
+}: { segments: string[]; currentPage: string }) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        {segments.map((segment, index) => (
+          <Fragment key={segment}>
+            <li>
+              <Link
+                href={`/${segments.slice(0, index + 1).join("/")}`}
+                className="py-1 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+              >
+                {capitalize(segment)}
+              </Link>
+            </li>
+            <li aria-hidden>
+              <span className="text-muted-foreground/40">/</span>
+            </li>
+          </Fragment>
+        ))}
+        <li>
+          <span className="py-1 text-foreground">{currentPage}</span>
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+// ─── Option D: Minimal path ─────────────────────────────────────────────────
+
+function BreadcrumbD({
+  segments,
+  currentPage,
+}: { segments: string[]; currentPage: string }) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex items-baseline gap-1.5 text-sm">
+        {segments.map((segment, index) => (
+          <Fragment key={segment}>
+            <li>
+              <Link
+                href={`/${segments.slice(0, index + 1).join("/")}`}
+                className="py-1 text-muted-foreground/50 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
+              >
+                {capitalize(segment)}
+              </Link>
+            </li>
+            <li aria-hidden>
+              <span className="text-muted-foreground/30">/</span>
+            </li>
+          </Fragment>
+        ))}
+        <li>
+          <span className="py-1 text-foreground">{currentPage}</span>
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+// ─── Picker-wrapped export ──────────────────────────────────────────────────
+
 export function DocsSubNav({
   className,
+  title,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<"div"> & { title?: string }) {
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean).slice(0, -1);
+  const currentPage = title || capitalize(
+    pathname.split("/").filter(Boolean).pop() ?? "",
+  );
 
   return (
     <div
       className={cn("flex items-center justify-between gap-2", className)}
       {...props}
     >
-      <div className="prose text-muted-foreground">
-        {segments.map((segment, index) => (
-          <Fragment key={segment}>
-            <Link href={`/${segments.slice(0, index + 1).join("/")}`}>
-              {segment.split("-").join(" ")}
-            </Link>
-            {index < segments.length - 1 ? (
-              <span className="text-muted-foreground">{" | "}</span>
-            ) : null}
-          </Fragment>
-        ))}
+      <div data-uidotsh-pick="Breadcrumb style" className="contents">
+        <div data-uidotsh-option="Pipe (current)" className="contents">
+          <BreadcrumbA segments={segments} />
+        </div>
+        <div
+          data-uidotsh-option="Chevron + current page"
+          className="contents"
+          hidden
+        >
+          <BreadcrumbB segments={segments} currentPage={currentPage} />
+        </div>
+        <div
+          data-uidotsh-option="Slash + current page"
+          className="contents"
+          hidden
+        >
+          <BreadcrumbC segments={segments} currentPage={currentPage} />
+        </div>
+        <div
+          data-uidotsh-option="Minimal path"
+          className="contents"
+          hidden
+        >
+          <BreadcrumbD segments={segments} currentPage={currentPage} />
+        </div>
       </div>
       <CopyDropdownButton className="p-0" />
     </div>

--- a/apps/web/src/content/docs-sub-nav.tsx
+++ b/apps/web/src/content/docs-sub-nav.tsx
@@ -147,9 +147,8 @@ export function DocsSubNav({
 }: React.ComponentProps<"div"> & { title?: string }) {
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean).slice(0, -1);
-  const currentPage = title || capitalize(
-    pathname.split("/").filter(Boolean).pop() ?? "",
-  );
+  const currentPage =
+    title || capitalize(pathname.split("/").filter(Boolean).pop() ?? "");
 
   return (
     <div
@@ -174,11 +173,7 @@ export function DocsSubNav({
         >
           <BreadcrumbC segments={segments} currentPage={currentPage} />
         </div>
-        <div
-          data-uidotsh-option="Minimal path"
-          className="contents"
-          hidden
-        >
+        <div data-uidotsh-option="Minimal path" className="contents" hidden>
           <BreadcrumbD segments={segments} currentPage={currentPage} />
         </div>
       </div>

--- a/apps/web/src/content/docs-sub-nav.tsx
+++ b/apps/web/src/content/docs-sub-nav.tsx
@@ -1,181 +1,40 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Fragment } from "react";
 import { CopyDropdownButton } from "./copy-button";
 
-function capitalize(str: string) {
-  return str
-    .split("-")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
-}
-
-// ─── Option A: Pipe separator (current) ─────────────────────────────────────
-
-function BreadcrumbA({ segments }: { segments: string[] }) {
-  return (
-    <nav aria-label="Breadcrumb">
-      <ol className="flex items-center gap-1 text-sm text-muted-foreground">
-        {segments.map((segment, index) => (
-          <Fragment key={segment}>
-            <li>
-              <Link
-                href={`/${segments.slice(0, index + 1).join("/")}`}
-                className="py-1 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
-              >
-                {capitalize(segment)}
-              </Link>
-            </li>
-            {index < segments.length - 1 ? (
-              <li aria-hidden>
-                <span className="text-muted-foreground/40">|</span>
-              </li>
-            ) : null}
-          </Fragment>
-        ))}
-      </ol>
-    </nav>
-  );
-}
-
-// ─── Option B: Chevron separator with current page ──────────────────────────
-
-function BreadcrumbB({
-  segments,
-  currentPage,
-}: { segments: string[]; currentPage: string }) {
-  return (
-    <nav aria-label="Breadcrumb">
-      <ol className="flex items-center gap-1 text-sm text-muted-foreground">
-        {segments.map((segment, index) => (
-          <Fragment key={segment}>
-            <li>
-              <Link
-                href={`/${segments.slice(0, index + 1).join("/")}`}
-                className="py-1 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
-              >
-                {capitalize(segment)}
-              </Link>
-            </li>
-            <li aria-hidden>
-              <ChevronRight className="size-3 text-muted-foreground/50" />
-            </li>
-          </Fragment>
-        ))}
-        <li>
-          <span className="py-1 text-foreground">{currentPage}</span>
-        </li>
-      </ol>
-    </nav>
-  );
-}
-
-// ─── Option C: Slash separator with current page ────────────────────────────
-
-function BreadcrumbC({
-  segments,
-  currentPage,
-}: { segments: string[]; currentPage: string }) {
-  return (
-    <nav aria-label="Breadcrumb">
-      <ol className="flex items-center gap-1.5 text-sm text-muted-foreground">
-        {segments.map((segment, index) => (
-          <Fragment key={segment}>
-            <li>
-              <Link
-                href={`/${segments.slice(0, index + 1).join("/")}`}
-                className="py-1 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
-              >
-                {capitalize(segment)}
-              </Link>
-            </li>
-            <li aria-hidden>
-              <span className="text-muted-foreground/40">/</span>
-            </li>
-          </Fragment>
-        ))}
-        <li>
-          <span className="py-1 text-foreground">{currentPage}</span>
-        </li>
-      </ol>
-    </nav>
-  );
-}
-
-// ─── Option D: Minimal path ─────────────────────────────────────────────────
-
-function BreadcrumbD({
-  segments,
-  currentPage,
-}: { segments: string[]; currentPage: string }) {
-  return (
-    <nav aria-label="Breadcrumb">
-      <ol className="flex items-baseline gap-1.5 text-sm">
-        {segments.map((segment, index) => (
-          <Fragment key={segment}>
-            <li>
-              <Link
-                href={`/${segments.slice(0, index + 1).join("/")}`}
-                className="py-1 text-muted-foreground/50 transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none"
-              >
-                {capitalize(segment)}
-              </Link>
-            </li>
-            <li aria-hidden>
-              <span className="text-muted-foreground/30">/</span>
-            </li>
-          </Fragment>
-        ))}
-        <li>
-          <span className="py-1 text-foreground">{currentPage}</span>
-        </li>
-      </ol>
-    </nav>
-  );
-}
-
-// ─── Picker-wrapped export ──────────────────────────────────────────────────
-
 export function DocsSubNav({
   className,
-  title,
   ...props
-}: React.ComponentProps<"div"> & { title?: string }) {
+}: React.ComponentProps<"div">) {
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean).slice(0, -1);
-  const currentPage =
-    title || capitalize(pathname.split("/").filter(Boolean).pop() ?? "");
 
   return (
     <div
-      className={cn("flex items-center justify-between gap-2", className)}
+      className={cn(
+        "flex items-center justify-between gap-2 font-mono",
+        className,
+      )}
       {...props}
     >
-      <div data-uidotsh-pick="Breadcrumb style" className="contents">
-        <div data-uidotsh-option="Pipe (current)" className="contents">
-          <BreadcrumbA segments={segments} />
-        </div>
-        <div
-          data-uidotsh-option="Chevron + current page"
-          className="contents"
-          hidden
-        >
-          <BreadcrumbB segments={segments} currentPage={currentPage} />
-        </div>
-        <div
-          data-uidotsh-option="Slash + current page"
-          className="contents"
-          hidden
-        >
-          <BreadcrumbC segments={segments} currentPage={currentPage} />
-        </div>
-        <div data-uidotsh-option="Minimal path" className="contents" hidden>
-          <BreadcrumbD segments={segments} currentPage={currentPage} />
-        </div>
+      <div className="text-muted-foreground">
+        {segments.map((segment, index) => (
+          <Fragment key={segment}>
+            <Link
+              href={`/${segments.slice(0, index + 1).join("/")}`}
+              className="ease transition-colors duration-150 hover:text-foreground motion-reduce:transition-none"
+            >
+              {segment.split("-").join(" ")}
+            </Link>
+            {index < segments.length - 1 ? (
+              <span className="text-muted-foreground">{" | "}</span>
+            ) : null}
+          </Fragment>
+        ))}
       </div>
       <CopyDropdownButton className="p-0" />
     </div>

--- a/apps/web/src/content/docs-toc.tsx
+++ b/apps/web/src/content/docs-toc.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { TocItem } from "./toc";
 
 function useActiveHeading(items: TocItem[]) {
@@ -30,19 +30,21 @@ function useActiveHeading(items: TocItem[]) {
   return active;
 }
 
-// ─── Option A: Flat (current) ───────────────────────────────────────────────
+export function TableOfContents({ items }: { items: TocItem[] }) {
+  const active = useActiveHeading(items);
 
-function TocA({ items, active }: { items: TocItem[]; active?: string }) {
+  if (items.length === 0) return null;
+
   return (
     <nav aria-label="Table of contents" className="text-sm">
-      <p className="mb-3 font-medium text-foreground">On this page</p>
+      <p className="mb-3 font-medium font-mono text-foreground">On this page</p>
       <ul>
         {items.map((item) => (
           <li key={item.slug}>
             <a
               href={`#${item.slug}`}
               className={cn(
-                "block py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none",
+                "ease block py-2 text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground motion-reduce:transition-none",
                 item.depth === 2 ? "pl-2" : "pl-4",
                 active === item.slug && "bg-muted text-foreground",
               )}
@@ -53,173 +55,5 @@ function TocA({ items, active }: { items: TocItem[]; active?: string }) {
         ))}
       </ul>
     </nav>
-  );
-}
-
-// ─── Option B: Sliding border track ─────────────────────────────────────────
-// A vertical border with a highlight segment that visually slides to the
-// active heading. Uses a CSS custom property on the <ul> to position a
-// pseudo-element at the active item's offset.
-
-function TocB({ items, active }: { items: TocItem[]; active?: string }) {
-  const listRef = useRef<HTMLUListElement>(null);
-  const [marker, setMarker] = useState({ top: 0, height: 0 });
-
-  useEffect(() => {
-    if (!active || !listRef.current) return;
-    const activeEl = listRef.current.querySelector(
-      `[data-toc-slug="${active}"]`,
-    ) as HTMLElement | null;
-    if (!activeEl) return;
-    const listRect = listRef.current.getBoundingClientRect();
-    const elRect = activeEl.getBoundingClientRect();
-    setMarker({
-      top: elRect.top - listRect.top,
-      height: elRect.height,
-    });
-  }, [active]);
-
-  return (
-    <nav aria-label="Table of contents" className="text-sm">
-      <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        On this page
-      </p>
-      <div className="relative">
-        <div className="absolute top-0 left-0 bottom-0 w-px bg-border" />
-        <div
-          className="absolute left-0 w-px bg-foreground transition-all duration-200 ease-out motion-reduce:transition-none"
-          style={{ top: marker.top, height: marker.height }}
-        />
-        <ul ref={listRef}>
-          {items.map((item) => (
-            <li key={item.slug}>
-              <a
-                href={`#${item.slug}`}
-                data-toc-slug={item.slug}
-                className={cn(
-                  "block py-1.5 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none",
-                  item.depth === 2 ? "pl-3" : "pl-5",
-                  active === item.slug && "text-foreground",
-                )}
-              >
-                {item.text}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </nav>
-  );
-}
-
-// ─── Option C: Numbered sections ────────────────────────────────────────────
-// Each h2 gets an auto-incrementing number, h3s indent without a number.
-// The number transitions from muted to foreground when active.
-
-function TocC({ items, active }: { items: TocItem[]; active?: string }) {
-  let h2Index = 0;
-  return (
-    <nav aria-label="Table of contents" className="text-sm">
-      <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        On this page
-      </p>
-      <ul className="flex flex-col">
-        {items.map((item) => {
-          const isH2 = item.depth === 2;
-          if (isH2) h2Index++;
-          return (
-            <li key={item.slug}>
-              <a
-                href={`#${item.slug}`}
-                className={cn(
-                  "group flex items-baseline gap-2.5 py-1.5 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none",
-                  !isH2 && "ml-7",
-                  active === item.slug && "text-foreground",
-                )}
-              >
-                {isH2 ? (
-                  <span
-                    className={cn(
-                      "w-4 shrink-0 text-right tabular-nums text-xs text-muted-foreground/50 transition-colors duration-150 ease group-hover:text-muted-foreground motion-reduce:transition-none",
-                      active === item.slug && "text-foreground/60",
-                    )}
-                  >
-                    {String(h2Index).padStart(2, "0")}
-                  </span>
-                ) : null}
-                <span>{item.text}</span>
-              </a>
-            </li>
-          );
-        })}
-      </ul>
-    </nav>
-  );
-}
-
-// ─── Option D: Minimal fade ────────────────────────────────────────────────
-// No indicators at all. Inactive items are heavily faded, active item is
-// full contrast. The contrast change IS the indicator. Cleanest possible.
-
-function TocD({ items, active }: { items: TocItem[]; active?: string }) {
-  const hasActive = active != null;
-  return (
-    <nav aria-label="Table of contents" className="text-sm">
-      <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        On this page
-      </p>
-      <ul className="flex flex-col">
-        {items.map((item) => {
-          const isActive = active === item.slug;
-          return (
-            <li key={item.slug}>
-              <a
-                href={`#${item.slug}`}
-                className={cn(
-                  "block py-1.5 transition-colors duration-200 ease hover:text-foreground motion-reduce:transition-none",
-                  item.depth > 2 && "ml-3",
-                  isActive
-                    ? "text-foreground"
-                    : hasActive
-                      ? "text-muted-foreground/40"
-                      : "text-muted-foreground",
-                )}
-              >
-                {item.text}
-              </a>
-            </li>
-          );
-        })}
-      </ul>
-    </nav>
-  );
-}
-
-// ─── Picker-wrapped export ──────────────────────────────────────────────────
-
-export function TableOfContents({ items }: { items: TocItem[] }) {
-  const active = useActiveHeading(items);
-
-  if (items.length === 0) return null;
-
-  return (
-    <div data-uidotsh-pick="TOC style" className="contents">
-      <div data-uidotsh-option="Flat (current)" className="contents">
-        <TocA items={items} active={active} />
-      </div>
-      <div
-        data-uidotsh-option="Sliding border track"
-        className="contents"
-        hidden
-      >
-        <TocB items={items} active={active} />
-      </div>
-      <div data-uidotsh-option="Numbered sections" className="contents" hidden>
-        <TocC items={items} active={active} />
-      </div>
-      <div data-uidotsh-option="Minimal fade" className="contents" hidden>
-        <TocD items={items} active={active} />
-      </div>
-    </div>
   );
 }

--- a/apps/web/src/content/docs-toc.tsx
+++ b/apps/web/src/content/docs-toc.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { TocItem } from "./toc";
 
-export function TableOfContents({ items }: { items: TocItem[] }) {
+function useActiveHeading(items: TocItem[]) {
   const [active, setActive] = useState<string>();
 
   useEffect(() => {
@@ -27,8 +27,12 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
     return () => observer.disconnect();
   }, [items]);
 
-  if (items.length === 0) return null;
+  return active;
+}
 
+// ─── Option A: Flat (current) ───────────────────────────────────────────────
+
+function TocA({ items, active }: { items: TocItem[]; active?: string }) {
   return (
     <nav aria-label="Table of contents" className="text-sm">
       <p className="mb-3 font-medium text-foreground">On this page</p>
@@ -38,7 +42,7 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
             <a
               href={`#${item.slug}`}
               className={cn(
-                "block py-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+                "block py-2 text-muted-foreground transition-colors duration-150 ease hover:bg-muted hover:text-foreground motion-reduce:transition-none",
                 item.depth === 2 ? "pl-2" : "pl-4",
                 active === item.slug && "bg-muted text-foreground",
               )}
@@ -49,5 +53,181 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
         ))}
       </ul>
     </nav>
+  );
+}
+
+// ─── Option B: Sliding border track ─────────────────────────────────────────
+// A vertical border with a highlight segment that visually slides to the
+// active heading. Uses a CSS custom property on the <ul> to position a
+// pseudo-element at the active item's offset.
+
+function TocB({ items, active }: { items: TocItem[]; active?: string }) {
+  const listRef = useRef<HTMLUListElement>(null);
+  const [marker, setMarker] = useState({ top: 0, height: 0 });
+
+  useEffect(() => {
+    if (!active || !listRef.current) return;
+    const activeEl = listRef.current.querySelector(
+      `[data-toc-slug="${active}"]`,
+    ) as HTMLElement | null;
+    if (!activeEl) return;
+    const listRect = listRef.current.getBoundingClientRect();
+    const elRect = activeEl.getBoundingClientRect();
+    setMarker({
+      top: elRect.top - listRect.top,
+      height: elRect.height,
+    });
+  }, [active]);
+
+  return (
+    <nav aria-label="Table of contents" className="text-sm">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        On this page
+      </p>
+      <div className="relative">
+        <div className="absolute top-0 left-0 bottom-0 w-px bg-border" />
+        <div
+          className="absolute left-0 w-px bg-foreground transition-all duration-200 ease-out motion-reduce:transition-none"
+          style={{ top: marker.top, height: marker.height }}
+        />
+        <ul ref={listRef}>
+          {items.map((item) => (
+            <li key={item.slug}>
+              <a
+                href={`#${item.slug}`}
+                data-toc-slug={item.slug}
+                className={cn(
+                  "block py-1.5 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none",
+                  item.depth === 2 ? "pl-3" : "pl-5",
+                  active === item.slug && "text-foreground",
+                )}
+              >
+                {item.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+}
+
+// ─── Option C: Numbered sections ────────────────────────────────────────────
+// Each h2 gets an auto-incrementing number, h3s indent without a number.
+// The number transitions from muted to foreground when active.
+
+function TocC({ items, active }: { items: TocItem[]; active?: string }) {
+  let h2Index = 0;
+  return (
+    <nav aria-label="Table of contents" className="text-sm">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        On this page
+      </p>
+      <ul className="flex flex-col">
+        {items.map((item) => {
+          const isH2 = item.depth === 2;
+          if (isH2) h2Index++;
+          return (
+            <li key={item.slug}>
+              <a
+                href={`#${item.slug}`}
+                className={cn(
+                  "group flex items-baseline gap-2.5 py-1.5 text-muted-foreground transition-colors duration-150 ease hover:text-foreground motion-reduce:transition-none",
+                  !isH2 && "ml-7",
+                  active === item.slug && "text-foreground",
+                )}
+              >
+                {isH2 ? (
+                  <span
+                    className={cn(
+                      "w-4 shrink-0 text-right tabular-nums text-xs text-muted-foreground/50 transition-colors duration-150 ease group-hover:text-muted-foreground motion-reduce:transition-none",
+                      active === item.slug && "text-foreground/60",
+                    )}
+                  >
+                    {String(h2Index).padStart(2, "0")}
+                  </span>
+                ) : null}
+                <span>{item.text}</span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+// ─── Option D: Minimal fade ────────────────────────────────────────────────
+// No indicators at all. Inactive items are heavily faded, active item is
+// full contrast. The contrast change IS the indicator. Cleanest possible.
+
+function TocD({ items, active }: { items: TocItem[]; active?: string }) {
+  const hasActive = active != null;
+  return (
+    <nav aria-label="Table of contents" className="text-sm">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        On this page
+      </p>
+      <ul className="flex flex-col">
+        {items.map((item) => {
+          const isActive = active === item.slug;
+          return (
+            <li key={item.slug}>
+              <a
+                href={`#${item.slug}`}
+                className={cn(
+                  "block py-1.5 transition-colors duration-200 ease hover:text-foreground motion-reduce:transition-none",
+                  item.depth > 2 && "ml-3",
+                  isActive
+                    ? "text-foreground"
+                    : hasActive
+                      ? "text-muted-foreground/40"
+                      : "text-muted-foreground",
+                )}
+              >
+                {item.text}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+// ─── Picker-wrapped export ──────────────────────────────────────────────────
+
+export function TableOfContents({ items }: { items: TocItem[] }) {
+  const active = useActiveHeading(items);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div data-uidotsh-pick="TOC style" className="contents">
+      <div data-uidotsh-option="Flat (current)" className="contents">
+        <TocA items={items} active={active} />
+      </div>
+      <div
+        data-uidotsh-option="Sliding border track"
+        className="contents"
+        hidden
+      >
+        <TocB items={items} active={active} />
+      </div>
+      <div
+        data-uidotsh-option="Numbered sections"
+        className="contents"
+        hidden
+      >
+        <TocC items={items} active={active} />
+      </div>
+      <div
+        data-uidotsh-option="Minimal fade"
+        className="contents"
+        hidden
+      >
+        <TocD items={items} active={active} />
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/content/docs-toc.tsx
+++ b/apps/web/src/content/docs-toc.tsx
@@ -214,18 +214,10 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
       >
         <TocB items={items} active={active} />
       </div>
-      <div
-        data-uidotsh-option="Numbered sections"
-        className="contents"
-        hidden
-      >
+      <div data-uidotsh-option="Numbered sections" className="contents" hidden>
         <TocC items={items} active={active} />
       </div>
-      <div
-        data-uidotsh-option="Minimal fade"
-        className="contents"
-        hidden
-      >
+      <div data-uidotsh-option="Minimal fade" className="contents" hidden>
         <TocD items={items} active={active} />
       </div>
     </div>

--- a/apps/web/src/content/header.tsx
+++ b/apps/web/src/content/header.tsx
@@ -18,7 +18,7 @@ export function Header() {
           <DropdownMenuTrigger className="group flex items-center gap-1 data-[state=open]:bg-muted">
             <span className="w-full truncate text-left">{section.label}</span>
             <span
-              className="relative top-[1px] shrink-0 origin-center text-[10px] text-muted-foreground transition duration-300 group-hover:text-foreground group-data-[state=open]:rotate-180 group-data-[state=open]:text-foreground"
+              className="relative top-[1px] shrink-0 origin-center font-sans text-[10px] text-muted-foreground transition duration-300 group-hover:text-foreground group-data-[state=open]:rotate-180 group-data-[state=open]:text-foreground"
               aria-hidden="true"
             >
               ▲

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -193,15 +193,15 @@
 }
 
 .prose h2 {
-  @apply text-2xl text-foreground font-semibold tracking-tight mt-12 mb-4 pt-8 border-t border-border/60 relative scroll-mt-20;
+  @apply text-2xl text-foreground font-semibold tracking-tight mt-12 mb-4 pt-8 border-t border-border/60 relative scroll-mt-12;
 }
 
 .prose h3 {
-  @apply text-xl text-foreground font-medium tracking-tight mt-8 mb-3 relative scroll-mt-20;
+  @apply text-xl text-foreground font-medium tracking-tight mt-8 mb-3 relative scroll-mt-8;
 }
 
 .prose h4 {
-  @apply text-lg text-foreground font-medium tracking-tight mt-6 mb-2 relative scroll-mt-20;
+  @apply text-lg text-foreground font-medium tracking-tight mt-6 mb-2 relative scroll-mt-6;
 }
 
 .prose hr {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -145,7 +145,7 @@
 }
 
 .prose a {
-  @apply text-foreground underline transition-all decoration-muted-foreground/50 underline-offset-2 decoration-2 hover:decoration-muted-foreground;
+  @apply text-foreground underline decoration-muted-foreground/50 underline-offset-2 decoration-2 hover:decoration-muted-foreground transition-colors duration-150 motion-reduce:transition-none;
 }
 
 .prose .anchor:after {
@@ -193,15 +193,15 @@
 }
 
 .prose h2 {
-  @apply text-2xl text-foreground font-semibold tracking-tight mt-12 mb-4 pt-8 border-t border-border/60 relative;
+  @apply text-2xl text-foreground font-semibold tracking-tight mt-12 mb-4 pt-8 border-t border-border/60 relative scroll-mt-20;
 }
 
 .prose h3 {
-  @apply text-xl text-foreground font-medium tracking-tight mt-8 mb-3 relative;
+  @apply text-xl text-foreground font-medium tracking-tight mt-8 mb-3 relative scroll-mt-20;
 }
 
 .prose h4 {
-  @apply text-lg text-foreground font-medium tracking-tight mt-6 mb-2 relative;
+  @apply text-lg text-foreground font-medium tracking-tight mt-6 mb-2 relative scroll-mt-20;
 }
 
 .prose hr {
@@ -231,7 +231,7 @@
 }
 
 .prose figure img {
-  @apply aspect-video object-cover border border-border;
+  @apply aspect-video object-cover border border-border outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10;
 }
 
 .prose figure figcaption {


### PR DESCRIPTION
## Summary

- Switched docs from monospace to Inter for better readability
- Added **design variant pickers** (sidebar, TOC, breadcrumbs) — toggle via the ui.sh toolbar at the bottom of the page
- Redesigned copy-link button with animated icon cross-fade and dropdown
- Aligned header columns with sidebar / main content / TOC widths
- Added font smoothing, heading scroll-margin, image outlines, transition polish, and motion-reduce support throughout

## How to review

Run `pnpm dev:web` and visit `/docs`. Use the **picker toolbar** at the bottom of the viewport to toggle between design options for:

- **Sidebar style** — Flat, Left border indicator, Rounded pill, Indent + background
- **TOC style** — Flat, Sliding border, Numbered, Minimal fade
- **Breadcrumb style** — Pipe, Chevron, Slash, Minimal path

Pick the ones you like and I'll strip the others + remove the picker script.

## Test plan

- [ ] Verify each sidebar variant renders correctly and highlights the active page
- [ ] Verify each TOC variant tracks scroll position
- [ ] Verify breadcrumb links navigate correctly
- [ ] Verify copy-link button copies URL and shows check animation
- [ ] Check mobile layout (sheet sidebar, responsive header)
- [ ] Verify `prefers-reduced-motion` disables animations