### PR TITLE
Use page component name/description for public monitor display

### DIFF
--- a/apps/workflows/src/checker/private-location.test.ts
+++ b/apps/workflows/src/checker/private-location.test.ts
@@ -1,6 +1,9 @@
 import { and, db, eq } from "@openstatus/db";
 import {
+  monitor,
+  notification,
   notificationTrigger,
+  notificationsToMonitors,
   privateLocation,
   privateLocationMonitorStatus,
   privateLocationToMonitors,
@@ -26,8 +29,12 @@ import { providerToFunction } from "./utils";
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous provider stubs
 type AnyStub = Stub<any>;
 
-const TEST_MONITOR_ID = 1; // seed: workspace 1, active, linked to email notification 1
-const INACTIVE_MONITOR_ID = 2; // seed: active = false
+// Dedicated fixtures, not seed monitor 1: other suites (api/server maintenance
+// tests) put seed monitor 1 under active maintenance on the shared CI database,
+// which makes updateStatusPrivate suppress notifications and drop the write.
+const TEST_MONITOR_ID = 9101;
+const INACTIVE_MONITOR_ID = 9102;
+const TEST_NOTIFICATION_ID = 9101;
 const TEST_LOCATION_ID = 9001;
 const UNATTACHED_LOCATION_ID = 9002;
 
@@ -75,6 +82,49 @@ describe("updateStatusPrivate", () => {
 
   beforeAll(async () => {
     await db
+      .insert(monitor)
+      .values([
+        {
+          id: TEST_MONITOR_ID,
+          workspaceId: 1,
+          active: true,
+          url: "https://private-location.test",
+          name: "Private Location Test Monitor",
+          periodicity: "1m",
+          regions: "ams",
+        },
+        {
+          id: INACTIVE_MONITOR_ID,
+          workspaceId: 1,
+          active: false,
+          url: "https://private-location-inactive.test",
+          name: "Private Location Inactive Monitor",
+          periodicity: "1m",
+          regions: "ams",
+        },
+      ])
+      .onConflictDoNothing()
+      .run();
+    await db
+      .insert(notification)
+      .values({
+        id: TEST_NOTIFICATION_ID,
+        provider: "email",
+        name: "private location test notification",
+        data: '{"email":"ping@openstatus.dev"}',
+        workspaceId: 1,
+      })
+      .onConflictDoNothing()
+      .run();
+    await db
+      .insert(notificationsToMonitors)
+      .values({
+        monitorId: TEST_MONITOR_ID,
+        notificationId: TEST_NOTIFICATION_ID,
+      })
+      .onConflictDoNothing()
+      .run();
+    await db
       .insert(privateLocation)
       .values({
         id: TEST_LOCATION_ID,
@@ -113,6 +163,16 @@ describe("updateStatusPrivate", () => {
       .delete(privateLocation)
       .where(eq(privateLocation.id, TEST_LOCATION_ID))
       .run();
+    await db
+      .delete(notificationsToMonitors)
+      .where(eq(notificationsToMonitors.monitorId, TEST_MONITOR_ID))
+      .run();
+    await db
+      .delete(notification)
+      .where(eq(notification.id, TEST_NOTIFICATION_ID))
+      .run();
+    await db.delete(monitor).where(eq(monitor.id, TEST_MONITOR_ID)).run();
+    await db.delete(monitor).where(eq(monitor.id, INACTIVE_MONITOR_ID)).run();
   });
 
   beforeEach(() => {

--- a/packages/api/src/router/statusPage.e2e.test.ts
+++ b/packages/api/src/router/statusPage.e2e.test.ts
@@ -1209,9 +1209,7 @@ describe("statusPage exposes page component names, not internal monitor names", 
       .where(eq(pageComponent.id, clearedDescriptionComponentId));
     await db.delete(monitor).where(eq(monitor.id, publicNameMonitorId));
     await db.delete(monitor).where(eq(monitor.id, noDescriptionMonitorId));
-    await db
-      .delete(monitor)
-      .where(eq(monitor.id, clearedDescriptionMonitorId));
+    await db.delete(monitor).where(eq(monitor.id, clearedDescriptionMonitorId));
     await db.delete(page).where(eq(page.id, publicNamePageId));
   });
 

--- a/packages/api/src/router/statusPage.e2e.test.ts
+++ b/packages/api/src/router/statusPage.e2e.test.ts
@@ -1065,6 +1065,8 @@ describe("statusPage exposes page component names, not internal monitor names", 
   let publicNameComponentId: number;
   let noDescriptionMonitorId: number;
   let noDescriptionComponentId: number;
+  let clearedDescriptionMonitorId: number;
+  let clearedDescriptionComponentId: number;
 
   const internalName = "Internal Monitor Name";
   const internalDescription = "Internal monitor description";
@@ -1162,6 +1164,37 @@ describe("statusPage exposes page component names, not internal monitor names", 
       .returning()
       .get();
     noDescriptionComponentId = noDescriptionComponent.id;
+
+    // mirrors a deliberately cleared field: the dashboard stores ""
+    const clearedDescriptionMonitor = await db
+      .insert(monitor)
+      .values({
+        workspaceId: 1,
+        name: "Cleared Description Component Monitor",
+        description: "Internal description that must stay hidden",
+        periodicity: "1m",
+        url: "https://example.com",
+        active: true,
+        public: true,
+      })
+      .returning()
+      .get();
+    clearedDescriptionMonitorId = clearedDescriptionMonitor.id;
+
+    const clearedDescriptionComponent = await db
+      .insert(pageComponent)
+      .values({
+        workspaceId: 1,
+        pageId: publicNamePageId,
+        type: "monitor",
+        monitorId: clearedDescriptionMonitorId,
+        name: "Cleared Description Component",
+        description: "",
+        order: 2,
+      })
+      .returning()
+      .get();
+    clearedDescriptionComponentId = clearedDescriptionComponent.id;
   });
 
   afterAll(async () => {
@@ -1171,8 +1204,14 @@ describe("statusPage exposes page component names, not internal monitor names", 
     await db
       .delete(pageComponent)
       .where(eq(pageComponent.id, noDescriptionComponentId));
+    await db
+      .delete(pageComponent)
+      .where(eq(pageComponent.id, clearedDescriptionComponentId));
     await db.delete(monitor).where(eq(monitor.id, publicNameMonitorId));
     await db.delete(monitor).where(eq(monitor.id, noDescriptionMonitorId));
+    await db
+      .delete(monitor)
+      .where(eq(monitor.id, clearedDescriptionMonitorId));
     await db.delete(page).where(eq(page.id, publicNamePageId));
   });
 
@@ -1234,6 +1273,27 @@ describe("statusPage exposes page component names, not internal monitor names", 
       (m) => m.id === noDescriptionMonitorId,
     );
     expect(lightItem?.description).toBe(fallbackDescription);
+  });
+
+  test("keeps a deliberately cleared component description blank", async () => {
+    const caller = await createCaller();
+    const result = await caller.statusPage.get({ slug: publicNameSlug });
+
+    const monitorItem = result?.monitors.find(
+      (m) => m.id === clearedDescriptionMonitorId,
+    );
+    expect(monitorItem?.description).toBe("");
+
+    const component = result?.pageComponents.find(
+      (c) => c.monitorId === clearedDescriptionMonitorId,
+    );
+    expect(component?.monitor?.description).toBe("");
+
+    const light = await caller.statusPage.getLight({ slug: publicNameSlug });
+    const lightItem = light?.monitors.find(
+      (m) => m.id === clearedDescriptionMonitorId,
+    );
+    expect(lightItem?.description).toBe("");
   });
 
   test("getUptime returns the page component name on the nested monitor", async () => {

--- a/packages/api/src/router/statusPage.e2e.test.ts
+++ b/packages/api/src/router/statusPage.e2e.test.ts
@@ -1151,6 +1151,13 @@ describe("statusPage exposes page component names, not internal monitor names", 
     expect(monitorItem?.description).toBe(componentDescription);
     expect(monitorItem?.name).not.toBe(internalName);
     expect(monitorItem?.name).not.toBe(legacyExternalName);
+
+    // the nested monitor relation must agree with the flat monitors array
+    const component = result?.pageComponents.find(
+      (c) => c.monitorId === publicNameMonitorId,
+    );
+    expect(component?.monitor?.name).toBe(componentName);
+    expect(component?.monitor?.description).toBe(componentDescription);
   });
 
   test("getLight returns the page component name and description", async () => {
@@ -1163,6 +1170,28 @@ describe("statusPage exposes page component names, not internal monitor names", 
 
     expect(monitorItem?.name).toBe(componentName);
     expect(monitorItem?.description).toBe(componentDescription);
+
+    const component = result?.pageComponents.find(
+      (c) => c.monitorId === publicNameMonitorId,
+    );
+    expect(component?.monitor?.name).toBe(componentName);
+    expect(component?.monitor?.description).toBe(componentDescription);
+  });
+
+  test("getUptime returns the page component name on the nested monitor", async () => {
+    const caller = await createCaller();
+    const result = await caller.statusPage.getUptime({
+      slug: publicNameSlug,
+      pageComponentIds: [String(publicNameComponentId)],
+    });
+
+    const component = result?.find(
+      (c) => c.pageComponentId === publicNameComponentId,
+    );
+
+    expect(component?.name).toBe(componentName);
+    expect(component?.monitor?.name).toBe(componentName);
+    expect(component?.monitor?.description).toBe(componentDescription);
   });
 
   test("getMonitor returns the page component name and description", async () => {

--- a/packages/api/src/router/statusPage.e2e.test.ts
+++ b/packages/api/src/router/statusPage.e2e.test.ts
@@ -1063,12 +1063,15 @@ describe("statusPage exposes page component names, not internal monitor names", 
   let publicNamePageId: number;
   let publicNameMonitorId: number;
   let publicNameComponentId: number;
+  let noDescriptionMonitorId: number;
+  let noDescriptionComponentId: number;
 
   const internalName = "Internal Monitor Name";
   const internalDescription = "Internal monitor description";
   const legacyExternalName = "Legacy External Name";
   const componentName = "Public Component Name";
   const componentDescription = "Public component description";
+  const fallbackDescription = "Monitor description used as fallback";
 
   async function createCaller() {
     const { edgeRouter } = await import("../edge");
@@ -1129,13 +1132,47 @@ describe("statusPage exposes page component names, not internal monitor names", 
       .returning()
       .get();
     publicNameComponentId = testComponent.id;
+
+    // mirrors pre-existing components: description was never backfilled (NULL)
+    const noDescriptionMonitor = await db
+      .insert(monitor)
+      .values({
+        workspaceId: 1,
+        name: "No Description Component Monitor",
+        description: fallbackDescription,
+        periodicity: "1m",
+        url: "https://example.com",
+        active: true,
+        public: true,
+      })
+      .returning()
+      .get();
+    noDescriptionMonitorId = noDescriptionMonitor.id;
+
+    const noDescriptionComponent = await db
+      .insert(pageComponent)
+      .values({
+        workspaceId: 1,
+        pageId: publicNamePageId,
+        type: "monitor",
+        monitorId: noDescriptionMonitorId,
+        name: "No Description Component",
+        order: 1,
+      })
+      .returning()
+      .get();
+    noDescriptionComponentId = noDescriptionComponent.id;
   });
 
   afterAll(async () => {
     await db
       .delete(pageComponent)
       .where(eq(pageComponent.id, publicNameComponentId));
+    await db
+      .delete(pageComponent)
+      .where(eq(pageComponent.id, noDescriptionComponentId));
     await db.delete(monitor).where(eq(monitor.id, publicNameMonitorId));
+    await db.delete(monitor).where(eq(monitor.id, noDescriptionMonitorId));
     await db.delete(page).where(eq(page.id, publicNamePageId));
   });
 
@@ -1176,6 +1213,27 @@ describe("statusPage exposes page component names, not internal monitor names", 
     );
     expect(component?.monitor?.name).toBe(componentName);
     expect(component?.monitor?.description).toBe(componentDescription);
+  });
+
+  test("falls back to the monitor description when the component has none", async () => {
+    const caller = await createCaller();
+    const result = await caller.statusPage.get({ slug: publicNameSlug });
+
+    const monitorItem = result?.monitors.find(
+      (m) => m.id === noDescriptionMonitorId,
+    );
+    expect(monitorItem?.description).toBe(fallbackDescription);
+
+    const component = result?.pageComponents.find(
+      (c) => c.monitorId === noDescriptionMonitorId,
+    );
+    expect(component?.monitor?.description).toBe(fallbackDescription);
+
+    const light = await caller.statusPage.getLight({ slug: publicNameSlug });
+    const lightItem = light?.monitors.find(
+      (m) => m.id === noDescriptionMonitorId,
+    );
+    expect(lightItem?.description).toBe(fallbackDescription);
   });
 
   test("getUptime returns the page component name on the nested monitor", async () => {

--- a/packages/api/src/router/statusPage.e2e.test.ts
+++ b/packages/api/src/router/statusPage.e2e.test.ts
@@ -1057,3 +1057,122 @@ describe("statusPage.get gates incidents by barType (calendar manual mode)", () 
     expect(monitorIncidents(result)).toEqual([]);
   });
 });
+
+describe("statusPage exposes page component names, not internal monitor names", () => {
+  const publicNameSlug = "public-component-name-test-page";
+  let publicNamePageId: number;
+  let publicNameMonitorId: number;
+  let publicNameComponentId: number;
+
+  const internalName = "Internal Monitor Name";
+  const internalDescription = "Internal monitor description";
+  const legacyExternalName = "Legacy External Name";
+  const componentName = "Public Component Name";
+  const componentDescription = "Public component description";
+
+  async function createCaller() {
+    const { edgeRouter } = await import("../edge");
+    const { createInnerTRPCContext } = await import("../trpc");
+    const ctx = createInnerTRPCContext({
+      req: undefined,
+      // @ts-expect-error - auth not required for public procedure
+      auth: undefined,
+    });
+    return edgeRouter.createCaller(ctx);
+  }
+
+  beforeAll(async () => {
+    await db.delete(page).where(eq(page.slug, publicNameSlug));
+
+    const testPage = await db
+      .insert(page)
+      .values({
+        workspaceId: 1,
+        title: "Public Component Name Page",
+        description: "Verifies public naming in statusPage procedures",
+        slug: publicNameSlug,
+        customDomain: "",
+      })
+      .returning()
+      .get();
+    publicNamePageId = testPage.id;
+
+    // externalName is set on purpose: the legacy `externalName || name`
+    // schema transform must not override the page component name.
+    const testMonitor = await db
+      .insert(monitor)
+      .values({
+        workspaceId: 1,
+        name: internalName,
+        externalName: legacyExternalName,
+        description: internalDescription,
+        periodicity: "1m",
+        url: "https://example.com",
+        active: true,
+        public: true,
+      })
+      .returning()
+      .get();
+    publicNameMonitorId = testMonitor.id;
+
+    const testComponent = await db
+      .insert(pageComponent)
+      .values({
+        workspaceId: 1,
+        pageId: publicNamePageId,
+        type: "monitor",
+        monitorId: publicNameMonitorId,
+        name: componentName,
+        description: componentDescription,
+        order: 0,
+      })
+      .returning()
+      .get();
+    publicNameComponentId = testComponent.id;
+  });
+
+  afterAll(async () => {
+    await db
+      .delete(pageComponent)
+      .where(eq(pageComponent.id, publicNameComponentId));
+    await db.delete(monitor).where(eq(monitor.id, publicNameMonitorId));
+    await db.delete(page).where(eq(page.id, publicNamePageId));
+  });
+
+  test("get returns the page component name and description", async () => {
+    const caller = await createCaller();
+    const result = await caller.statusPage.get({ slug: publicNameSlug });
+
+    const monitorItem = result?.monitors.find(
+      (m) => m.id === publicNameMonitorId,
+    );
+
+    expect(monitorItem?.name).toBe(componentName);
+    expect(monitorItem?.description).toBe(componentDescription);
+    expect(monitorItem?.name).not.toBe(internalName);
+    expect(monitorItem?.name).not.toBe(legacyExternalName);
+  });
+
+  test("getLight returns the page component name and description", async () => {
+    const caller = await createCaller();
+    const result = await caller.statusPage.getLight({ slug: publicNameSlug });
+
+    const monitorItem = result?.monitors.find(
+      (m) => m.id === publicNameMonitorId,
+    );
+
+    expect(monitorItem?.name).toBe(componentName);
+    expect(monitorItem?.description).toBe(componentDescription);
+  });
+
+  test("getMonitor returns the page component name and description", async () => {
+    const caller = await createCaller();
+    const result = await caller.statusPage.getMonitor({
+      slug: publicNameSlug,
+      id: publicNameMonitorId,
+    });
+
+    expect(result?.name).toBe(componentName);
+    expect(result?.description).toBe(componentDescription);
+  });
+});

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -239,11 +239,6 @@ export const statusPageRouter = createTRPCRouter({
                 : "success"));
         return {
           ...c.monitor,
-          // the page component carries the public-facing name/description;
-          // clear externalName so the schema transform keeps the override
-          name: c.name,
-          description: c.description ?? "",
-          externalName: null,
           status,
           events,
           monitorGroupId: c.groupId,
@@ -1048,8 +1043,6 @@ export const statusPageRouter = createTRPCRouter({
 
         return {
           ...selectPublicMonitorSchema.parse(c.monitor),
-          name: c.name,
-          description: c.description ?? "",
           data,
         };
       });
@@ -1080,12 +1073,11 @@ export const statusPageRouter = createTRPCRouter({
 
       const monitorComponents = pageComponents.filter(isMonitorComponent);
 
-      const _component = monitorComponents.find(
+      const _monitor = monitorComponents.find(
         (c) => c.monitor.id === opts.input.id,
-      );
-      const _monitor = _component?.monitor;
+      )?.monitor;
 
-      if (!_component || !_monitor) return null;
+      if (!_monitor) return null;
       if (!_monitor.public) return null;
       if (_monitor.deletedAt) return null;
 
@@ -1142,8 +1134,6 @@ export const statusPageRouter = createTRPCRouter({
 
       return {
         ...selectPublicMonitorSchema.parse(_monitor),
-        name: _component.name,
-        description: _component.description ?? "",
         data: {
           latency,
           regions,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -498,9 +498,11 @@ export const statusPageRouter = createTRPCRouter({
         .map((c) => ({
           ...c.monitor,
           // the page component carries the public-facing name/description;
-          // clear externalName so the schema transform keeps the override
+          // clear externalName so the schema transform keeps the override.
+          // description falls back to the monitor's own: pre-existing
+          // components were never backfilled and carry NULL.
           name: c.name,
-          description: c.description ?? "",
+          description: c.description || c.monitor?.description || "",
           externalName: null,
         }))
         .sort((a, b) => {

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -239,6 +239,11 @@ export const statusPageRouter = createTRPCRouter({
                 : "success"));
         return {
           ...c.monitor,
+          // the page component carries the public-facing name/description;
+          // clear externalName so the schema transform keeps the override
+          name: c.name,
+          description: c.description ?? "",
+          externalName: null,
           status,
           events,
           monitorGroupId: c.groupId,
@@ -497,7 +502,11 @@ export const statusPageRouter = createTRPCRouter({
       const monitors = monitorComponents
         .map((c) => ({
           ...c.monitor,
-          name: c.monitor?.externalName ?? c.monitor?.name ?? "",
+          // the page component carries the public-facing name/description;
+          // clear externalName so the schema transform keeps the override
+          name: c.name,
+          description: c.description ?? "",
+          externalName: null,
         }))
         .sort((a, b) => {
           const aComp = monitorComponents.find((m) => m.monitor?.id === a.id);
@@ -1039,6 +1048,8 @@ export const statusPageRouter = createTRPCRouter({
 
         return {
           ...selectPublicMonitorSchema.parse(c.monitor),
+          name: c.name,
+          description: c.description ?? "",
           data,
         };
       });
@@ -1069,11 +1080,12 @@ export const statusPageRouter = createTRPCRouter({
 
       const monitorComponents = pageComponents.filter(isMonitorComponent);
 
-      const _monitor = monitorComponents.find(
+      const _component = monitorComponents.find(
         (c) => c.monitor.id === opts.input.id,
-      )?.monitor;
+      );
+      const _monitor = _component?.monitor;
 
-      if (!_monitor) return null;
+      if (!_component || !_monitor) return null;
       if (!_monitor.public) return null;
       if (_monitor.deletedAt) return null;
 
@@ -1130,6 +1142,8 @@ export const statusPageRouter = createTRPCRouter({
 
       return {
         ...selectPublicMonitorSchema.parse(_monitor),
+        name: _component.name,
+        description: _component.description ?? "",
         data: {
           latency,
           regions,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -499,10 +499,10 @@ export const statusPageRouter = createTRPCRouter({
           ...c.monitor,
           // the page component carries the public-facing name/description;
           // clear externalName so the schema transform keeps the override.
-          // description falls back to the monitor's own: pre-existing
-          // components were never backfilled and carry NULL.
+          // description: NULL means never backfilled → fall back to the
+          // monitor's own; "" is a deliberately cleared field → stays blank.
           name: c.name,
-          description: c.description || c.monitor?.description || "",
+          description: c.description ?? c.monitor?.description ?? "",
           externalName: null,
         }))
         .sort((a, b) => {

--- a/packages/db/src/schema/shared.ts
+++ b/packages/db/src/schema/shared.ts
@@ -159,15 +159,15 @@ export const selectPageComponentWithMonitorRelation = selectPageComponentSchema
   })
   // the component owns the public-facing monitor name/description; externalName
   // is cleared so downstream `externalName || name` transforms keep the override.
-  // description falls back to the monitor's own: pre-existing components were
-  // never backfilled and carry NULL.
+  // description: NULL means never backfilled → fall back to the monitor's own;
+  // "" is a deliberately cleared field (the dashboard stores "") → stays blank.
   .transform(({ monitor, ...component }) => ({
     ...component,
     monitor: monitor
       ? {
           ...monitor,
           name: component.name,
-          description: component.description || monitor.description,
+          description: component.description ?? monitor.description,
           externalName: null,
         }
       : monitor,

--- a/packages/db/src/schema/shared.ts
+++ b/packages/db/src/schema/shared.ts
@@ -158,14 +158,16 @@ export const selectPageComponentWithMonitorRelation = selectPageComponentSchema
     group: selectPageComponentGroupSchema.nullish(),
   })
   // the component owns the public-facing monitor name/description; externalName
-  // is cleared so downstream `externalName || name` transforms keep the override
+  // is cleared so downstream `externalName || name` transforms keep the override.
+  // description falls back to the monitor's own: pre-existing components were
+  // never backfilled and carry NULL.
   .transform(({ monitor, ...component }) => ({
     ...component,
     monitor: monitor
       ? {
           ...monitor,
           name: component.name,
-          description: component.description ?? "",
+          description: component.description || monitor.description,
           externalName: null,
         }
       : monitor,

--- a/packages/db/src/schema/shared.ts
+++ b/packages/db/src/schema/shared.ts
@@ -148,19 +148,28 @@ const trackersSchema = z
   )
   .prefault([]);
 
-export const selectPageComponentWithMonitorRelation =
-  selectPageComponentSchema.extend({
+export const selectPageComponentWithMonitorRelation = selectPageComponentSchema
+  .extend({
     monitor: selectPublicMonitorBaseSchema
       .extend({
         incidents: selectIncidentSchema.array().nullish(),
       })
-      .transform((data) => ({
-        ...data,
-        name: data.externalName || data.name,
-      }))
       .nullish(),
     group: selectPageComponentGroupSchema.nullish(),
-  });
+  })
+  // the component owns the public-facing monitor name/description; externalName
+  // is cleared so downstream `externalName || name` transforms keep the override
+  .transform(({ monitor, ...component }) => ({
+    ...component,
+    monitor: monitor
+      ? {
+          ...monitor,
+          name: component.name,
+          description: component.description ?? "",
+          externalName: null,
+        }
+      : monitor,
+  }));
 
 export type PageComponentWithMonitorRelation = z.infer<
   typeof selectPageComponentWithMonitorRelation


### PR DESCRIPTION
## Summary

Updates the status page API to use the monitor component's `name` and `description` fields (which carry the public-facing overrides) instead of falling back to the monitor's `externalName` or `name`. This ensures that status pages display the customized names and descriptions configured at the page level, rather than global monitor settings.

## Changes

- **Three endpoints updated** to consistently use `c.name` and `c.description` from the page component:
  - `getMonitors` (line 239): Added explicit name/description assignment and cleared `externalName` to prevent schema transform conflicts
  - `getMonitorsWithoutEvents` (line 502): Same pattern applied
  - `getMonitor` (line 1048): Added name/description override to the returned object

- **Refactored monitor lookup** in `getMonitor` (line 1069):
  - Changed from storing only `?.monitor` to storing the full component (`_component`)
  - Updated null checks to validate both component and monitor existence
  - Enables access to component-level name/description fields

- **Schema handling**: Set `externalName: null` in two locations to ensure the schema transform respects the page component's name override rather than applying the monitor's external name.

## Implementation Details

The page component model (`c`) carries the public-facing customizations, while the underlying monitor (`c.monitor`) holds the global defaults. By explicitly assigning `c.name` and `c.description` to the response and clearing `externalName`, we ensure the API returns the page-specific configuration that users configured in the status page UI.

https://claude.ai/code/session_01KceRCyZB6RjKZw2RMarfZi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

