### PR TITLE
fix: handle non-JSON Vercel responses in domain router

### DIFF
--- a/apps/dashboard/src/components/domains/use-domain-status.ts
+++ b/apps/dashboard/src/components/domains/use-domain-status.ts
@@ -55,6 +55,9 @@ export function useDomainStatus(domain?: string) {
     if (verificationJson?.verified) {
       status = "Valid Configuration";
     }
+    // config check failed (e.g. Vercel outage) — don't report healthy
+  } else if (configJson?.error) {
+    status = "Unknown Error";
   } else if (configJson?.misconfigured) {
     status = "Invalid Configuration";
   } else {

--- a/packages/api/src/lib/vercel.ts
+++ b/packages/api/src/lib/vercel.ts
@@ -17,6 +17,20 @@ export async function vercelFetch(path: string, init?: RequestInit) {
   });
 }
 
+// Vercel can return non-JSON bodies (plain-text error pages during outages,
+// rate limits) — never let JSON.parse bubble up as an INTERNAL_SERVER_ERROR.
+export async function parseVercelJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    console.error("Vercel returned a non-JSON response:", {
+      status: response.status,
+      url: response.url,
+    });
+    return null;
+  }
+}
+
 export async function addDomainToVercel(domain: string) {
   const response = await vercelFetch(
     `/v9/projects/${env.PROJECT_ID_VERCEL}/domains?teamId=${env.TEAM_ID_VERCEL}`,

--- a/packages/api/src/router/domain.ts
+++ b/packages/api/src/router/domain.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { env } from "../env";
-import { vercelFetch } from "../lib/vercel";
+import { parseVercelJson, vercelFetch } from "../lib/vercel";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const domainConfigResponseSchema = z.object({
@@ -41,6 +41,15 @@ export const domainResponseSchema = z.object({
     .optional(),
 });
 
+const domainResponseWithErrorSchema = domainResponseSchema.extend({
+  error: z
+    .object({
+      code: z.string(),
+      message: z.string(),
+    })
+    .optional(),
+});
+
 export type DomainVerificationResponse = z.infer<typeof domainResponseSchema>;
 export type DomainConfigResponse = z.infer<typeof domainConfigResponseSchema>;
 export type DomainResponse = z.infer<typeof domainResponseSchema>;
@@ -61,17 +70,13 @@ export const domainRouter = createTRPCRouter({
       const data = await vercelFetch(
         `/v9/projects/${env.PROJECT_ID_VERCEL}/domains/${opts.input.domain}?teamId=${env.TEAM_ID_VERCEL}`,
       );
-      const json = await data.json();
-      const result = domainResponseSchema
-        .extend({
-          error: z
-            .object({
-              code: z.string(),
-              message: z.string(),
-            })
-            .optional(),
-        })
-        .parse(json);
+      const json = await parseVercelJson(data);
+      if (json === null) {
+        return domainResponseWithErrorSchema.parse({
+          error: { code: "internal_error", message: "Unexpected response" },
+        });
+      }
+      const result = domainResponseWithErrorSchema.parse(json);
       console.log({ result });
       return result;
     }),
@@ -84,7 +89,10 @@ export const domainRouter = createTRPCRouter({
       const data = await vercelFetch(
         `/v6/domains/${opts.input.domain}/config?teamId=${env.TEAM_ID_VERCEL}`,
       );
-      const json = await data.json();
+      const json = await parseVercelJson(data);
+      if (json === null) {
+        return null;
+      }
       const result = domainConfigResponseSchema.parse(json);
       return result;
     }),
@@ -98,7 +106,10 @@ export const domainRouter = createTRPCRouter({
         `/v9/projects/${env.PROJECT_ID_VERCEL}/domains/${opts.input.domain}/verify?teamId=${env.TEAM_ID_VERCEL}`,
         { method: "POST" },
       );
-      const json = await data.json();
+      const json = await parseVercelJson(data);
+      if (json === null) {
+        return null;
+      }
       const result = domainResponseSchema.parse(json);
       return result;
     }),

--- a/packages/api/src/router/domain.ts
+++ b/packages/api/src/router/domain.ts
@@ -41,13 +41,19 @@ export const domainResponseSchema = z.object({
     .optional(),
 });
 
+const vercelErrorSchema = z
+  .object({
+    code: z.string(),
+    message: z.string(),
+  })
+  .optional();
+
 const domainResponseWithErrorSchema = domainResponseSchema.extend({
-  error: z
-    .object({
-      code: z.string(),
-      message: z.string(),
-    })
-    .optional(),
+  error: vercelErrorSchema,
+});
+
+const domainConfigWithErrorSchema = domainConfigResponseSchema.extend({
+  error: vercelErrorSchema,
 });
 
 export type DomainVerificationResponse = z.infer<typeof domainResponseSchema>;
@@ -91,9 +97,11 @@ export const domainRouter = createTRPCRouter({
       );
       const json = await parseVercelJson(data);
       if (json === null) {
-        return null;
+        return domainConfigWithErrorSchema.parse({
+          error: { code: "internal_error", message: "Unexpected response" },
+        });
       }
-      const result = domainConfigResponseSchema.parse(json);
+      const result = domainConfigWithErrorSchema.parse(json);
       return result;
     }),
   verifyDomain: protectedProcedure


### PR DESCRIPTION
Vercel can return plain-text error pages (outages, rate limits), which
made data.json() throw and surface as an unhandled INTERNAL_SERVER_ERROR
in the domain.getDomainResponse/getConfigResponse/verifyDomain queries.
Parse the body defensively and fall back to an error object (or null)
the client already knows how to render.

Fixes OPENSTATUS-7PK

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EPCij3bxjq7PH4dcsZfX5V

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

