### PR TITLE
Stop Sentry from capturing tRPC loggerLink noise as errors

### DIFF
--- a/apps/dashboard/src/lib/trpc/client.tsx
+++ b/apps/dashboard/src/lib/trpc/client.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import type { AppRouter } from "@openstatus/api";
-import * as Sentry from "@sentry/nextjs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createTRPCClient, loggerLink } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
 import { useState } from "react";
 
-import { endingLink } from "@/lib/trpc/shared";
+import { endingLink, sentryLoggerLink } from "@/lib/trpc/shared";
 
 export const { TRPCProvider, useTRPC, useTRPCClient } =
   createTRPCContext<AppRouter>();
@@ -42,24 +41,7 @@ export function TRPCReactProvider({ children }: { children: React.ReactNode }) {
   const [trpcClient] = useState(() =>
     createTRPCClient<AppRouter>({
       links: [
-        loggerLink({
-          enabled: (opts) =>
-            process.env.NODE_ENV === "development" ||
-            (opts.direction === "down" && opts.result instanceof Error),
-          // Report the real error to Sentry directly instead of letting
-          // captureConsoleIntegration scrape tRPC's styled console.error format string.
-          logger: (opts) => {
-            if (opts.direction === "down" && opts.result instanceof Error) {
-              Sentry.captureException(opts.result, {
-                extra: { path: opts.path, input: opts.input },
-              });
-              return;
-            }
-            if (process.env.NODE_ENV === "development") {
-              console.log(opts);
-            }
-          },
-        }),
+        sentryLoggerLink(),
         endingLink({
           headers: {
             "x-trpc-source": "client",

--- a/apps/dashboard/src/lib/trpc/client.tsx
+++ b/apps/dashboard/src/lib/trpc/client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createTRPCClient, loggerLink } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
@@ -45,6 +46,19 @@ export function TRPCReactProvider({ children }: { children: React.ReactNode }) {
           enabled: (opts) =>
             process.env.NODE_ENV === "development" ||
             (opts.direction === "down" && opts.result instanceof Error),
+          // Report the real error to Sentry directly instead of letting
+          // captureConsoleIntegration scrape tRPC's styled console.error format string.
+          logger: (opts) => {
+            if (opts.direction === "down" && opts.result instanceof Error) {
+              Sentry.captureException(opts.result, {
+                extra: { path: opts.path, input: opts.input },
+              });
+              return;
+            }
+            if (process.env.NODE_ENV === "development") {
+              console.log(opts);
+            }
+          },
         }),
         endingLink({
           headers: {

--- a/apps/dashboard/src/lib/trpc/server.tsx
+++ b/apps/dashboard/src/lib/trpc/server.tsx
@@ -1,5 +1,6 @@
 import "server-only";
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import { HydrationBoundary } from "@tanstack/react-query";
 import { dehydrate } from "@tanstack/react-query";
 import { TRPCClientError, createTRPCClient, loggerLink } from "@trpc/client";
@@ -27,6 +28,19 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
         enabled: (opts) =>
           process.env.NODE_ENV === "development" ||
           (opts.direction === "down" && opts.result instanceof Error),
+        // Report the real error to Sentry directly instead of letting
+        // captureConsoleIntegration scrape tRPC's styled console.error format string.
+        logger: (opts) => {
+          if (opts.direction === "down" && opts.result instanceof Error) {
+            Sentry.captureException(opts.result, {
+              extra: { path: opts.path, input: opts.input },
+            });
+            return;
+          }
+          if (process.env.NODE_ENV === "development") {
+            console.log(opts);
+          }
+        },
       }),
       endingLink({
         headers: {

--- a/apps/dashboard/src/lib/trpc/server.tsx
+++ b/apps/dashboard/src/lib/trpc/server.tsx
@@ -1,9 +1,8 @@
 import "server-only";
 import type { AppRouter } from "@openstatus/api";
-import * as Sentry from "@sentry/nextjs";
 import { HydrationBoundary } from "@tanstack/react-query";
 import { dehydrate } from "@tanstack/react-query";
-import { TRPCClientError, createTRPCClient, loggerLink } from "@trpc/client";
+import { TRPCClientError, createTRPCClient } from "@trpc/client";
 import {
   type ResolverDef,
   type TRPCQueryOptions,
@@ -14,7 +13,7 @@ import { notFound } from "next/navigation";
 import { cache } from "react";
 
 import { makeQueryClient } from "./query-client";
-import { endingLink } from "./shared";
+import { endingLink, sentryLoggerLink } from "./shared";
 
 // IMPORTANT: Create a stable getter for the query client that
 //            will return the same client during the same request.
@@ -24,24 +23,7 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
   queryClient: getQueryClient,
   client: createTRPCClient({
     links: [
-      loggerLink({
-        enabled: (opts) =>
-          process.env.NODE_ENV === "development" ||
-          (opts.direction === "down" && opts.result instanceof Error),
-        // Report the real error to Sentry directly instead of letting
-        // captureConsoleIntegration scrape tRPC's styled console.error format string.
-        logger: (opts) => {
-          if (opts.direction === "down" && opts.result instanceof Error) {
-            Sentry.captureException(opts.result, {
-              extra: { path: opts.path, input: opts.input },
-            });
-            return;
-          }
-          if (process.env.NODE_ENV === "development") {
-            console.log(opts);
-          }
-        },
-      }),
+      sentryLoggerLink(),
       endingLink({
         headers: {
           "x-trpc-source": "server",

--- a/apps/dashboard/src/lib/trpc/shared.ts
+++ b/apps/dashboard/src/lib/trpc/shared.ts
@@ -8,6 +8,9 @@ import superjson from "superjson";
  * tRPC logger link that reports failed queries to Sentry directly instead of
  * letting captureConsoleIntegration scrape tRPC's styled console.error format
  * string (which surfaces as noise like "%c << query #1 %c...%c %O").
+ *
+ * Only the operation `path` is attached — never `input`, which can carry
+ * secrets (page passwords, subscriber tokens, emails).
  */
 export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
   loggerLink<AppRouter>({
@@ -17,7 +20,7 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
     logger: (opts) => {
       if (opts.direction === "down" && opts.result instanceof Error) {
         Sentry.captureException(opts.result, {
-          extra: { path: opts.path, input: opts.input },
+          extra: { path: opts.path },
         });
         if (process.env.NODE_ENV === "development") {
           console.warn("[tRPC error]", opts.path, opts.result);

--- a/apps/dashboard/src/lib/trpc/shared.ts
+++ b/apps/dashboard/src/lib/trpc/shared.ts
@@ -1,7 +1,34 @@
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import type { HTTPBatchLinkOptions, HTTPHeaders, TRPCLink } from "@trpc/client";
-import { httpBatchLink } from "@trpc/client";
+import { httpBatchLink, loggerLink } from "@trpc/client";
 import superjson from "superjson";
+
+/**
+ * tRPC logger link that reports failed queries to Sentry directly instead of
+ * letting captureConsoleIntegration scrape tRPC's styled console.error format
+ * string (which surfaces as noise like "%c << query #1 %c...%c %O").
+ */
+export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
+  loggerLink<AppRouter>({
+    enabled: (opts) =>
+      process.env.NODE_ENV === "development" ||
+      (opts.direction === "down" && opts.result instanceof Error),
+    logger: (opts) => {
+      if (opts.direction === "down" && opts.result instanceof Error) {
+        Sentry.captureException(opts.result, {
+          extra: { path: opts.path, input: opts.input },
+        });
+        if (process.env.NODE_ENV === "development") {
+          console.warn("[tRPC error]", opts.path, opts.result);
+        }
+        return;
+      }
+      if (process.env.NODE_ENV === "development") {
+        console.log(opts);
+      }
+    },
+  });
 
 /**
  * Shared onError handler for tRPC route handlers.

--- a/apps/status-page/src/lib/trpc/client.tsx
+++ b/apps/status-page/src/lib/trpc/client.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import type { AppRouter } from "@openstatus/api";
-import * as Sentry from "@sentry/nextjs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createTRPCClient, loggerLink } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
 import { useState } from "react";
 
-import { endingLink } from "./shared";
+import { endingLink, sentryLoggerLink } from "./shared";
 
 export const { TRPCProvider, useTRPC, useTRPCClient } =
   createTRPCContext<AppRouter>();
@@ -42,24 +41,7 @@ export function TRPCReactProvider({ children }: { children: React.ReactNode }) {
   const [trpcClient] = useState(() =>
     createTRPCClient<AppRouter>({
       links: [
-        loggerLink({
-          enabled: (opts) =>
-            process.env.NODE_ENV === "development" ||
-            (opts.direction === "down" && opts.result instanceof Error),
-          // Report the real error to Sentry directly instead of letting
-          // captureConsoleIntegration scrape tRPC's styled console.error format string.
-          logger: (opts) => {
-            if (opts.direction === "down" && opts.result instanceof Error) {
-              Sentry.captureException(opts.result, {
-                extra: { path: opts.path, input: opts.input },
-              });
-              return;
-            }
-            if (process.env.NODE_ENV === "development") {
-              console.log(opts);
-            }
-          },
-        }),
+        sentryLoggerLink(),
         endingLink({
           headers: {
             "x-trpc-source": "client",

--- a/apps/status-page/src/lib/trpc/client.tsx
+++ b/apps/status-page/src/lib/trpc/client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createTRPCClient, loggerLink } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
@@ -45,6 +46,19 @@ export function TRPCReactProvider({ children }: { children: React.ReactNode }) {
           enabled: (opts) =>
             process.env.NODE_ENV === "development" ||
             (opts.direction === "down" && opts.result instanceof Error),
+          // Report the real error to Sentry directly instead of letting
+          // captureConsoleIntegration scrape tRPC's styled console.error format string.
+          logger: (opts) => {
+            if (opts.direction === "down" && opts.result instanceof Error) {
+              Sentry.captureException(opts.result, {
+                extra: { path: opts.path, input: opts.input },
+              });
+              return;
+            }
+            if (process.env.NODE_ENV === "development") {
+              console.log(opts);
+            }
+          },
         }),
         endingLink({
           headers: {

--- a/apps/status-page/src/lib/trpc/server.tsx
+++ b/apps/status-page/src/lib/trpc/server.tsx
@@ -1,9 +1,8 @@
 import "server-only";
 import type { AppRouter } from "@openstatus/api";
-import * as Sentry from "@sentry/nextjs";
 import { HydrationBoundary } from "@tanstack/react-query";
 import { dehydrate } from "@tanstack/react-query";
-import { createTRPCClient, loggerLink } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 import {
   type TRPCQueryOptions,
   createTRPCOptionsProxy,
@@ -12,7 +11,7 @@ import { cookies } from "next/headers";
 import { cache } from "react";
 
 import { makeQueryClient } from "./query-client";
-import { endingLink } from "./shared";
+import { endingLink, sentryLoggerLink } from "./shared";
 
 // IMPORTANT: Create a stable getter for the query client that
 //            will return the same client during the same request.
@@ -22,24 +21,7 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
   queryClient: getQueryClient,
   client: createTRPCClient({
     links: [
-      loggerLink({
-        enabled: (opts) =>
-          process.env.NODE_ENV === "development" ||
-          (opts.direction === "down" && opts.result instanceof Error),
-        // Report the real error to Sentry directly instead of letting
-        // captureConsoleIntegration scrape tRPC's styled console.error format string.
-        logger: (opts) => {
-          if (opts.direction === "down" && opts.result instanceof Error) {
-            Sentry.captureException(opts.result, {
-              extra: { path: opts.path, input: opts.input },
-            });
-            return;
-          }
-          if (process.env.NODE_ENV === "development") {
-            console.log(opts);
-          }
-        },
-      }),
+      sentryLoggerLink(),
       endingLink({
         headers: {
           "x-trpc-source": "server",

--- a/apps/status-page/src/lib/trpc/server.tsx
+++ b/apps/status-page/src/lib/trpc/server.tsx
@@ -1,5 +1,6 @@
 import "server-only";
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import { HydrationBoundary } from "@tanstack/react-query";
 import { dehydrate } from "@tanstack/react-query";
 import { createTRPCClient, loggerLink } from "@trpc/client";
@@ -25,6 +26,19 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
         enabled: (opts) =>
           process.env.NODE_ENV === "development" ||
           (opts.direction === "down" && opts.result instanceof Error),
+        // Report the real error to Sentry directly instead of letting
+        // captureConsoleIntegration scrape tRPC's styled console.error format string.
+        logger: (opts) => {
+          if (opts.direction === "down" && opts.result instanceof Error) {
+            Sentry.captureException(opts.result, {
+              extra: { path: opts.path, input: opts.input },
+            });
+            return;
+          }
+          if (process.env.NODE_ENV === "development") {
+            console.log(opts);
+          }
+        },
       }),
       endingLink({
         headers: {

--- a/apps/status-page/src/lib/trpc/shared.ts
+++ b/apps/status-page/src/lib/trpc/shared.ts
@@ -9,6 +9,9 @@ import superjson from "superjson";
  * tRPC logger link that reports failed queries to Sentry directly instead of
  * letting captureConsoleIntegration scrape tRPC's styled console.error format
  * string (which surfaces as noise like "%c << query #1 %c...%c %O").
+ *
+ * Only the operation `path` is attached — never `input`, which can carry
+ * secrets (page passwords, subscriber tokens, emails).
  */
 export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
   loggerLink<AppRouter>({
@@ -18,7 +21,7 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
     logger: (opts) => {
       if (opts.direction === "down" && opts.result instanceof Error) {
         Sentry.captureException(opts.result, {
-          extra: { path: opts.path, input: opts.input },
+          extra: { path: opts.path },
         });
         if (process.env.NODE_ENV === "development") {
           console.warn("[tRPC error]", opts.path, opts.result);

--- a/apps/status-page/src/lib/trpc/shared.ts
+++ b/apps/status-page/src/lib/trpc/shared.ts
@@ -1,8 +1,35 @@
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import type { HTTPBatchLinkOptions, HTTPHeaders, TRPCLink } from "@trpc/client";
-import { httpBatchLink } from "@trpc/client";
+import { httpBatchLink, loggerLink } from "@trpc/client";
 import type { TRPCError } from "@trpc/server";
 import superjson from "superjson";
+
+/**
+ * tRPC logger link that reports failed queries to Sentry directly instead of
+ * letting captureConsoleIntegration scrape tRPC's styled console.error format
+ * string (which surfaces as noise like "%c << query #1 %c...%c %O").
+ */
+export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
+  loggerLink<AppRouter>({
+    enabled: (opts) =>
+      process.env.NODE_ENV === "development" ||
+      (opts.direction === "down" && opts.result instanceof Error),
+    logger: (opts) => {
+      if (opts.direction === "down" && opts.result instanceof Error) {
+        Sentry.captureException(opts.result, {
+          extra: { path: opts.path, input: opts.input },
+        });
+        if (process.env.NODE_ENV === "development") {
+          console.warn("[tRPC error]", opts.path, opts.result);
+        }
+        return;
+      }
+      if (process.env.NODE_ENV === "development") {
+        console.log(opts);
+      }
+    },
+  });
 
 /**
  * Shared onError handler for tRPC route handlers.

--- a/apps/web/src/trpc/client.ts
+++ b/apps/web/src/trpc/client.ts
@@ -1,4 +1,5 @@
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import { createTRPCClient, loggerLink } from "@trpc/client";
 
 import { endingLink } from "./shared";
@@ -9,6 +10,19 @@ export const api = createTRPCClient<AppRouter>({
       enabled: (opts) =>
         process.env.NODE_ENV === "development" ||
         (opts.direction === "down" && opts.result instanceof Error),
+      // Report the real error to Sentry directly instead of letting
+      // captureConsoleIntegration scrape tRPC's styled console.error format string.
+      logger: (opts) => {
+        if (opts.direction === "down" && opts.result instanceof Error) {
+          Sentry.captureException(opts.result, {
+            extra: { path: opts.path, input: opts.input },
+          });
+          return;
+        }
+        if (process.env.NODE_ENV === "development") {
+          console.log(opts);
+        }
+      },
     }),
     endingLink({
       headers: {

--- a/apps/web/src/trpc/client.ts
+++ b/apps/web/src/trpc/client.ts
@@ -1,29 +1,11 @@
 import type { AppRouter } from "@openstatus/api";
-import * as Sentry from "@sentry/nextjs";
-import { createTRPCClient, loggerLink } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 
-import { endingLink } from "./shared";
+import { endingLink, sentryLoggerLink } from "./shared";
 
 export const api = createTRPCClient<AppRouter>({
   links: [
-    loggerLink({
-      enabled: (opts) =>
-        process.env.NODE_ENV === "development" ||
-        (opts.direction === "down" && opts.result instanceof Error),
-      // Report the real error to Sentry directly instead of letting
-      // captureConsoleIntegration scrape tRPC's styled console.error format string.
-      logger: (opts) => {
-        if (opts.direction === "down" && opts.result instanceof Error) {
-          Sentry.captureException(opts.result, {
-            extra: { path: opts.path, input: opts.input },
-          });
-          return;
-        }
-        if (process.env.NODE_ENV === "development") {
-          console.log(opts);
-        }
-      },
-    }),
+    sentryLoggerLink(),
     endingLink({
       headers: {
         "x-trpc-source": "client",

--- a/apps/web/src/trpc/server.ts
+++ b/apps/web/src/trpc/server.ts
@@ -1,30 +1,12 @@
 import type { AppRouter } from "@openstatus/api";
-import * as Sentry from "@sentry/nextjs";
-import { createTRPCClient, loggerLink } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 import { headers } from "next/headers";
 
-import { endingLink } from "./shared";
+import { endingLink, sentryLoggerLink } from "./shared";
 
 export const api = createTRPCClient<AppRouter>({
   links: [
-    loggerLink({
-      enabled: (opts) =>
-        process.env.NODE_ENV === "development" ||
-        (opts.direction === "down" && opts.result instanceof Error),
-      // Report the real error to Sentry directly instead of letting
-      // captureConsoleIntegration scrape tRPC's styled console.error format string.
-      logger: (opts) => {
-        if (opts.direction === "down" && opts.result instanceof Error) {
-          Sentry.captureException(opts.result, {
-            extra: { path: opts.path, input: opts.input },
-          });
-          return;
-        }
-        if (process.env.NODE_ENV === "development") {
-          console.log(opts);
-        }
-      },
-    }),
+    sentryLoggerLink(),
     endingLink({
       headers: async () => {
         const h = new Map(await headers());

--- a/apps/web/src/trpc/server.ts
+++ b/apps/web/src/trpc/server.ts
@@ -1,4 +1,5 @@
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import { createTRPCClient, loggerLink } from "@trpc/client";
 import { headers } from "next/headers";
 
@@ -10,6 +11,19 @@ export const api = createTRPCClient<AppRouter>({
       enabled: (opts) =>
         process.env.NODE_ENV === "development" ||
         (opts.direction === "down" && opts.result instanceof Error),
+      // Report the real error to Sentry directly instead of letting
+      // captureConsoleIntegration scrape tRPC's styled console.error format string.
+      logger: (opts) => {
+        if (opts.direction === "down" && opts.result instanceof Error) {
+          Sentry.captureException(opts.result, {
+            extra: { path: opts.path, input: opts.input },
+          });
+          return;
+        }
+        if (process.env.NODE_ENV === "development") {
+          console.log(opts);
+        }
+      },
     }),
     endingLink({
       headers: async () => {

--- a/apps/web/src/trpc/shared.ts
+++ b/apps/web/src/trpc/shared.ts
@@ -8,6 +8,9 @@ import superjson from "superjson";
  * tRPC logger link that reports failed queries to Sentry directly instead of
  * letting captureConsoleIntegration scrape tRPC's styled console.error format
  * string (which surfaces as noise like "%c << query #1 %c...%c %O").
+ *
+ * Only the operation `path` is attached — never `input`, which can carry
+ * secrets (page passwords, subscriber tokens, emails).
  */
 export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
   loggerLink<AppRouter>({
@@ -17,7 +20,7 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
     logger: (opts) => {
       if (opts.direction === "down" && opts.result instanceof Error) {
         Sentry.captureException(opts.result, {
-          extra: { path: opts.path, input: opts.input },
+          extra: { path: opts.path },
         });
         if (process.env.NODE_ENV === "development") {
           console.warn("[tRPC error]", opts.path, opts.result);

--- a/apps/web/src/trpc/shared.ts
+++ b/apps/web/src/trpc/shared.ts
@@ -1,7 +1,34 @@
 import type { AppRouter } from "@openstatus/api";
+import * as Sentry from "@sentry/nextjs";
 import type { HTTPBatchLinkOptions, HTTPHeaders, TRPCLink } from "@trpc/client";
-import { httpBatchLink } from "@trpc/client";
+import { httpBatchLink, loggerLink } from "@trpc/client";
 import superjson from "superjson";
+
+/**
+ * tRPC logger link that reports failed queries to Sentry directly instead of
+ * letting captureConsoleIntegration scrape tRPC's styled console.error format
+ * string (which surfaces as noise like "%c << query #1 %c...%c %O").
+ */
+export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
+  loggerLink<AppRouter>({
+    enabled: (opts) =>
+      process.env.NODE_ENV === "development" ||
+      (opts.direction === "down" && opts.result instanceof Error),
+    logger: (opts) => {
+      if (opts.direction === "down" && opts.result instanceof Error) {
+        Sentry.captureException(opts.result, {
+          extra: { path: opts.path, input: opts.input },
+        });
+        if (process.env.NODE_ENV === "development") {
+          console.warn("[tRPC error]", opts.path, opts.result);
+        }
+        return;
+      }
+      if (process.env.NODE_ENV === "development") {
+        console.log(opts);
+      }
+    },
+  });
 
 /**
  * Shared onError handler for tRPC route handlers.


### PR DESCRIPTION
captureConsoleIntegration (levels: ["error"]) was scraping the raw
console.error call that trpc's loggerLink makes for failed queries,
producing spurious Sentry issues whose title/message was just the
CSS-styled printf format string (e.g. "%c << query #1 %cstatusPage.getMonitor%c %O")
instead of the actual error (OPENSTATUS-FRONTEND-ET, OPENSTATUS-FRONTEND-E5).

Replace the default logger with one that reports the real error to
Sentry directly via captureException and only logs to the console
(never console.error) in development, across dashboard, status-page,
and web's tRPC client/server setups.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

