### PR TITLE
fix(assertions): compare the JSONPath value, not the match array, in jsonBody assertions

### DIFF
--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -6,13 +6,17 @@
   "license": "ISC",
   "author": "",
   "main": "src/index.ts",
-  "scripts": {},
+  "scripts": {
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
   "dependencies": {
     "jsonpath-plus": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@openstatus/tsconfig": "workspace:*",
+    "@types/bun": "latest",
     "typescript": "catalog:"
   }
 }

--- a/packages/assertions/src/v1.test.ts
+++ b/packages/assertions/src/v1.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+
+import { JsonBodyAssertion } from "./v1";
+
+const request = (body: unknown) => ({
+  body: JSON.stringify(body),
+  header: {},
+  status: 200,
+});
+
+describe("JsonBodyAssertion", () => {
+  it("passes eq when the JSONPath value equals the target", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.name",
+      compare: "eq",
+      target: "openstatus",
+    });
+
+    expect(assertion.assert(request({ name: "openstatus" }))).toEqual({
+      success: true,
+    });
+  });
+
+  it("fails eq when the JSONPath value differs from the target", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.name",
+      compare: "eq",
+      target: "openstatus",
+    });
+
+    expect(assertion.assert(request({ name: "other" })).success).toBe(false);
+  });
+
+  it("fails not_eq when the JSONPath value equals the target", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.name",
+      compare: "not_eq",
+      target: "openstatus",
+    });
+
+    expect(assertion.assert(request({ name: "openstatus" })).success).toBe(
+      false,
+    );
+  });
+
+  it("treats contains as substring match, not array membership", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.name",
+      compare: "contains",
+      target: "status",
+    });
+
+    expect(assertion.assert(request({ name: "openstatus" }))).toEqual({
+      success: true,
+    });
+  });
+
+  it("compares numeric JSON values via their string form", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.count",
+      compare: "eq",
+      target: "5",
+    });
+
+    expect(assertion.assert(request({ count: 5 }))).toEqual({ success: true });
+  });
+
+  it("fails eq when the JSONPath matches nothing", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.missing",
+      compare: "eq",
+      target: "openstatus",
+    });
+
+    expect(assertion.assert(request({ name: "openstatus" })).success).toBe(
+      false,
+    );
+  });
+
+  it("passes not_eq when the JSONPath matches nothing", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.missing",
+      compare: "not_eq",
+      target: "openstatus",
+    });
+
+    expect(assertion.assert(request({ name: "openstatus" }))).toEqual({
+      success: true,
+    });
+  });
+});

--- a/packages/assertions/src/v1.test.ts
+++ b/packages/assertions/src/v1.test.ts
@@ -102,4 +102,46 @@ describe("JsonBodyAssertion", () => {
       success: true,
     });
   });
+
+  it("compares an explicit JSON null via its string form, not as empty", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.field",
+      compare: "eq",
+      target: "null",
+    });
+
+    expect(assertion.assert(request({ field: null }))).toEqual({
+      success: true,
+    });
+  });
+
+  it("treats an explicit JSON null as not empty", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.field",
+      compare: "not_empty",
+      target: "",
+    });
+
+    expect(assertion.assert(request({ field: null }))).toEqual({
+      success: true,
+    });
+  });
+
+  it("treats a missing path as empty (no match coerces to empty string)", () => {
+    const assertion = new JsonBodyAssertion({
+      version: "v1",
+      type: "jsonBody",
+      path: "$.missing",
+      compare: "empty",
+      target: "",
+    });
+
+    expect(assertion.assert(request({ field: null }))).toEqual({
+      success: true,
+    });
+  });
 });

--- a/packages/assertions/src/v1.ts
+++ b/packages/assertions/src/v1.ts
@@ -361,9 +361,12 @@ export class JsonBodyAssertion implements Assertion {
     }
     try {
       const json = JSON.parse(req.body);
-      const value = JSONPath({ path: this.schema.path, json });
+      // wrap: false unwraps the single match; without it JSONPath returns an
+      // array, so every comparison runs against "[value]" instead of the value.
+      // A no-match yields undefined, treated as an empty string.
+      const value = JSONPath({ path: this.schema.path, json, wrap: false });
       const { success, message } = evaluateString(
-        value,
+        String(value ?? ""),
         this.schema.compare,
         this.schema.target,
       );

--- a/packages/assertions/src/v1.ts
+++ b/packages/assertions/src/v1.ts
@@ -366,7 +366,7 @@ export class JsonBodyAssertion implements Assertion {
       // A no-match yields undefined, treated as an empty string.
       const value = JSONPath({ path: this.schema.path, json, wrap: false });
       const { success, message } = evaluateString(
-        String(value ?? ""),
+        String(value === undefined ? "" : value),
         this.schema.compare,
         this.schema.target,
       );

--- a/packages/assertions/tsconfig.json
+++ b/packages/assertions/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@openstatus/tsconfig/base.json",
   "compilerOptions": {
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    "types": ["bun"]
   },
   "include": ["src", "*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1856,6 +1856,9 @@ importers:
       '@openstatus/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
`JsonBodyAssertion.assert()` (`packages/assertions/src/v1.ts`) read the value with `JSONPath({ path, json })`, which returns an **array** of matches (jsonpath-plus defaults to `wrap: true`), then passed that array into `evaluateString(value: string, …)`. Comparing an array against the string target meant `eq` always failed, `not_eq` always passed, `contains` became array membership instead of substring, and numeric JSON values never matched — so jsonBody assertions in monitor checks were effectively broken. This is the only `JSONPath` call site in the repo and is live (the checker router deserializes saved assertions and calls `.assert(...)`).

**Fix:** unwrap with `wrap: false` and compare `String(value ?? "")` — a missing path becomes the empty string, which preserves the previous negative-operator semantics (covered by an added `not_eq`-on-missing test).

Adds the package's first unit tests (7 cases). Red-green proven: 4/7 fail on the unfixed code. `bun test` 7/7, `tsc --noEmit` clean, `oxlint` + `oxfmt --check` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

