### PR TITLE
fix(notifications): show region location, not the raw code, in recovery/degraded emails

### DIFF
--- a/packages/notifications/email/src/index.test.ts
+++ b/packages/notifications/email/src/index.test.ts
@@ -58,7 +58,7 @@ describe("Email Notifications", () => {
       statusCode: 500,
       message: "Something went wrong",
       latency: 1500,
-      region: "iad",
+      regions: ["iad"],
       cronTimestamp: Date.now(),
     });
 
@@ -70,6 +70,7 @@ describe("Email Notifications", () => {
     expect(callArgs.url).toBe("https://api.example.com/health");
     expect(callArgs.status).toBe("500");
     expect(callArgs.latency).toBe("1500ms");
+    expect(callArgs.region).toBe("Ashburn, Virginia, USA");
     expect(callArgs.message).toBe("Something went wrong");
     expect(callArgs.timestamp).toBeDefined();
   });
@@ -106,7 +107,7 @@ describe("Email Notifications", () => {
       notification,
       statusCode: 200,
       latency: 100,
-      region: "ams",
+      regions: ["ams"],
       cronTimestamp: Date.now(),
     });
 
@@ -117,6 +118,7 @@ describe("Email Notifications", () => {
     expect(callArgs.to).toBe("ping@openstatus.dev");
     expect(callArgs.status).toBe("200");
     expect(callArgs.latency).toBe("100ms");
+    expect(callArgs.region).toBe("Amsterdam, Netherlands");
   });
 
   test("Send Degraded", async () => {
@@ -131,7 +133,7 @@ describe("Email Notifications", () => {
       notification,
       statusCode: 503,
       latency: 2000,
-      region: "lax",
+      regions: ["lax"],
       cronTimestamp: Date.now(),
     });
 
@@ -141,6 +143,7 @@ describe("Email Notifications", () => {
     expect(callArgs.name).toBe("API Health Check");
     expect(callArgs.status).toBe("503");
     expect(callArgs.latency).toBe("2000ms");
+    expect(callArgs.region).toBe("Los Angeles, California, USA");
   });
 
   test("Handles invalid notification data gracefully", async () => {

--- a/packages/notifications/email/src/index.ts
+++ b/packages/notifications/email/src/index.ts
@@ -59,7 +59,7 @@ export const sendRecovery = async ({
     url: monitor.url,
     status: statusCode?.toString(),
     latency: latency ? `${latency}ms` : "N/A",
-    region: region ?? "N/A",
+    region: region ? regionDict[region].location : "N/A",
     timestamp: new Date(cronTimestamp).toISOString(),
   });
 };
@@ -87,7 +87,7 @@ export const sendDegraded = async ({
     url: monitor.url,
     status: statusCode?.toString(),
     latency: latency ? `${latency}ms` : "N/A",
-    region: region ?? "N/A",
+    region: region ? regionDict[region].location : "N/A",
     timestamp: new Date(cronTimestamp).toISOString(),
   });
 };


### PR DESCRIPTION
In `packages/notifications/email`, `sendAlert` renders the region as the human-readable location via `regionDict[region].location` (e.g. "Frankfurt, Germany"), but `sendRecovery` and `sendDegraded` passed the raw region code (`region ?? "N/A"` → "fra"). So for the same monitor, the alert email showed "Frankfurt, Germany" while the recovery/degraded emails showed "fra".

This mirrors `sendAlert`'s lookup in the two other senders so all three email types are consistent. It also rewires the email tests to the real `regions: [...]` field (the old singular `region:` field was never read by the code) and adds region-location assertions.

Red-green proven: on the unfixed code recovery shows "ams" instead of "Amsterdam, Netherlands" and degraded shows "lax" instead of "Los Angeles, California, USA"; 5/5 pass with the fix. `bun test` 5/5, `tsc` / `oxlint` / `oxfmt --check` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

