### PR TITLE
feat(dashboard): add loading skeleton to status pages list

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/status-pages/(list)/client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/(list)/client.tsx
@@ -14,14 +14,14 @@ import {
 import { columns } from "@/components/data-table/status-pages/columns";
 import { DataTable } from "@/components/ui/data-table/data-table";
 import { DataTablePaginationSimple } from "@/components/ui/data-table/data-table-pagination";
+import { DataTableSkeleton } from "@/components/ui/data-table/data-table-skeleton";
 import { useTRPC } from "@/lib/trpc/client";
 
 export function Client() {
   const trpc = useTRPC();
   const { data: statusPages } = useQuery(trpc.page.list.queryOptions());
 
-  // TODO: add skeleton
-  if (!statusPages) return null;
+  if (!statusPages) return <DataTableSkeleton rows={3} />;
 
   return (
     <SectionGroup>


### PR DESCRIPTION
## Description
The status pages list (`apps/dashboard/src/app/(dashboard)/status-pages/(list)/client.tsx`) 
currently returns `null` while data is loading, resulting in a blank screen with no 
loading feedback for the user.

## Fixed
Replaced `return null` with `<DataTableSkeleton rows={3} />` using the existing 
`DataTableSkeleton` component already used in other parts of the dashboard 
(e.g. `monitors/[id]/logs/client.tsx`).

## Related
- Existing `DataTableSkeleton` component: 
  `apps/dashboard/src/components/ui/data-table/data-table-skeleton.tsx`

closes #2260 