### PR TITLE
fix(docker): use exec-form healthchecks for workflows and server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
             libsql:
                 condition: service_healthy
         healthcheck:
-            test: ["CMD-SHELL", "curl -f http://localhost:3000/ping || exit 1"]
+            test: ["CMD", "curl", "-f", "http://localhost:3000/ping"]
             interval: 15s
             timeout: 10s
             retries: 3
@@ -103,7 +103,7 @@ services:
             libsql:
                 condition: service_healthy
         healthcheck:
-            test: ["CMD-SHELL", "curl -f http://localhost:3000/ping || exit 1"]
+            test: ["CMD", "curl", "-f", "http://localhost:3000/ping"]
             interval: 15s
             timeout: 10s
             retries: 3


### PR DESCRIPTION
## Summary

This PR applies the same healthcheck fix introduced in #2342 to the default `docker-compose.yaml`.

While reproducing #2336 on the current `main` branch, I found that the `workflows` and `server` services still used `CMD-SHELL` for their curl-based healthchecks in `docker-compose.yaml`, even though the equivalent fix had already been applied to `docker-compose.github-packages.yaml`.

Since these services use shell-less runtime images, Docker attempts to execute the healthcheck through `/bin/sh`, causing it to fail before `curl` is executed.

This PR updates those healthchecks to use the exec-form `CMD`, matching the implementation already used in `docker-compose.github-packages.yaml`.

## Verification

### Before

```bash
docker compose down -v
docker compose up -d
```

Docker reported:

```text
dependency failed to start: container openstatus-workflows is unhealthy
```

Health output:

```text
OCI runtime exec failed:
exec: "/bin/sh": stat /bin/sh: no such file or directory
```

### After

```bash
docker compose down -v
docker compose up -d
```

Both `workflows` and `server` become healthy, allowing the remaining dependent services to start successfully.

Related to #2336.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

