### PR TITLE
fix: retry turso query + add small caching

### DIFF
--- a/apps/server/src/libs/middlewares/auth.ts
+++ b/apps/server/src/libs/middlewares/auth.ts
@@ -10,11 +10,7 @@ import {
   shouldUpdateLastUsed,
   verifyApiKeyHash,
 } from "@openstatus/db/src/utils/api-key";
-import {
-  isRetryableDbError,
-  isTransientServerError,
-  withBusyRetry,
-} from "@openstatus/services";
+import { retryRead } from "@openstatus/services";
 import { UnkeyCore } from "@unkey/api/core";
 import { keysVerifyKey } from "@unkey/api/funcs/keysVerifyKey";
 import type { Context, Next } from "hono";
@@ -24,10 +20,6 @@ import { OpenStatusApiError } from "@/libs/errors";
 import type { Variables } from "@/types";
 
 const logger = getLogger("api-server");
-
-// Reads only: a 502 can land after a write partially applied.
-const retryRead = <T>(fn: () => Promise<T>): Promise<T> =>
-  withBusyRetry(fn, (e) => isRetryableDbError(e) || isTransientServerError(e));
 
 export async function lookupWorkspace(workspaceId: number) {
   const _workspace = await retryRead(() =>

--- a/apps/web/src/app/(landing)/status/[id]/page.tsx
+++ b/apps/web/src/app/(landing)/status/[id]/page.tsx
@@ -33,46 +33,51 @@ export async function generateMetadata(args: {
   params: Promise<RouteParams>;
 }): Promise<Metadata> {
   const { id } = await args.params;
-  const service = await cachedGetExternalServiceBySlug(id);
-  if (!service) return { ...defaultMetadata, title: "Not Found" };
+  try {
+    const service = await cachedGetExternalServiceBySlug(id);
+    if (!service) return { ...defaultMetadata, title: "Not Found" };
 
-  const { escalated } = await getServiceEscalation(service);
+    const { escalated } = await getServiceEscalation(service);
 
-  const title = escalated
-    ? `Users reporting issues with ${service.name}. ${service.name} Status & Incidents`
-    : `Is ${service.name} Down? ${service.name} Status & Incidents`;
-  const description = escalated
-    ? `Users are reporting problems with ${service.name} in the last ${REPORT_WINDOW_MINUTES} minutes. Check the live ${service.name} status, uptime over the last ${HISTORY_DAYS} days, and recent ${service.name} incidents tracked by OpenStatus.`
-    : `Is ${service.name} down right now? Check the live ${service.name} status, uptime over the last ${HISTORY_DAYS} days, and recent ${service.name} incidents tracked by OpenStatus.`;
-  const canonicalUrl = `${BASE_URL}/status/${service.slug}`;
-  const ogImage = `${BASE_URL}/api/og/external-service?slug=${encodeURIComponent(service.slug)}`;
-  const indexable = service.deletedAt == null;
+    const title = escalated
+      ? `Users reporting issues with ${service.name}. ${service.name} Status & Incidents`
+      : `Is ${service.name} Down? ${service.name} Status & Incidents`;
+    const description = escalated
+      ? `Users are reporting problems with ${service.name} in the last ${REPORT_WINDOW_MINUTES} minutes. Check the live ${service.name} status, uptime over the last ${HISTORY_DAYS} days, and recent ${service.name} incidents tracked by OpenStatus.`
+      : `Is ${service.name} down right now? Check the live ${service.name} status, uptime over the last ${HISTORY_DAYS} days, and recent ${service.name} incidents tracked by OpenStatus.`;
+    const canonicalUrl = `${BASE_URL}/status/${service.slug}`;
+    const ogImage = `${BASE_URL}/api/og/external-service?slug=${encodeURIComponent(service.slug)}`;
+    const indexable = service.deletedAt == null;
 
-  return {
-    ...defaultMetadata,
-    title,
-    description,
-    alternates: {
-      canonical: canonicalUrl,
-    },
-    robots: {
-      index: indexable,
-      follow: true,
-    },
-    openGraph: {
-      ...ogMetadata,
+    return {
+      ...defaultMetadata,
       title,
       description,
-      url: canonicalUrl,
-      images: [ogImage],
-    },
-    twitter: {
-      ...twitterMetadata,
-      title,
-      description,
-      images: [ogImage],
-    },
-  };
+      alternates: {
+        canonical: canonicalUrl,
+      },
+      robots: {
+        index: indexable,
+        follow: true,
+      },
+      openGraph: {
+        ...ogMetadata,
+        title,
+        description,
+        url: canonicalUrl,
+        images: [ogImage],
+      },
+      twitter: {
+        ...twitterMetadata,
+        title,
+        description,
+        images: [ogImage],
+      },
+    };
+  } catch (err) {
+    console.warn(`[status metadata] fallback for ${id}:`, err);
+    return defaultMetadata;
+  }
 }
 
 export default async function Page(args: { params: Promise<RouteParams> }) {

--- a/apps/web/src/app/api/og/external-service/route.tsx
+++ b/apps/web/src/app/api/og/external-service/route.tsx
@@ -15,7 +15,9 @@ import { cn } from "@/lib/utils";
 
 import { SIZE } from "../utils";
 
-export const runtime = "edge";
+// nodejs (not edge): this route pulls in the service reads + Effect retry, which
+// push the bundle past the 2 MB edge limit. Node has no such cap.
+export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const FOOTER = "openstatus.dev/status";

--- a/apps/web/src/lib/external-report-escalation.ts
+++ b/apps/web/src/lib/external-report-escalation.ts
@@ -8,10 +8,38 @@ import {
   getServiceReportWindows,
 } from "@openstatus/services/external-service-report";
 import { OSTinybird, safePipeData } from "@openstatus/tinybird";
+import { unstable_cache } from "next/cache";
 
 import { env } from "@/env";
 
 const tb = new OSTinybird(env.TINY_BIRD_API_KEY);
+
+const REPORTS_REVALIDATE_SECONDS = 30;
+const REPORTS_TAG = "external-services";
+
+// Keyed by serviceId only — `since` is a moving Date.now() window, so it must be
+// computed inside (keying on it would make every request a cache miss).
+const cachedServiceReporters = unstable_cache(
+  async (serviceId: number): Promise<number> => {
+    const since = new Date(Date.now() - REPORT_WINDOW_MS);
+    const rows = await getServiceReportWindows({
+      serviceIds: [serviceId],
+      since,
+    });
+    return rows[0]?.reporters ?? 0;
+  },
+  ["external-service-report:service-reporters"],
+  { revalidate: REPORTS_REVALIDATE_SECONDS, tags: [REPORTS_TAG] },
+);
+
+const cachedComponentReporters = unstable_cache(
+  async (serviceId: number) => {
+    const since = new Date(Date.now() - REPORT_WINDOW_MS);
+    return getComponentReportWindows({ serviceId, since });
+  },
+  ["external-service-report:component-reporters"],
+  { revalidate: REPORTS_REVALIDATE_SECONDS, tags: [REPORTS_TAG] },
+);
 
 type EscalationInput = {
   id: number;
@@ -28,16 +56,9 @@ export type ServiceEscalation = {
   lastFetchedAt: number;
 };
 
-async function serviceReporters(
-  serviceId: number,
-  since: Date,
-): Promise<number> {
+async function serviceReporters(serviceId: number): Promise<number> {
   try {
-    const rows = await getServiceReportWindows({
-      serviceIds: [serviceId],
-      since,
-    });
-    return rows[0]?.reporters ?? 0;
+    return await cachedServiceReporters(serviceId);
   } catch (err) {
     console.error("[escalation] service reporters read failed:", err);
     return 0;
@@ -49,14 +70,13 @@ export async function getServiceEscalation(
 ): Promise<ServiceEscalation> {
   const aliasSlugs = Array.isArray(service.aliases) ? service.aliases : [];
   const slugChain = [service.slug, ...aliasSlugs];
-  const since = new Date(Date.now() - REPORT_WINDOW_MS);
 
   const [latestRes, reporters] = await Promise.all([
     safePipeData(
       tb.externalStatusLatest({ ids: slugChain }),
       "externalStatusLatest (escalation)",
     ),
-    serviceReporters(service.id, since),
+    serviceReporters(service.id),
   ]);
 
   const latestRows = [...latestRes.data].sort(
@@ -84,13 +104,9 @@ export async function getComponentEscalation(args: {
   indicator: string;
   status: string;
 }): Promise<{ indicator: string; status: string; escalated: boolean }> {
-  const since = new Date(Date.now() - REPORT_WINDOW_MS);
   let reporters = 0;
   try {
-    const rows = await getComponentReportWindows({
-      serviceId: args.serviceId,
-      since,
-    });
+    const rows = await cachedComponentReporters(args.serviceId);
     reporters =
       rows.find((r) => r.componentId === args.componentId)?.reporters ?? 0;
   } catch (err) {

--- a/apps/web/src/lib/external-report-escalation.ts
+++ b/apps/web/src/lib/external-report-escalation.ts
@@ -15,7 +15,9 @@ import { env } from "@/env";
 const tb = new OSTinybird(env.TINY_BIRD_API_KEY);
 
 const REPORTS_REVALIDATE_SECONDS = 30;
-const REPORTS_TAG = "external-services";
+// Distinct from the "external-services" tag on service-lookup caches so that
+// service mutations don't also flush the short-lived reports cache.
+const REPORTS_TAG = "external-service-reports";
 
 // Keyed by serviceId only — `since` is a moving Date.now() window, so it must be
 // computed inside (keying on it would make every request a cache miss).

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -136,6 +136,7 @@
     "@openstatus/theme-store": "workspace:*",
     "@openstatus/tinybird": "workspace:*",
     "@openstatus/utils": "workspace:*",
+    "effect": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/services/src/__tests__/retry.test.ts
+++ b/packages/services/src/__tests__/retry.test.ts
@@ -4,8 +4,19 @@ import { NotFoundError } from "../errors";
 import {
   isRetryableDbError,
   isTransientServerError,
+  retryRead,
   withBusyRetry,
 } from "../retry";
+
+const transient502 = () => {
+  const err = new Error("Failed query: select ...");
+  (err as Error & { cause: unknown }).cause = {
+    code: "SERVER_ERROR",
+    status: 502,
+    message: "SERVER_ERROR: Server returned HTTP status 502",
+  };
+  return err;
+};
 
 describe("isRetryableDbError", () => {
   test("true for SQLITE_BUSY code", () => {
@@ -141,5 +152,59 @@ describe("withBusyRetry", () => {
     });
     await expect(promise).rejects.toBe(original);
     expect(attempts).toBe(1);
+  });
+});
+
+describe("retryRead", () => {
+  test("retries a drizzle-wrapped transient 502 then resolves", async () => {
+    let attempts = 0;
+    const result = await retryRead(async () => {
+      attempts++;
+      if (attempts < 3) throw transient502();
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(attempts).toBe(3);
+  });
+
+  test("retries SQLITE_BUSY", async () => {
+    let attempts = 0;
+    const result = await retryRead(async () => {
+      attempts++;
+      if (attempts < 2) throw { code: "SQLITE_BUSY" };
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(attempts).toBe(2);
+  });
+
+  test("does not retry a 4xx server error", async () => {
+    let attempts = 0;
+    const original = {
+      code: "SERVER_ERROR",
+      status: 404,
+      message: "Server returned HTTP status 404",
+    };
+    const promise = retryRead(async () => {
+      attempts++;
+      throw original;
+    });
+    await expect(promise).rejects.toBe(original);
+    expect(attempts).toBe(1);
+  });
+
+  test("gives up after 5 attempts on a sustained 5xx", async () => {
+    let attempts = 0;
+    const original = {
+      code: "SERVER_ERROR",
+      status: 503,
+      message: "Server returned HTTP status 503",
+    };
+    const promise = retryRead(async () => {
+      attempts++;
+      throw original;
+    });
+    await expect(promise).rejects.toBe(original);
+    expect(attempts).toBe(5);
   });
 });

--- a/packages/services/src/__tests__/retry.test.ts
+++ b/packages/services/src/__tests__/retry.test.ts
@@ -51,6 +51,26 @@ describe("isRetryableDbError", () => {
     expect(isRetryableDbError(null)).toBe(false);
     expect(isRetryableDbError("SQLITE_BUSY")).toBe(false);
   });
+
+  test("terminates on a self-referential cause cycle", () => {
+    const err: { code?: string; cause?: unknown } = {};
+    err.cause = err;
+    expect(isRetryableDbError(err)).toBe(false);
+  });
+
+  test("finds a retryable code at the deepest searched level", () => {
+    // wrapped 9 times -> code sits at depth 9, the last level inspected.
+    let chain: { code?: string; cause?: unknown } = { code: "SQLITE_BUSY" };
+    for (let i = 0; i < 9; i++) chain = { cause: chain };
+    expect(isRetryableDbError(chain)).toBe(true);
+  });
+
+  test("stops at MAX_CAUSE_DEPTH (code one level too deep is unreachable)", () => {
+    // wrapped 10 times -> code sits at depth 10, never inspected.
+    let chain: { code?: string; cause?: unknown } = { code: "SQLITE_BUSY" };
+    for (let i = 0; i < 10; i++) chain = { cause: chain };
+    expect(isRetryableDbError(chain)).toBe(false);
+  });
 });
 
 describe("isTransientServerError", () => {

--- a/packages/services/src/external-service-component/list.ts
+++ b/packages/services/src/external-service-component/list.ts
@@ -5,6 +5,7 @@ import { externalServiceComponent } from "@openstatus/db/src/schema";
 import { defaultTb } from "../context";
 import { getExternalServiceBySlug } from "../external-service";
 import type { GlobalReadContext } from "../external-service/internal";
+import { retryRead } from "../retry";
 
 export type ExternalComponentListItem = {
   id: number;
@@ -80,27 +81,29 @@ export async function listExternalComponentsByServiceId(args: {
   const { ctx, externalServiceId } = args;
   const db = ctx?.db ?? defaultDb;
 
-  const rows = await db
-    .select({
-      id: externalServiceComponent.id,
-      externalServiceId: externalServiceComponent.externalServiceId,
-      upstreamComponentId: externalServiceComponent.upstreamComponentId,
-      slug: externalServiceComponent.slug,
-      name: externalServiceComponent.name,
-      description: externalServiceComponent.description,
-      groupName: externalServiceComponent.groupName,
-      position: externalServiceComponent.position,
-      indicator: externalServiceComponent.indicator,
-      status: externalServiceComponent.status,
-      firstSeenAt: externalServiceComponent.firstSeenAt,
-    })
-    .from(externalServiceComponent)
-    .where(eq(externalServiceComponent.externalServiceId, externalServiceId))
-    .orderBy(
-      asc(externalServiceComponent.position),
-      asc(externalServiceComponent.name),
-    )
-    .all();
+  const rows = await retryRead(() =>
+    db
+      .select({
+        id: externalServiceComponent.id,
+        externalServiceId: externalServiceComponent.externalServiceId,
+        upstreamComponentId: externalServiceComponent.upstreamComponentId,
+        slug: externalServiceComponent.slug,
+        name: externalServiceComponent.name,
+        description: externalServiceComponent.description,
+        groupName: externalServiceComponent.groupName,
+        position: externalServiceComponent.position,
+        indicator: externalServiceComponent.indicator,
+        status: externalServiceComponent.status,
+        firstSeenAt: externalServiceComponent.firstSeenAt,
+      })
+      .from(externalServiceComponent)
+      .where(eq(externalServiceComponent.externalServiceId, externalServiceId))
+      .orderBy(
+        asc(externalServiceComponent.position),
+        asc(externalServiceComponent.name),
+      )
+      .all(),
+  );
 
   if (rows.length === 0) return [];
 

--- a/packages/services/src/external-service-component/list.ts
+++ b/packages/services/src/external-service-component/list.ts
@@ -189,33 +189,35 @@ export async function getExternalComponentBySlug(args: {
   const service = await getExternalServiceBySlug({ ctx, slug: serviceSlug });
   if (!service) return { service: null, component: null };
 
-  const rows = await db
-    .select({
-      id: externalServiceComponent.id,
-      externalServiceId: externalServiceComponent.externalServiceId,
-      upstreamComponentId: externalServiceComponent.upstreamComponentId,
-      slug: externalServiceComponent.slug,
-      aliases: externalServiceComponent.aliases,
-      name: externalServiceComponent.name,
-      description: externalServiceComponent.description,
-      groupName: externalServiceComponent.groupName,
-      position: externalServiceComponent.position,
-      indicator: externalServiceComponent.indicator,
-      status: externalServiceComponent.status,
-      firstSeenAt: externalServiceComponent.firstSeenAt,
-    })
-    .from(externalServiceComponent)
-    .where(
-      and(
-        eq(externalServiceComponent.externalServiceId, service.id),
-        or(
-          eq(externalServiceComponent.slug, componentSlug),
-          sql`EXISTS (SELECT 1 FROM json_each(${externalServiceComponent.aliases}) WHERE value = ${componentSlug})`,
+  const rows = await retryRead(() =>
+    db
+      .select({
+        id: externalServiceComponent.id,
+        externalServiceId: externalServiceComponent.externalServiceId,
+        upstreamComponentId: externalServiceComponent.upstreamComponentId,
+        slug: externalServiceComponent.slug,
+        aliases: externalServiceComponent.aliases,
+        name: externalServiceComponent.name,
+        description: externalServiceComponent.description,
+        groupName: externalServiceComponent.groupName,
+        position: externalServiceComponent.position,
+        indicator: externalServiceComponent.indicator,
+        status: externalServiceComponent.status,
+        firstSeenAt: externalServiceComponent.firstSeenAt,
+      })
+      .from(externalServiceComponent)
+      .where(
+        and(
+          eq(externalServiceComponent.externalServiceId, service.id),
+          or(
+            eq(externalServiceComponent.slug, componentSlug),
+            sql`EXISTS (SELECT 1 FROM json_each(${externalServiceComponent.aliases}) WHERE value = ${componentSlug})`,
+          ),
         ),
-      ),
-    )
-    .limit(1)
-    .all();
+      )
+      .limit(1)
+      .all(),
+  );
 
   const row = rows[0];
   if (!row) return { service, component: null };

--- a/packages/services/src/external-service-incident/list.ts
+++ b/packages/services/src/external-service-incident/list.ts
@@ -4,6 +4,7 @@ import { externalServiceIncident } from "@openstatus/db/src/schema";
 
 import { getExternalServiceBySlug } from "../external-service";
 import type { GlobalReadContext } from "../external-service/internal";
+import { retryRead } from "../retry";
 
 export type ExternalIncidentListItem = {
   id: number;
@@ -39,29 +40,31 @@ export async function listExternalIncidentsByServiceId(args: {
   const db = ctx?.db ?? defaultDb;
   const limit = args.limit ?? DEFAULT_LIMIT;
 
-  const rows = await db
-    .select({
-      id: externalServiceIncident.id,
-      externalServiceId: externalServiceIncident.externalServiceId,
-      providerIncidentId: externalServiceIncident.providerIncidentId,
-      name: externalServiceIncident.name,
-      status: externalServiceIncident.status,
-      impact: externalServiceIncident.impact,
-      shortlink: externalServiceIncident.shortlink,
-      startedAt: externalServiceIncident.startedAt,
-      createdAt: externalServiceIncident.createdAt,
-      resolvedAt: externalServiceIncident.resolvedAt,
-    })
-    .from(externalServiceIncident)
-    .where(eq(externalServiceIncident.externalServiceId, externalServiceId))
-    .orderBy(
-      desc(
-        sql`COALESCE(${externalServiceIncident.startedAt}, ${externalServiceIncident.createdAt})`,
-      ),
-      desc(externalServiceIncident.createdAt),
-    )
-    .limit(limit)
-    .all();
+  const rows = await retryRead(() =>
+    db
+      .select({
+        id: externalServiceIncident.id,
+        externalServiceId: externalServiceIncident.externalServiceId,
+        providerIncidentId: externalServiceIncident.providerIncidentId,
+        name: externalServiceIncident.name,
+        status: externalServiceIncident.status,
+        impact: externalServiceIncident.impact,
+        shortlink: externalServiceIncident.shortlink,
+        startedAt: externalServiceIncident.startedAt,
+        createdAt: externalServiceIncident.createdAt,
+        resolvedAt: externalServiceIncident.resolvedAt,
+      })
+      .from(externalServiceIncident)
+      .where(eq(externalServiceIncident.externalServiceId, externalServiceId))
+      .orderBy(
+        desc(
+          sql`COALESCE(${externalServiceIncident.startedAt}, ${externalServiceIncident.createdAt})`,
+        ),
+        desc(externalServiceIncident.createdAt),
+      )
+      .limit(limit)
+      .all(),
+  );
 
   return rows;
 }

--- a/packages/services/src/external-service-incident/list.ts
+++ b/packages/services/src/external-service-incident/list.ts
@@ -81,34 +81,36 @@ export async function listExternalIncidentsByComponent(args: {
   const db = ctx?.db ?? defaultDb;
   const limit = args.limit ?? DEFAULT_LIMIT;
 
-  const rows = await db
-    .select({
-      id: externalServiceIncident.id,
-      externalServiceId: externalServiceIncident.externalServiceId,
-      providerIncidentId: externalServiceIncident.providerIncidentId,
-      name: externalServiceIncident.name,
-      status: externalServiceIncident.status,
-      impact: externalServiceIncident.impact,
-      shortlink: externalServiceIncident.shortlink,
-      startedAt: externalServiceIncident.startedAt,
-      createdAt: externalServiceIncident.createdAt,
-      resolvedAt: externalServiceIncident.resolvedAt,
-    })
-    .from(externalServiceIncident)
-    .where(
-      and(
-        eq(externalServiceIncident.externalServiceId, externalServiceId),
-        sql`EXISTS (SELECT 1 FROM json_each(${externalServiceIncident.affectedComponentIds}) WHERE value = ${upstreamComponentId})`,
-      ),
-    )
-    .orderBy(
-      desc(
-        sql`COALESCE(${externalServiceIncident.startedAt}, ${externalServiceIncident.createdAt})`,
-      ),
-      desc(externalServiceIncident.createdAt),
-    )
-    .limit(limit)
-    .all();
+  const rows = await retryRead(() =>
+    db
+      .select({
+        id: externalServiceIncident.id,
+        externalServiceId: externalServiceIncident.externalServiceId,
+        providerIncidentId: externalServiceIncident.providerIncidentId,
+        name: externalServiceIncident.name,
+        status: externalServiceIncident.status,
+        impact: externalServiceIncident.impact,
+        shortlink: externalServiceIncident.shortlink,
+        startedAt: externalServiceIncident.startedAt,
+        createdAt: externalServiceIncident.createdAt,
+        resolvedAt: externalServiceIncident.resolvedAt,
+      })
+      .from(externalServiceIncident)
+      .where(
+        and(
+          eq(externalServiceIncident.externalServiceId, externalServiceId),
+          sql`EXISTS (SELECT 1 FROM json_each(${externalServiceIncident.affectedComponentIds}) WHERE value = ${upstreamComponentId})`,
+        ),
+      )
+      .orderBy(
+        desc(
+          sql`COALESCE(${externalServiceIncident.startedAt}, ${externalServiceIncident.createdAt})`,
+        ),
+        desc(externalServiceIncident.createdAt),
+      )
+      .limit(limit)
+      .all(),
+  );
 
   return rows;
 }

--- a/packages/services/src/external-service-report/read.ts
+++ b/packages/services/src/external-service-report/read.ts
@@ -12,6 +12,7 @@ import {
 import { externalServiceReport } from "@openstatus/db/src/schema";
 
 import type { GlobalReadContext } from "../external-service/internal";
+import { retryRead } from "../retry";
 
 export type ServiceReportWindow = {
   externalServiceId: number;
@@ -43,22 +44,24 @@ export async function getServiceReportWindows(args: {
   const { ctx, serviceIds, since } = args;
   if (serviceIds.length === 0) return [];
   const db = ctx?.db ?? defaultDb;
-  return db
-    .select({
-      externalServiceId: externalServiceReport.externalServiceId,
-      reporters: distinctReporters,
-      total: totalReports,
-      countries: distinctCountries,
-    })
-    .from(externalServiceReport)
-    .where(
-      and(
-        inArray(externalServiceReport.externalServiceId, serviceIds),
-        gte(externalServiceReport.createdAt, since),
-      ),
-    )
-    .groupBy(externalServiceReport.externalServiceId)
-    .all();
+  return retryRead(() =>
+    db
+      .select({
+        externalServiceId: externalServiceReport.externalServiceId,
+        reporters: distinctReporters,
+        total: totalReports,
+        countries: distinctCountries,
+      })
+      .from(externalServiceReport)
+      .where(
+        and(
+          inArray(externalServiceReport.externalServiceId, serviceIds),
+          gte(externalServiceReport.createdAt, since),
+        ),
+      )
+      .groupBy(externalServiceReport.externalServiceId)
+      .all(),
+  );
 }
 
 export async function getComponentReportWindows(args: {
@@ -68,22 +71,24 @@ export async function getComponentReportWindows(args: {
 }): Promise<ComponentReportWindow[]> {
   const { ctx, serviceId, since } = args;
   const db = ctx?.db ?? defaultDb;
-  const rows = await db
-    .select({
-      componentId: externalServiceReport.externalServiceComponentId,
-      reporters: distinctReporters,
-      total: totalReports,
-    })
-    .from(externalServiceReport)
-    .where(
-      and(
-        eq(externalServiceReport.externalServiceId, serviceId),
-        isNotNull(externalServiceReport.externalServiceComponentId),
-        gte(externalServiceReport.createdAt, since),
-      ),
-    )
-    .groupBy(externalServiceReport.externalServiceComponentId)
-    .all();
+  const rows = await retryRead(() =>
+    db
+      .select({
+        componentId: externalServiceReport.externalServiceComponentId,
+        reporters: distinctReporters,
+        total: totalReports,
+      })
+      .from(externalServiceReport)
+      .where(
+        and(
+          eq(externalServiceReport.externalServiceId, serviceId),
+          isNotNull(externalServiceReport.externalServiceComponentId),
+          gte(externalServiceReport.createdAt, since),
+        ),
+      )
+      .groupBy(externalServiceReport.externalServiceComponentId)
+      .all(),
+  );
   return rows.flatMap((r) =>
     r.componentId == null
       ? []

--- a/packages/services/src/external-service-report/read.ts
+++ b/packages/services/src/external-service-report/read.ts
@@ -109,22 +109,24 @@ export async function getServiceReportDaily(args: {
 }): Promise<DailyReport[]> {
   const { ctx, serviceId, since } = args;
   const db = ctx?.db ?? defaultDb;
-  return db
-    .select({
-      day: dayBucket,
-      reporters: distinctReporters,
-      total: totalReports,
-    })
-    .from(externalServiceReport)
-    .where(
-      and(
-        eq(externalServiceReport.externalServiceId, serviceId),
-        gte(externalServiceReport.createdAt, since),
-      ),
-    )
-    .groupBy(dayBucket)
-    .orderBy(asc(dayBucket))
-    .all();
+  return retryRead(() =>
+    db
+      .select({
+        day: dayBucket,
+        reporters: distinctReporters,
+        total: totalReports,
+      })
+      .from(externalServiceReport)
+      .where(
+        and(
+          eq(externalServiceReport.externalServiceId, serviceId),
+          gte(externalServiceReport.createdAt, since),
+        ),
+      )
+      .groupBy(dayBucket)
+      .orderBy(asc(dayBucket))
+      .all(),
+  );
 }
 
 export async function getServiceReportCountries(args: {
@@ -136,18 +138,20 @@ export async function getServiceReportCountries(args: {
   const { ctx, serviceId, since } = args;
   const limit = Math.max(0, Math.trunc(args.limit));
   const db = ctx?.db ?? defaultDb;
-  return db
-    .select({ country: externalServiceReport.country, total: totalReports })
-    .from(externalServiceReport)
-    .where(
-      and(
-        eq(externalServiceReport.externalServiceId, serviceId),
-        gte(externalServiceReport.createdAt, since),
-        sql`${externalServiceReport.country} != ''`,
-      ),
-    )
-    .groupBy(externalServiceReport.country)
-    .orderBy(desc(totalReports), asc(externalServiceReport.country))
-    .limit(limit)
-    .all();
+  return retryRead(() =>
+    db
+      .select({ country: externalServiceReport.country, total: totalReports })
+      .from(externalServiceReport)
+      .where(
+        and(
+          eq(externalServiceReport.externalServiceId, serviceId),
+          gte(externalServiceReport.createdAt, since),
+          sql`${externalServiceReport.country} != ''`,
+        ),
+      )
+      .groupBy(externalServiceReport.country)
+      .orderBy(desc(totalReports), asc(externalServiceReport.country))
+      .limit(limit)
+      .all(),
+  );
 }

--- a/packages/services/src/external-service/list-slugs.ts
+++ b/packages/services/src/external-service/list-slugs.ts
@@ -23,9 +23,9 @@ export async function listExternalServiceSlugs(args?: {
     })
     .from(externalService);
 
-  const rows = includeDeleted
-    ? await retryRead(() => query.all())
-    : await retryRead(() => query.where(liveOnlyClause()).all());
+  const rows = await retryRead(() =>
+    includeDeleted ? query.all() : query.where(liveOnlyClause()).all(),
+  );
 
   const canonical: string[] = [];
   const aliases: Array<{ from: string; to: string }> = [];

--- a/packages/services/src/external-service/list-slugs.ts
+++ b/packages/services/src/external-service/list-slugs.ts
@@ -1,6 +1,7 @@
 import { db as defaultDb } from "@openstatus/db";
 import { externalService } from "@openstatus/db/src/schema";
 
+import { retryRead } from "../retry";
 import { type GlobalReadContext, liveOnlyClause } from "./internal";
 
 export type SlugMap = {
@@ -23,8 +24,8 @@ export async function listExternalServiceSlugs(args?: {
     .from(externalService);
 
   const rows = includeDeleted
-    ? await query.all()
-    : await query.where(liveOnlyClause()).all();
+    ? await retryRead(() => query.all())
+    : await retryRead(() => query.where(liveOnlyClause()).all());
 
   const canonical: string[] = [];
   const aliases: Array<{ from: string; to: string }> = [];

--- a/packages/services/src/external-service/list.ts
+++ b/packages/services/src/external-service/list.ts
@@ -6,6 +6,7 @@ import {
   selectExternalServiceSchema,
 } from "@openstatus/db/src/schema";
 
+import { retryRead } from "../retry";
 import { type GlobalReadContext, liveOnlyClause } from "./internal";
 
 export type ListExternalServicesInput = {
@@ -58,8 +59,8 @@ export async function listExternalServices(args: {
     .orderBy(asc(sql`lower(${externalService.name})`));
 
   const rows = input?.includeDeleted
-    ? await query.all()
-    : await query.where(liveOnlyClause()).all();
+    ? await retryRead(() => query.all())
+    : await retryRead(() => query.where(liveOnlyClause()).all());
 
   return validateRows(rows);
 }
@@ -71,16 +72,18 @@ export async function getExternalServiceBySlug(args: {
   const { ctx, slug } = args;
   const db = ctx?.db ?? defaultDb;
 
-  const rows = await db
-    .select()
-    .from(externalService)
-    .where(
-      or(
-        eq(externalService.slug, slug),
-        sql`EXISTS (SELECT 1 FROM json_each(${externalService.aliases}) WHERE value = ${slug})`,
-      ),
-    )
-    .all();
+  const rows = await retryRead(() =>
+    db
+      .select()
+      .from(externalService)
+      .where(
+        or(
+          eq(externalService.slug, slug),
+          sql`EXISTS (SELECT 1 FROM json_each(${externalService.aliases}) WHERE value = ${slug})`,
+        ),
+      )
+      .all(),
+  );
 
   const validated = validateRows(rows);
   return validated[0] ?? null;

--- a/packages/services/src/external-service/list.ts
+++ b/packages/services/src/external-service/list.ts
@@ -58,9 +58,9 @@ export async function listExternalServices(args: {
     .from(externalService)
     .orderBy(asc(sql`lower(${externalService.name})`));
 
-  const rows = input?.includeDeleted
-    ? await retryRead(() => query.all())
-    : await retryRead(() => query.where(liveOnlyClause()).all());
+  const rows = await retryRead(() =>
+    input?.includeDeleted ? query.all() : query.where(liveOnlyClause()).all(),
+  );
 
   return validateRows(rows);
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   isRetryableDbError,
   isTransientServerError,
+  retryRead,
   withBusyRetry,
 } from "./retry";
 

--- a/packages/services/src/retry.ts
+++ b/packages/services/src/retry.ts
@@ -1,9 +1,10 @@
+import { Cause, Effect, Exit, Schedule } from "effect";
+
 const RETRYABLE_CODES = new Set(["SQLITE_BUSY", "SQLITE_LOCKED"]);
 const RETRYABLE_MESSAGE = /database is (locked|busy)/i;
 const TRANSIENT_SERVER_MESSAGE = /Server returned HTTP status 5\d\d/i;
 const MAX_ATTEMPTS = 5;
 const BASE_DELAY_MS = 25;
-const MAX_DELAY_MS = 400;
 const MAX_CAUSE_DEPTH = 10;
 
 function hasCode(value: object): value is { code: unknown } {
@@ -61,25 +62,26 @@ export function isTransientServerError(err: unknown): boolean {
   return false;
 }
 
-function backoffDelayMs(attempt: number): number {
-  const cap = Math.min(MAX_DELAY_MS, BASE_DELAY_MS * 2 ** attempt);
-  return Math.random() * cap;
-}
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const retrySchedule = Schedule.exponential(`${BASE_DELAY_MS} millis`).pipe(
+  Schedule.jittered,
+);
 
 export async function withBusyRetry<T>(
   fn: () => Promise<T>,
   isRetryable: (err: unknown) => boolean = isRetryableDbError,
 ): Promise<T> {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt >= MAX_ATTEMPTS - 1 || !isRetryable(err)) throw err;
-      await sleep(backoffDelayMs(attempt));
-    }
-  }
+  const exit = await Effect.runPromiseExit(
+    Effect.tryPromise({ try: () => fn(), catch: (err) => err }).pipe(
+      Effect.retry({
+        schedule: retrySchedule,
+        times: MAX_ATTEMPTS - 1,
+        while: isRetryable,
+      }),
+    ),
+  );
+  // squash so callers reject with the original error, not Effect's FiberFailure.
+  if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+  return exit.value;
 }
 
 // Idempotent reads only: also retries transient Turso 5xx (see isTransientServerError).

--- a/packages/services/src/retry.ts
+++ b/packages/services/src/retry.ts
@@ -81,3 +81,7 @@ export async function withBusyRetry<T>(
     }
   }
 }
+
+// Idempotent reads only: also retries transient Turso 5xx (see isTransientServerError).
+export const retryRead = <T>(fn: () => Promise<T>): Promise<T> =>
+  withBusyRetry(fn, (e) => isRetryableDbError(e) || isTransientServerError(e));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2551,6 +2551,9 @@ importers:
       '@openstatus/utils':
         specifier: workspace:*
         version: link:../utils
+      effect:
+        specifier: 'catalog:'
+        version: 3.21.2
       zod:
         specifier: 'catalog:'
         version: 4.1.13


### PR DESCRIPTION
Stop transient Turso 502s flooding Sentry on /status/[slug]

Bot crawls hit /status/[slug], which fires uncached Turso reads with no retry. Transient 502s surfaced as Sentry errors (via captureConsole) even though the page served stale data fine.

  - Retry idempotent service reads on transient 5xx (retryRead, reusing the existing apps/server helper)
  - Cache report aggregations 30s (keyed by serviceId)
  - Guard generateMetadata cold path → fallback metadata

Sentry left unchanged: retry kills the noise at source, so remaining events = real sustained failures.


