### PR TITLE
logs: catch sentry error on external failure

### DIFF
--- a/apps/workflows/src/cron/external-status.ts
+++ b/apps/workflows/src/cron/external-status.ts
@@ -23,7 +23,11 @@ import { Effect } from "effect";
 import type { Context } from "hono";
 
 import { env } from "../env";
-import { reportBackgroundError, runSentryCron } from "../lib/sentry";
+import {
+  reportBackgroundError,
+  reportFetchFailure,
+  runSentryCron,
+} from "../lib/sentry";
 
 const logger = getLogger(["workflow", "external-status"]);
 
@@ -161,10 +165,9 @@ function runStatusPhase(
           }),
         ),
         Effect.catchAll((err: FetchError) =>
-          Effect.succeed<StatusPhaseOutcome>({
-            kind: "fail",
-            slug: entry.id,
-            reason: err.message,
+          Effect.sync<StatusPhaseOutcome>(() => {
+            reportFetchFailure({ phase: "status", slug: entry.id, error: err });
+            return { kind: "fail", slug: entry.id, reason: err.message };
           }),
         ),
       );
@@ -214,10 +217,13 @@ function runIncidentPhase(
           ),
         ),
         Effect.catchAll((err: FetchError) =>
-          Effect.succeed<IncidentPhaseOutcome>({
-            kind: "fail",
-            slug: entry.id,
-            reason: err.message,
+          Effect.sync<IncidentPhaseOutcome>(() => {
+            reportFetchFailure({
+              phase: "incidents",
+              slug: entry.id,
+              error: err,
+            });
+            return { kind: "fail", slug: entry.id, reason: err.message };
           }),
         ),
       );
@@ -281,10 +287,13 @@ function runComponentPhase(
           ),
         ),
         Effect.catchAll((err: FetchError) =>
-          Effect.succeed<ComponentPhaseOutcome>({
-            kind: "fail",
-            slug: entry.id,
-            reason: err.message,
+          Effect.sync<ComponentPhaseOutcome>(() => {
+            reportFetchFailure({
+              phase: "components",
+              slug: entry.id,
+              error: err,
+            });
+            return { kind: "fail", slug: entry.id, reason: err.message };
           }),
         ),
       );
@@ -426,7 +435,7 @@ export async function runExternalStatusTick(): Promise<{
           runIncidentPhase(triplets, tickStartedAt),
           runComponentPhase(triplets, tickStartedAt, tickStartedAt.getTime()),
         ],
-        { concurrency: "50" },
+        { concurrency: 50 },
       ),
     );
 

--- a/apps/workflows/src/lib/sentry.ts
+++ b/apps/workflows/src/lib/sentry.ts
@@ -1,3 +1,4 @@
+import { FetchError } from "@openstatus/status-fetcher";
 import * as Sentry from "@sentry/bun";
 
 import { env } from "../env";
@@ -31,4 +32,24 @@ export function runSentryCron(monitorSlug: string): {
 export async function reportBackgroundError(message: string): Promise<void> {
   Sentry.captureMessage(message, "error");
   await Sentry.flush();
+}
+
+// Fires inside the per-service fetch loop, so no flush here — the tick's
+// cronCompleted/cronFailed path flushes once the tick settles.
+export function reportFetchFailure(args: {
+  phase: "status" | "incidents" | "components";
+  slug: string;
+  error: FetchError;
+}): void {
+  const { phase, slug, error } = args;
+  Sentry.captureException(error, {
+    tags: {
+      cron: "external-status",
+      phase,
+      slug,
+      fetcher: error.fetcherName ?? "unknown",
+      http_status: error.httpStatus,
+    },
+    extra: { url: error.url },
+  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

