### PR TITLE
feat(theme-store): add Further community theme

### DIFF
--- a/packages/theme-store/src/further.ts
+++ b/packages/theme-store/src/further.ts
@@ -1,0 +1,51 @@
+import type { Theme } from "./types";
+
+export const FURTHER_THEME = {
+  id: "further",
+  name: "Further",
+  author: { name: "@withfurther", url: "https://www.withfurther.com" },
+  light: {
+    "--radius": "0.75rem",
+
+    "--background": "oklch(100% 0 0)",
+    "--foreground": "oklch(24.78% 0 0)",
+    "--border": "oklch(90% 0.004 91.45)",
+    "--input": "oklch(90% 0.004 91.45)",
+
+    "--primary": "oklch(24.78% 0 0)",
+    "--primary-foreground": "oklch(97.91% 0.0041 91.45)",
+    "--secondary": "oklch(97.91% 0.0041 91.45)",
+    "--secondary-foreground": "oklch(24.78% 0 0)",
+    "--muted": "oklch(97.91% 0.0041 91.45)",
+    "--muted-foreground": "oklch(50% 0.004 91.45)",
+    "--accent": "oklch(97.91% 0.0041 91.45)",
+    "--accent-foreground": "oklch(24.78% 0 0)",
+
+    "--success": "oklch(64% 0.17 150)",
+    "--destructive": "oklch(57.7% 0.245 27.325)",
+    "--warning": "oklch(77% 0.16 70)",
+    "--info": "oklch(57.37% 0.1946 257.86)",
+  },
+  dark: {
+    "--radius": "0.75rem",
+
+    "--background": "oklch(21.06% 0.005 67.55)",
+    "--foreground": "oklch(97.91% 0.0041 91.45)",
+    "--border": "oklch(100% 0 0 / 10%)",
+    "--input": "oklch(100% 0 0 / 15%)",
+
+    "--primary": "oklch(97.91% 0.0041 91.45)",
+    "--primary-foreground": "oklch(21.06% 0.005 67.55)",
+    "--secondary": "oklch(27.5% 0.005 67.55)",
+    "--secondary-foreground": "oklch(97.91% 0.0041 91.45)",
+    "--muted": "oklch(27.5% 0.005 67.55)",
+    "--muted-foreground": "oklch(72% 0.004 91.45)",
+    "--accent": "oklch(27.5% 0.005 67.55)",
+    "--accent-foreground": "oklch(97.91% 0.0041 91.45)",
+
+    "--success": "oklch(72% 0.19 150)",
+    "--destructive": "oklch(70.4% 0.191 22.216)",
+    "--warning": "oklch(77% 0.16 70)",
+    "--info": "oklch(66% 0.17 257.86)",
+  },
+} as const satisfies Theme;

--- a/packages/theme-store/src/index.ts
+++ b/packages/theme-store/src/index.ts
@@ -6,6 +6,7 @@ import {
   sanitizeCustomTheme,
 } from "./custom-theme";
 import { DRACULA_THEME } from "./dracula";
+import { FURTHER_THEME } from "./further";
 import { GITHUB_HIGH_CONTRAST_THEME } from "./github";
 import { OPENSTATUS_ROUNDED_THEME, OPENSTATUS_THEME } from "./openstatus";
 import { SUPABASE_THEME } from "./supabase";
@@ -18,6 +19,7 @@ const THEMES_LIST = [
   SUPABASE_THEME,
   GITHUB_HIGH_CONTRAST_THEME,
   DRACULA_THEME,
+  FURTHER_THEME,
 ] satisfies Theme[];
 
 // NOTE: runtime validation to ensure that the theme IDs are unique


### PR DESCRIPTION
## What

Adds a new community theme, **Further**, contributed from the [Further](https://www.withfurther.com) brand (AI-powered platform for first-time homebuyers). We run our status page on OpenStatus at [status.withfurther.com](https://status.withfurther.com) and wanted our brand palette available via the theme explorer.

## Design notes

- **Light**: pure white background, warm near-black foreground (`#212121`), cream (`#f9f8f5`) secondary/muted/accent surfaces sampled from our brand marks, dark primary buttons.
- **Dark**: warm near-black background (`#1a1816`, sampled from the brand dark mark), cream foreground — same warm-neutral family as light mode.
- **Status colors**: kept close to the openstatus defaults for semantic recognizability; `--info` uses the Further brand blue (`#1a73e8` → `oklch(57.37% 0.1946 257.86)`), light-mode `--success` darkened to `oklch(64% 0.17 150)` for better contrast on white than the default.
- **Radius**: `0.75rem` — echoes the rounded/pill shapes used across withfurther.com.

## Accessibility

Measured WCAG contrast ratios:

| pair | light | dark |
|---|---|---|
| foreground / background | 16.1:1 | 16.7:1 |
| muted-foreground / background | 6.0:1 | 7.1:1 |
| info / background | 4.5:1 | 5.6:1 |
| success / background | 3.1:1 | 7.7:1 |
| destructive / background | 4.8:1 | 6.1:1 |
| primary-foreground / primary | 15.2:1 | 15.2:1 |

All four status colors are clearly distinguishable from each other in both modes.

## Checks

- `deno check --sloppy-imports .` passes in `packages/theme-store`
- `deno test` — 7 passed (includes the unique-theme-id runtime assertion)
- `oxfmt --check` clean on both changed files

Happy to adjust anything to fit the design guidelines.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

