### PR TITLE
Add Commit Mono font and configure monospace font stack

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -25,6 +25,32 @@ const calSans = LocalFont({
   variable: "--font-cal",
 });
 
+const commitMono = LocalFont({
+  src: [
+    {
+      path: "../public/fonts/CommitMono-400-Regular.otf",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "../public/fonts/CommitMono-400-Italic.otf",
+      weight: "400",
+      style: "italic",
+    },
+    {
+      path: "../public/fonts/CommitMono-700-Regular.otf",
+      weight: "700",
+      style: "normal",
+    },
+    {
+      path: "../public/fonts/CommitMono-700-Italic.otf",
+      weight: "700",
+      style: "italic",
+    },
+  ],
+  variable: "--font-commit-mono",
+});
+
 export const metadata: Metadata = {
   ...defaultMetadata,
   twitter: {
@@ -45,7 +71,7 @@ export default function RootLayout({
       <body
         className={`${
           inter.className
-        } ${inter.variable} ${calSans.variable} antialiased`}
+        } ${inter.variable} ${calSans.variable} ${commitMono.variable} antialiased`}
       >
         <PlausibleProvider domain="openstatus.dev">
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -22,9 +22,6 @@
     var(--font-sans), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-cal: var(--font-calsans);
-  --font-mono:
-    var(--font-commit-mono), ui-monospace, SFMono-Regular, Menlo, Monaco,
-    Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
@@ -45,6 +42,10 @@
       height: 0;
     }
   }
+}
+
+@theme inline {
+  --font-mono: var(--font-commit-mono);
 }
 
 @utility container {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -22,6 +22,9 @@
     var(--font-sans), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-cal: var(--font-calsans);
+  --font-mono:
+    var(--font-commit-mono), ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;


### PR DESCRIPTION
## Summary
Adds the Commit Mono font family to the web application and configures it as the default monospace font stack.

## Changes
- **Font registration:** Added `commitMono` LocalFont configuration in `apps/web/src/app/layout.tsx` with support for regular and italic styles at weights 400 and 700
- **Layout integration:** Included the `commitMono` CSS variable in the root layout's body className
- **Font stack:** Defined `--font-mono` CSS variable in `apps/web/src/styles/globals.css` with Commit Mono as the primary monospace font, falling back to system monospace fonts

## Implementation Details
The Commit Mono font is loaded from OTF files in the public fonts directory and exposed via the `--font-commit-mono` CSS variable, which is then referenced in the global `--font-mono` stack for use throughout the application.

https://claude.ai/code/session_011v4nLgnniGav1frub1yxJ9

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

