### PR TITLE
slack app: dedupe event

### DIFF
--- a/apps/server/src/routes/slack/handler.test.ts
+++ b/apps/server/src/routes/slack/handler.test.ts
@@ -150,6 +150,39 @@ describe("handleSlackEvent", () => {
     expect(slackTestState.calls.length).toBe(0);
   });
 
+  test("responds once when a mention arrives as app_mention and message", async () => {
+    const ts = `${Date.now()}.55`;
+    const base = {
+      type: "event_callback",
+      team_id: "T_KNOWN",
+      event: {
+        text: "<@UBOT> create an incident",
+        user: "U1",
+        channel: "C1",
+        channel_type: "channel",
+        ts,
+      },
+    };
+
+    // Same underlying message, delivered as two distinct events.
+    await signAndPost(app, {
+      ...base,
+      event_id: `evt_mention_${ts}`,
+      event: { ...base.event, type: "app_mention" },
+    });
+    await signAndPost(app, {
+      ...base,
+      event_id: `evt_message_${ts}`,
+      event: { ...base.event, type: "message" },
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    const thinking = slackTestState.calls.filter(
+      (m) => m.method === "postMessage",
+    );
+    expect(thinking.length).toBe(1);
+  });
+
   test("handles app_uninstalled event", async () => {
     const res = await signAndPost(app, {
       type: "event_callback",

--- a/apps/server/src/routes/slack/handler.ts
+++ b/apps/server/src/routes/slack/handler.ts
@@ -170,6 +170,12 @@ async function processEvent(body: SlackEvent) {
   const teamId = body.team_id;
   if (!teamId || !event.channel || !event.ts) return;
 
+  // A single mention arrives as BOTH an `app_mention` and a `message.*` event
+  // (distinct event_ids, same message ts), so the event_id dedup above doesn't
+  // catch the pair. Dedup on the message identity so we only respond once.
+  // Runs before the first `await` so concurrent deliveries can't both pass.
+  if (dedup(`msg:${event.channel}:${event.ts}`)) return;
+
   const resolved = await resolveWorkspace(teamId);
   if (!resolved) {
     logger.warn("slack integration not found", { teamId });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

