### PR TITLE
Fix InputGroup control slot attribute ordering

### DIFF
--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -134,12 +134,14 @@ function InputGroupInput({
 }: React.ComponentProps<"input">) {
   return (
     <Input
+      {...props}
+      // after the spread so FormControl's Slot-injected data-slot can't
+      // clobber it — the group's focus/error selectors depend on it
       data-slot="input-group-control"
       className={cn(
         "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
         className,
       )}
-      {...props}
     />
   );
 }
@@ -150,12 +152,12 @@ function InputGroupTextarea({
 }: React.ComponentProps<"textarea">) {
   return (
     <Textarea
+      {...props}
       data-slot="input-group-control"
       className={cn(
         "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
         className,
       )}
-      {...props}
     />
   );
 }


### PR DESCRIPTION
## Summary

Reorder the spread operator and `data-slot` attribute in `InputGroupInput` and `InputGroupTextarea` components to ensure the group's focus/error selectors work correctly.

## Changes

- **InputGroupInput**: Moved `{...props}` before `data-slot="input-group-control"` so that FormControl's Slot-injected `data-slot` cannot override the group's required selector
- **InputGroupTextarea**: Applied the same fix for consistency

## Implementation Details

The `data-slot` attribute is critical for the input group's CSS selectors that handle focus and error states. By placing the spread operator first, any `data-slot` value from props is overridden by the explicit `data-slot="input-group-control"` attribute, ensuring the group's styling logic remains intact regardless of what props are passed in.

https://claude.ai/code/session_01MopB6mmGuKVKZX1zdWAjjA

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

