### PR TITLE
fix: include user reports in markdown page

### DIFF
--- a/apps/web/src/content/status-markdown.ts
+++ b/apps/web/src/content/status-markdown.ts
@@ -77,6 +77,12 @@ function countryCount(n: number): string {
   return ` from ${n} ${n === 1 ? "country" : "countries"}`;
 }
 
+function settledRows<T>(result: PromiseSettledResult<T[]>): T[] {
+  if (result.status === "fulfilled") return result.value;
+  console.warn("[status markdown] report query failed:", result.reason);
+  return [];
+}
+
 async function generateReportsMarkdown(args: {
   serviceId: number;
   serviceName: string;
@@ -85,50 +91,46 @@ async function generateReportsMarkdown(args: {
   const since = new Date(now - REPORT_WINDOW_MS);
   const dailySince = new Date(now - HISTORY_DAYS * 24 * 60 * 60 * 1000);
 
-  try {
-    const [windowRows, dailyRows, countryRows] = await Promise.all([
-      getServiceReportWindows({ serviceIds: [args.serviceId], since }),
-      getServiceReportDaily({ serviceId: args.serviceId, since: dailySince }),
-      getServiceReportCountries({
-        serviceId: args.serviceId,
-        since,
-        limit: REPORT_COUNTRIES_LIMIT,
-      }),
-    ]);
+  const [windowRes, dailyRes, countryRes] = await Promise.allSettled([
+    getServiceReportWindows({ serviceIds: [args.serviceId], since }),
+    getServiceReportDaily({ serviceId: args.serviceId, since: dailySince }),
+    getServiceReportCountries({
+      serviceId: args.serviceId,
+      since,
+      limit: REPORT_COUNTRIES_LIMIT,
+    }),
+  ]);
 
-    const reporters = windowRows[0]?.reporters ?? 0;
-    const countries = windowRows[0]?.countries ?? 0;
-    const dailyWithReports = dailyRows.filter((r) => r.total > 0);
-    if (reporters === 0 && dailyWithReports.length === 0) return "";
+  const windowRows = settledRows(windowRes);
+  const dailyRows = settledRows(dailyRes);
+  const countryRows = settledRows(countryRes);
 
-    let md = `## ${args.serviceName} user reports\n\n`;
-    if (reporters >= REPORT_THRESHOLD) {
-      md += `Users are reporting problems with ${args.serviceName}: ${reporters} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
-    } else {
-      md += `${reporters} user ${reporters === 1 ? "report" : "reports"} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
-    }
+  const reporters = windowRows[0]?.reporters ?? 0;
+  const countries = windowRows[0]?.countries ?? 0;
+  const dailyWithReports = dailyRows.filter((r) => r.total > 0);
+  if (reporters === 0 && dailyWithReports.length === 0) return "";
 
-    if (countryRows.length > 0) {
-      md += `Top countries: ${countryRows.map((c) => `${c.country} (${c.total})`).join(", ")}\n\n`;
-    }
-
-    if (dailyWithReports.length > 0) {
-      md += "| Day | Reports | Reporters |\n";
-      md += "| --- | --- | --- |\n";
-      for (const r of dailyWithReports) {
-        md += `| ${r.day} | ${r.total} | ${r.reporters} |\n`;
-      }
-      md += "\n";
-    }
-
-    return md;
-  } catch (err) {
-    console.warn(
-      `[status markdown] user reports skipped for ${args.serviceName}:`,
-      err,
-    );
-    return "";
+  let md = `## ${args.serviceName} user reports\n\n`;
+  if (reporters >= REPORT_THRESHOLD) {
+    md += `Users are reporting problems with ${args.serviceName}: ${reporters} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
+  } else {
+    md += `${reporters} user ${reporters === 1 ? "report" : "reports"} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
   }
+
+  if (countryRows.length > 0) {
+    md += `Top countries: ${countryRows.map((c) => `${c.country} (${c.total})`).join(", ")}\n\n`;
+  }
+
+  if (dailyWithReports.length > 0) {
+    md += "| Day | Reports | Reporters |\n";
+    md += "| --- | --- | --- |\n";
+    for (const r of dailyWithReports) {
+      md += `| ${r.day} | ${r.total} | ${r.reporters} |\n`;
+    }
+    md += "\n";
+  }
+
+  return md;
 }
 
 export async function generateStatusIndexMarkdown(): Promise<string> {

--- a/apps/web/src/content/status-markdown.ts
+++ b/apps/web/src/content/status-markdown.ts
@@ -1,3 +1,13 @@
+import {
+  REPORT_THRESHOLD,
+  REPORT_WINDOW_MINUTES,
+  REPORT_WINDOW_MS,
+} from "@openstatus/api/src/router/effective-status";
+import {
+  getServiceReportCountries,
+  getServiceReportDaily,
+  getServiceReportWindows,
+} from "@openstatus/services/external-service-report";
 import { OSTinybird, safePipeData } from "@openstatus/tinybird";
 
 import { env } from "@/env";
@@ -23,6 +33,7 @@ type HistoryRow = {
 };
 
 const HISTORY_DAYS = 45;
+const REPORT_COUNTRIES_LIMIT = 5;
 
 function pillLabel(args: { indicator: string; status: string }): string {
   if (args.status === "under_maintenance") return "Maintenance";
@@ -59,6 +70,65 @@ function dayLabel(row: HistoryRow): string {
 function formatIso(ms: number): string {
   if (!ms) return "no data";
   return new Date(ms).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function countryCount(n: number): string {
+  if (n <= 0) return "";
+  return ` from ${n} ${n === 1 ? "country" : "countries"}`;
+}
+
+async function generateReportsMarkdown(args: {
+  serviceId: number;
+  serviceName: string;
+}): Promise<string> {
+  const now = Date.now();
+  const since = new Date(now - REPORT_WINDOW_MS);
+  const dailySince = new Date(now - HISTORY_DAYS * 24 * 60 * 60 * 1000);
+
+  try {
+    const [windowRows, dailyRows, countryRows] = await Promise.all([
+      getServiceReportWindows({ serviceIds: [args.serviceId], since }),
+      getServiceReportDaily({ serviceId: args.serviceId, since: dailySince }),
+      getServiceReportCountries({
+        serviceId: args.serviceId,
+        since,
+        limit: REPORT_COUNTRIES_LIMIT,
+      }),
+    ]);
+
+    const reporters = windowRows[0]?.reporters ?? 0;
+    const countries = windowRows[0]?.countries ?? 0;
+    const dailyWithReports = dailyRows.filter((r) => r.total > 0);
+    if (reporters === 0 && dailyWithReports.length === 0) return "";
+
+    let md = `## ${args.serviceName} user reports\n\n`;
+    if (reporters >= REPORT_THRESHOLD) {
+      md += `Users are reporting problems with ${args.serviceName}: ${reporters} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
+    } else {
+      md += `${reporters} user ${reporters === 1 ? "report" : "reports"} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
+    }
+
+    if (countryRows.length > 0) {
+      md += `Top countries: ${countryRows.map((c) => `${c.country} (${c.total})`).join(", ")}\n\n`;
+    }
+
+    if (dailyWithReports.length > 0) {
+      md += "| Day | Reports | Reporters |\n";
+      md += "| --- | --- | --- |\n";
+      for (const r of dailyWithReports) {
+        md += `| ${r.day} | ${r.total} | ${r.reporters} |\n`;
+      }
+      md += "\n";
+    }
+
+    return md;
+  } catch (err) {
+    console.warn(
+      `[status markdown] user reports skipped for ${args.serviceName}:`,
+      err,
+    );
+    return "";
+  }
 }
 
 export async function generateStatusIndexMarkdown(): Promise<string> {
@@ -182,6 +252,11 @@ export async function generateStatusDetailMarkdown(
     }
   }
   md += "\n";
+
+  md += await generateReportsMarkdown({
+    serviceId: service.id,
+    serviceName: service.name,
+  });
 
   md += "## Links\n\n";
   md += `- HTML page: /status/${service.slug}\n`;

--- a/apps/web/src/content/status-markdown.ts
+++ b/apps/web/src/content/status-markdown.ts
@@ -105,16 +105,19 @@ async function generateReportsMarkdown(args: {
   const dailyRows = settledRows(dailyRes);
   const countryRows = settledRows(countryRes);
 
+  const windowOk = windowRes.status === "fulfilled";
   const reporters = windowRows[0]?.reporters ?? 0;
   const countries = windowRows[0]?.countries ?? 0;
   const dailyWithReports = dailyRows.filter((r) => r.total > 0);
   if (reporters === 0 && dailyWithReports.length === 0) return "";
 
   let md = `## ${args.serviceName} user reports\n\n`;
-  if (reporters >= REPORT_THRESHOLD) {
-    md += `Users are reporting problems with ${args.serviceName}: ${reporters} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
-  } else {
-    md += `${reporters} user ${reporters === 1 ? "report" : "reports"} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
+  if (windowOk) {
+    if (reporters >= REPORT_THRESHOLD) {
+      md += `Users are reporting problems with ${args.serviceName}: ${reporters} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
+    } else {
+      md += `${reporters} user ${reporters === 1 ? "report" : "reports"} in the last ${REPORT_WINDOW_MINUTES} minutes${countryCount(countries)}.\n\n`;
+    }
   }
 
   if (countryRows.length > 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

