### PR TITLE
fix(server): set acknowledgedBy/resolvedBy on incident update

### DIFF
--- a/apps/server/src/routes/v1/incidents/put.ts
+++ b/apps/server/src/routes/v1/incidents/put.ts
@@ -54,6 +54,7 @@ export function registerPutIncident(app: typeof incidentsApi) {
   return app.openapi(putRoute, async (c) => {
     const input = c.req.valid("json");
     const workspaceId = c.get("workspace").id;
+    const apiKey = c.get("apiKey");
     const { id } = c.req.valid("param");
 
     const _incident = await db
@@ -76,8 +77,16 @@ export function registerPutIncident(app: typeof incidentsApi) {
 
     const _newIncident = await db
       .update(incidentTable)
-      // TODO: we should set the acknowledgedBy and resolvedBy fields
-      .set({ ...input, updatedAt: new Date() })
+      .set({
+        ...input,
+        updatedAt: new Date(),
+        ...(input.acknowledgedAt !== undefined && {
+          acknowledgedBy: input.acknowledgedAt ? apiKey.createdById : null,
+        }),
+        ...(input.resolvedAt !== undefined && {
+          resolvedBy: input.resolvedAt ? apiKey.createdById : null,
+        }),
+      })
       .where(eq(incidentTable.id, Number(id)))
       .returning()
       .get();


### PR DESCRIPTION
## Description
The `PUT /v1/incidents/{id}` endpoint allows setting `acknowledgedAt` and 
`resolvedAt`, but never populates the corresponding `acknowledgedBy` and 
`resolvedBy` columns — even though both already exist in the schema 
(referencing `user.id`).

## Fix
Used `apiKey.createdById` from the auth context (already populated by 
`authMiddleware` for custom keys) to set `acknowledgedBy`/`resolvedBy` 
when the corresponding date field is being set. Falls back to `undefined` 
for Unkey/dev/super-admin keys, consistent with how `createdById` is 
already handled elsewhere (e.g. audit log attribution).

## Testing
Verified the update query sets the field conditionally based on whether 
`acknowledgedAt`/`resolvedAt` is present in the input.

> Opened issue #2297 two days ago with no response. Opening this PR 
> directly as the fix is scoped and ready.

Closes #2297

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

