### PR TITLE
fix(header-analysis): correct x-vercel-cache REVALIDATED state typo

### DIFF
--- a/packages/header-analysis/package.json
+++ b/packages/header-analysis/package.json
@@ -6,10 +6,14 @@
   "license": "ISC",
   "author": "",
   "main": "src/index.ts",
-  "scripts": {},
+  "scripts": {
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
   "dependencies": {},
   "devDependencies": {
     "@openstatus/tsconfig": "workspace:*",
+    "@types/bun": "latest",
     "typescript": "catalog:"
   }
 }

--- a/packages/header-analysis/src/parser/x-vercel-cache.test.ts
+++ b/packages/header-analysis/src/parser/x-vercel-cache.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseXVercelCache } from "./x-vercel-cache";
+
+describe("parseXVercelCache", () => {
+  it.each([
+    ["MISS", "The response was not found in the edge cache"],
+    ["HIT", "The response was served from the edge cache."],
+    ["STALE", "A background request to the origin server"],
+    ["PRERENDER", "The response was served from static storage."],
+    ["REVALIDATED", "the cache was refreshed"],
+  ])("describes the documented state %p", (value, expectedFragment) => {
+    const result = parseXVercelCache(value);
+    expect(result.value).toBe(value);
+    expect(result.description).toContain(expectedFragment);
+  });
+
+  it("matches states case-insensitively", () => {
+    const lower = parseXVercelCache("revalidated");
+    const upper = parseXVercelCache("REVALIDATED");
+    expect(lower.description).toBe(upper.description);
+    expect(lower.description).not.toBe("-");
+  });
+
+  it("falls back to '-' for an unknown value", () => {
+    const result = parseXVercelCache("UNKNOWN");
+    expect(result.value).toBe("UNKNOWN");
+    expect(result.description).toBe("-");
+  });
+});

--- a/packages/header-analysis/src/parser/x-vercel-cache.ts
+++ b/packages/header-analysis/src/parser/x-vercel-cache.ts
@@ -18,7 +18,7 @@ function getCacheDescription(key: string): string {
       return "The response was served from the edge cache. A background request to the origin server was made to update the content.";
     case "PRERENDER":
       return "The response was served from static storage.";
-    case "REVLIDATED":
+    case "REVALIDATED":
       return "The response was served from the origin server and the cache was refreshed due to an authorization from the user in the incoming request.";
     default:
       return "-";

--- a/packages/header-analysis/tsconfig.json
+++ b/packages/header-analysis/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@openstatus/tsconfig/base.json",
   "include": ["src", "*.ts"],
   "compilerOptions": {
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["bun"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1970,6 +1970,9 @@ importers:
       '@openstatus/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Summary

The `x-vercel-cache` header parser matched the cache state against the literal `"REVLIDATED"` — a typo. Vercel's actual `x-vercel-cache` header value is `REVALIDATED`, so this case never matched and revalidated edge responses fell through to the placeholder description `"-"` instead of the real "revalidated" description. Reproduced before the fix.

## Changes

- Correct `"REVLIDATED"` → `"REVALIDATED"` in `packages/header-analysis/src/parser/x-vercel-cache.ts`
- Add the package's first unit test (it had none), wired up with `bun:test` the same way the `status-fetcher` package is — covers each cache state and case-insensitivity

## Testing

- `bun test` (packages/header-analysis) → 7 pass / 0 fail
- Red-green proven: reverting the one-char fix fails 2 cases (`REVALIDATED` + case-insensitive), green after
- `tsc --noEmit` clean, `oxlint` clean, `oxfmt --check` clean (mirrors CI's `pnpm test` / `pnpm format`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

