### PR TITLE
fix(dashboard): add loading state to DomainConfiguration component

### DIFF
--- a/apps/dashboard/src/components/domains/domain-configuration.tsx
+++ b/apps/dashboard/src/components/domains/domain-configuration.tsx
@@ -47,9 +47,18 @@ const CNAME_VALUE =
 const A_RECORD_VALUE =
   process.env.NEXT_PUBLIC_VERCEL_PROJECT_DNS_A || "76.76.21.21";
 
-// FIXME: add loading state!
 export default function DomainConfiguration({ domain }: { domain: string }) {
   const { status, domainJson, steps, isLoading } = useDomainStatus(domain);
+
+  if (isLoading && !domainJson)
+    return (
+      <div className="flex items-center gap-3 border border-transparent px-4">
+        <DomainStatusIcon loading={true} />
+        <p className="text-muted-foreground text-sm">
+          Checking domain status...
+        </p>
+      </div>
+    );
 
   if (!status || !domainJson) return null;
 

--- a/apps/dashboard/src/components/domains/domain-status-icon.tsx
+++ b/apps/dashboard/src/components/domains/domain-status-icon.tsx
@@ -7,7 +7,7 @@ export function DomainStatusIcon({
   status,
   loading,
 }: {
-  status: DomainVerificationStatusProps;
+  status?: DomainVerificationStatusProps;
   loading?: boolean;
 }) {
   return loading ? (


### PR DESCRIPTION
## Description
`DomainConfiguration` receives `isLoading` from `useDomainStatus` but never 
uses it — returning `null` while all 3 domain queries are in flight, 
resulting in a blank screen with no loading feedback for the user.

## Fix
Added an early return when `isLoading` is true using the existing 
`DomainStatusIcon` component which already supports a `loading` prop 
that renders an animated spinner — consistent with existing design patterns.

## Testing
- Loading state now shows a spinner with "Checking domain status..." 
  while domain queries are in flight
- No change to existing behaviour after data loads

Closes #2262

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

