### PR TITLE
Updated prefetching in parallel

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -41,10 +41,12 @@ export default async function Layout({
 
 async function HydrateSidebar({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.page.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.monitor.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.workspace.get.queryOptions());
-  await queryClient.prefetchQuery(trpc.user.get.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
+    queryClient.prefetchQuery(trpc.user.get.queryOptions()),
+  ]);
 
   return <HydrateClient>{children}</HydrateClient>;
 }

--- a/apps/dashboard/src/app/(dashboard)/monitors/(list)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/(list)/page.tsx
@@ -12,9 +12,11 @@ export default async function Page({
 }) {
   const queryClient = getQueryClient();
 
-  await searchParamsCache.parse(searchParams);
-  await queryClient.prefetchQuery(trpc.monitor.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions());
+  await Promise.all([
+    searchParamsCache.parse(searchParams),
+    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions()),
+  ]);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/edit/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/edit/layout.tsx
@@ -6,8 +6,10 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
+  ]);
 
   return <HydrateClient>{children}</HydrateClient>;
 }

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/layout.tsx
@@ -28,8 +28,10 @@ export default async function Layout({
   await fetchQueryOrNotFound(
     trpc.monitor.get.queryOptions({ id: Number.parseInt(id) }),
   );
-  await queryClient.prefetchQuery(trpc.notification.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.notification.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
+  ]);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/overview/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/overview/layout.tsx
@@ -16,12 +16,14 @@ export default async function Layout({
 }) {
   const queryClient = getQueryClient();
 
-  await queryClient.prefetchQuery(trpc.monitor.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.page.list.queryOptions());
   // inputs must match page.tsx's queries exactly — a differing input misses the cache
-  await queryClient.prefetchQuery(trpc.incident.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.statusReport.list.queryOptions({}));
-  await queryClient.prefetchQuery(trpc.maintenance.list.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.incident.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.statusReport.list.queryOptions({})),
+    queryClient.prefetchQuery(trpc.maintenance.list.queryOptions()),
+  ]);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/settings/general/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/general/layout.tsx
@@ -16,9 +16,11 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.member.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.invitation.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.apiKeyRouter.getAll.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.member.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.invitation.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.apiKeyRouter.getAll.queryOptions()),
+  ]);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/settings/integrations/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/integrations/layout.tsx
@@ -16,8 +16,10 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.integrationRouter.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.workspace.get.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.integrationRouter.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
+  ]);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/settings/private-locations/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/private-locations/layout.tsx
@@ -16,8 +16,10 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.notification.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.notification.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
+  ]);
   return (
     <HydrateClient>
       <div>

--- a/apps/dashboard/src/app/onboarding/layout.tsx
+++ b/apps/dashboard/src/app/onboarding/layout.tsx
@@ -6,10 +6,12 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.workspace.get.queryOptions());
-  await queryClient.prefetchQuery(trpc.user.get.queryOptions());
-  await queryClient.prefetchQuery(trpc.monitor.list.queryOptions());
-  await queryClient.prefetchQuery(trpc.page.list.queryOptions());
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
+    queryClient.prefetchQuery(trpc.user.get.queryOptions()),
+    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
+    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
+  ]);
 
   return <HydrateClient>{children}</HydrateClient>;
 }


### PR DESCRIPTION
## Summary
- Several dashboard server layouts/pages prefetched multiple independent tRPC queries with sequential `await`s, so each cold navigation paid the sum of N round-trips to the DB instead of the max of N.
- Parallelized every affected site (9 files) with `Promise.all`: the main dashboard shell, overview, onboarding, monitor list, monitor detail, monitor edit, and the general/integrations/private-locations settings pages.
- Behavior-preserving — same queries, same cache keys, same error semantics. The one guarded case (`monitors/[id]/layout.tsx`) keeps its `fetchQueryOrNotFound` 404 check sequential and only parallelizes the two independent calls that follow it.

## Test plan
- [x] `tsc --noEmit` on `apps/dashboard` — no new errors from this change (pre-existing stale `.next` typed-route cache noise only, unrelated to the touched files)
- [x] `oxlint` on all 9 touched files — clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->