### PR TITLE
Include static components in status page banner calculation

### DIFF
--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -253,15 +253,18 @@ export const statusPageRouter = createTRPCRouter({
         };
       });
 
-      // no barType gate: incident-driven error is already suppressed per
-      // monitor in manual mode; report-driven error (major_outage) must show
-      const status = monitors.some((m) => m.status === "error")
-        ? "error"
-        : monitors.some((m) => m.status === "degraded")
-          ? "degraded"
-          : monitors.some((m) => m.status === "info")
-            ? "info"
-            : "success";
+      // Banner = worst status across ALL page components (monitor + static),
+      // so an active page-component impact surfaces — including on static
+      // components, which the monitor-only reduce dropped. Monitor components
+      // keep their incident/report/maintenance-derived status as the fallback
+      // when no impact is set. No barType gate: incident-driven error is
+      // already suppressed per monitor in manual mode; report-driven error
+      // (major_outage) must show.
+      const status = getWorstVariant(
+        components.map(
+          (c) => c.status as "success" | "degraded" | "error" | "info",
+        ),
+      );
 
       // Get page-wide events (not tied to specific monitors)
       const pageEvents = getEvents({

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -260,11 +260,7 @@ export const statusPageRouter = createTRPCRouter({
       // when no impact is set. No barType gate: incident-driven error is
       // already suppressed per monitor in manual mode; report-driven error
       // (major_outage) must show.
-      const status = getWorstVariant(
-        components.map(
-          (c) => c.status as "success" | "degraded" | "error" | "info",
-        ),
-      );
+      const status = getWorstVariant(components.map((c) => c.status));
 
       // Get page-wide events (not tied to specific monitors)
       const pageEvents = getEvents({


### PR DESCRIPTION
## Summary
Updates the status page banner calculation to consider all page components (both monitor-driven and static) when determining the worst status, rather than only monitor components. This ensures that active page-component impacts surface on the banner even for static components.

## Changes
- Replaced the nested ternary status calculation with a call to `getWorstVariant()` that operates on all components' statuses
- Updated the comment to clarify that the banner now reflects the worst status across all page components, including static ones
- Maintains existing behavior for incident/report/maintenance-derived status as fallback when no impact is set

## Implementation Details
The previous implementation only considered monitor statuses through a reduce operation. The new approach uses `components.map((c) => c.status)` to include both monitor and static component statuses, ensuring page-wide impacts are properly reflected in the banner status.

https://claude.ai/code/session_01L2VM74iH3srcPsbeQgTzhW

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

