### PR TITLE
Fix endpoint paths in status page markdown documentation

### DIFF
--- a/apps/web/src/content/pages/blog/status-page-markdown-for-agents.mdx
+++ b/apps/web/src/content/pages/blog/status-page-markdown-for-agents.mdx
@@ -35,8 +35,8 @@ Same status page, fetched both ways, then tokenized:
 
 | Request | What you get | Bytes | Tokens |
 | --- | --- | --- | --- |
-| `GET /status` | HTML | ~166 KB | ~59,500 |
-| `GET /status.md` *(or `Accept: text/markdown`)* | markdown | ~4.7 KB | ~1,225 |
+| `GET /` | HTML | ~166 KB | ~59,500 |
+| `GET /.md` *(or `Accept: text/markdown`)* | markdown | ~4.7 KB | ~1,225 |
 | **Shrinks by** | | **~36×** | **~49×** |
 
 That's a status page going from ~59,500 tokens to ~1,225 - roughly **49× lighter**. The `.md` suffix and the `Accept` header return byte-identical markdown; how you ask doesn't change what you get. The homepage tells the same story: ~181 KB / ~60,000 tokens of HTML collapse to ~8.8 KB / ~2,100 tokens as `/index.md`, about **28× lighter**.


### PR DESCRIPTION
## Summary
Updated the documentation examples in the status page markdown blog post to use correct endpoint paths that match the actual API implementation.

## Changes
- Changed `GET /status` to `GET /` in the comparison table
- Changed `GET /status.md` to `GET /.md` in the comparison table
- Updated the corresponding `Accept: text/markdown` header reference to reflect the correct endpoint

## Details
The documentation was referencing `/status` and `/status.md` endpoints, but the actual implementation uses `/` and `/.md` paths. This correction ensures that readers following the documentation will use the correct endpoints when requesting status pages in HTML or markdown format.

https://claude.ai/code/session_01RLFMEmdv3BBnCAfAjVNe2v

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

