### PR TITLE
Fix status page redirect to include default locale

### DIFF
--- a/apps/status-page/src/app/(public)/client.tsx
+++ b/apps/status-page/src/app/(public)/client.tsx
@@ -248,8 +248,6 @@ export function Client() {
             onClick={() => {
               // NOTE: we use it to display the 'floating-theme' component
               sessionStorage.setItem("community-theme", "true");
-              // The proxy doesn't rewrite on the themes subdomain, so the
-              // locale segment must be explicit to match /[domain]/[locale]
               window.location.href = `/status/${defaultLocale}`;
             }}
           >

--- a/apps/status-page/src/app/(public)/client.tsx
+++ b/apps/status-page/src/app/(public)/client.tsx
@@ -40,6 +40,7 @@ import { StatusComponentStatic } from "../../components/status-page/static/statu
 import { ThemePalettePicker } from "../../components/themes/theme-palette-picker";
 import { ThemeSelect } from "../../components/themes/theme-select";
 import { monitors } from "../../data/monitors";
+import { defaultLocale } from "../../i18n/config";
 import { useTRPC } from "../../lib/trpc/client";
 import { searchParamsParsers } from "./search-params";
 
@@ -247,7 +248,9 @@ export function Client() {
             onClick={() => {
               // NOTE: we use it to display the 'floating-theme' component
               sessionStorage.setItem("community-theme", "true");
-              window.location.href = "/status";
+              // The proxy doesn't rewrite on the themes subdomain, so the
+              // locale segment must be explicit to match /[domain]/[locale]
+              window.location.href = `/status/${defaultLocale}`;
             }}
           >
             Test it


### PR DESCRIPTION
## Summary
Updates the status page client redirect to include the default locale in the URL path, ensuring proper internationalization support when navigating to the status page.

## Changes
- Import `defaultLocale` from the i18n config
- Update the "Test it" button redirect from `/status` to `/status/${defaultLocale}` to match the expected locale-prefixed routing structure

## Details
The status page uses locale-prefixed routes (e.g., `/status/en`, `/status/fr`). The redirect was previously hardcoded to `/status` without a locale, which would not match the application's routing expectations. This change ensures the redirect navigates to the correct locale-aware path using the configured default locale.

https://claude.ai/code/session_0152w6QAWZDhjy3DyFHUoBJT

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

