### PR TITLE
status page: robots no index

### DIFF
--- a/apps/status-page/src/app/robots.ts
+++ b/apps/status-page/src/app/robots.ts
@@ -26,13 +26,31 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
     : null;
   const row = route
     ? await db
-        .select({ slug: page.slug, customDomain: page.customDomain })
+        .select({
+          slug: page.slug,
+          customDomain: page.customDomain,
+          allowIndex: page.allowIndex,
+        })
         .from(page)
         .where(
           sql`lower(${page.slug}) = ${route.prefix} OR lower(${page.customDomain}) = ${route.prefix}`,
         )
         .get()
     : undefined;
+
+  // The page owner opted out of indexing: disallow everything and omit the
+  // sitemap so crawlers have nothing to follow.
+  if (row && !row.allowIndex) {
+    return {
+      rules: [
+        {
+          userAgent: "*",
+          disallow: "/",
+        },
+      ],
+    };
+  }
+
   const sitemap = row
     ? `${getBaseUrl({ slug: row.slug, customDomain: row.customDomain ?? undefined })}/sitemap.xml`
     : undefined;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

