### PR TITLE
fix: show date on user reports chart

### DIFF
--- a/apps/web/src/app/(landing)/status/[id]/user-reports.tsx
+++ b/apps/web/src/app/(landing)/status/[id]/user-reports.tsx
@@ -81,7 +81,20 @@ export function UserReports({
               <ChartTooltip
                 cursor={false}
                 content={
-                  <ChartTooltipContent indicator="line" labelKey="day" />
+                  <ChartTooltipContent
+                    indicator="line"
+                    labelFormatter={(_, payload) => {
+                      const day = payload?.[0]?.payload?.day;
+                      return day
+                        ? new Date(day).toLocaleDateString(undefined, {
+                            timeZone: "UTC",
+                            day: "numeric",
+                            month: "short",
+                            year: "numeric",
+                          })
+                        : "";
+                    }}
+                  />
                 }
               />
               <Bar


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

