### PR TITLE
Centralize tRPC error handling and Sentry filtering

### DIFF
--- a/apps/dashboard/sentry.edge.config.ts
+++ b/apps/dashboard/sentry.edge.config.ts
@@ -3,14 +3,27 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "UNAUTHORIZED",
-  "NOT_FOUND",
+const IGNORED_TRPC_CODES = [
   "BAD_REQUEST",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "CONFLICT",
+  "PRECONDITION_FAILED",
+  "TOO_MANY_REQUESTS",
 ];
+
+// Duck-typed: `instanceof TRPCError` is unreliable here because the thrown
+// error comes from a different bundle than this config's `@trpc/server` copy.
+function isIgnoredTRPCError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    err.name === "TRPCError" &&
+    IGNORED_TRPC_CODES.includes((err as { code?: string }).code ?? "")
+  );
+}
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -23,10 +36,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (
-      hint.originalException instanceof TRPCError &&
-      IGNORED_TRPC_CODES.includes(hint.originalException.code)
-    ) {
+    if (isIgnoredTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/dashboard/sentry.edge.config.ts
+++ b/apps/dashboard/sentry.edge.config.ts
@@ -2,30 +2,8 @@
 // The config you add here will be used whenever one of the edge features is loaded.
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+import { isExpectedTRPCError } from "@openstatus/api/src/trpc-errors";
 import * as Sentry from "@sentry/nextjs";
-import type { TRPCError } from "@trpc/server";
-
-// tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "BAD_REQUEST",
-  "UNAUTHORIZED",
-  "FORBIDDEN",
-  "NOT_FOUND",
-  "CONFLICT",
-  "PRECONDITION_FAILED",
-  "TOO_MANY_REQUESTS",
-];
-
-// Match by name + code rather than `instanceof TRPCError`: the thrown error
-// comes from the app bundle, whose `@trpc/server` class identity differs from
-// the copy this instrumentation config would import at runtime.
-function isIgnoredTRPCError(err: unknown): err is TRPCError {
-  return (
-    err instanceof Error &&
-    err.name === "TRPCError" &&
-    IGNORED_TRPC_CODES.includes((err as TRPCError).code)
-  );
-}
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -38,7 +16,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (isIgnoredTRPCError(hint.originalException)) {
+    if (isExpectedTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/dashboard/sentry.edge.config.ts
+++ b/apps/dashboard/sentry.edge.config.ts
@@ -3,9 +3,10 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from "@sentry/nextjs";
+import type { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES = [
+const IGNORED_TRPC_CODES: TRPCError["code"][] = [
   "BAD_REQUEST",
   "UNAUTHORIZED",
   "FORBIDDEN",
@@ -15,13 +16,14 @@ const IGNORED_TRPC_CODES = [
   "TOO_MANY_REQUESTS",
 ];
 
-// Duck-typed: `instanceof TRPCError` is unreliable here because the thrown
-// error comes from a different bundle than this config's `@trpc/server` copy.
-function isIgnoredTRPCError(err: unknown): boolean {
+// Match by name + code rather than `instanceof TRPCError`: the thrown error
+// comes from the app bundle, whose `@trpc/server` class identity differs from
+// the copy this instrumentation config would import at runtime.
+function isIgnoredTRPCError(err: unknown): err is TRPCError {
   return (
     err instanceof Error &&
     err.name === "TRPCError" &&
-    IGNORED_TRPC_CODES.includes((err as { code?: string }).code ?? "")
+    IGNORED_TRPC_CODES.includes((err as TRPCError).code)
   );
 }
 

--- a/apps/dashboard/sentry.server.config.ts
+++ b/apps/dashboard/sentry.server.config.ts
@@ -3,9 +3,10 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import type { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES = [
+const IGNORED_TRPC_CODES: TRPCError["code"][] = [
   "BAD_REQUEST",
   "UNAUTHORIZED",
   "FORBIDDEN",
@@ -15,13 +16,14 @@ const IGNORED_TRPC_CODES = [
   "TOO_MANY_REQUESTS",
 ];
 
-// Duck-typed: `instanceof TRPCError` is unreliable here because the thrown
-// error comes from a different bundle than this config's `@trpc/server` copy.
-function isIgnoredTRPCError(err: unknown): boolean {
+// Match by name + code rather than `instanceof TRPCError`: the thrown error
+// comes from the app bundle, whose `@trpc/server` class identity differs from
+// the copy this instrumentation config would import at runtime.
+function isIgnoredTRPCError(err: unknown): err is TRPCError {
   return (
     err instanceof Error &&
     err.name === "TRPCError" &&
-    IGNORED_TRPC_CODES.includes((err as { code?: string }).code ?? "")
+    IGNORED_TRPC_CODES.includes((err as TRPCError).code)
   );
 }
 

--- a/apps/dashboard/sentry.server.config.ts
+++ b/apps/dashboard/sentry.server.config.ts
@@ -2,30 +2,8 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { isExpectedTRPCError } from "@openstatus/api/src/trpc-errors";
 import * as Sentry from "@sentry/nextjs";
-import type { TRPCError } from "@trpc/server";
-
-// tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "BAD_REQUEST",
-  "UNAUTHORIZED",
-  "FORBIDDEN",
-  "NOT_FOUND",
-  "CONFLICT",
-  "PRECONDITION_FAILED",
-  "TOO_MANY_REQUESTS",
-];
-
-// Match by name + code rather than `instanceof TRPCError`: the thrown error
-// comes from the app bundle, whose `@trpc/server` class identity differs from
-// the copy this instrumentation config would import at runtime.
-function isIgnoredTRPCError(err: unknown): err is TRPCError {
-  return (
-    err instanceof Error &&
-    err.name === "TRPCError" &&
-    IGNORED_TRPC_CODES.includes((err as TRPCError).code)
-  );
-}
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -38,7 +16,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (isIgnoredTRPCError(hint.originalException)) {
+    if (isExpectedTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/dashboard/sentry.server.config.ts
+++ b/apps/dashboard/sentry.server.config.ts
@@ -3,14 +3,27 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
 
 // tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "UNAUTHORIZED",
-  "NOT_FOUND",
+const IGNORED_TRPC_CODES = [
   "BAD_REQUEST",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "CONFLICT",
+  "PRECONDITION_FAILED",
+  "TOO_MANY_REQUESTS",
 ];
+
+// Duck-typed: `instanceof TRPCError` is unreliable here because the thrown
+// error comes from a different bundle than this config's `@trpc/server` copy.
+function isIgnoredTRPCError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    err.name === "TRPCError" &&
+    IGNORED_TRPC_CODES.includes((err as { code?: string }).code ?? "")
+  );
+}
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -23,10 +36,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (
-      hint.originalException instanceof TRPCError &&
-      IGNORED_TRPC_CODES.includes(hint.originalException.code)
-    ) {
+    if (isIgnoredTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/dashboard/src/app/api/trpc/lambda/[trpc]/route.ts
+++ b/apps/dashboard/src/app/api/trpc/lambda/[trpc]/route.ts
@@ -1,9 +1,10 @@
 import { appRouter, createTRPCContext } from "@openstatus/api";
+import { createTRPCOnError } from "@openstatus/api/src/trpc-errors";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { NextRequest } from "next/server";
 
 import { auth } from "@/lib/auth";
-import { createOnError, guardTRPCSource } from "@/lib/trpc/shared";
+import { guardTRPCSource } from "@/lib/trpc/shared";
 
 // Runs on the Node.js runtime (Vercel Fluid compute). The whole tRPC surface
 // is served here — several routers pull Node-only deps (@slack/web-api, email
@@ -18,7 +19,7 @@ const handler = (req: NextRequest) => {
     router: appRouter,
     req: req,
     createContext: () => createTRPCContext({ req, auth }),
-    onError: createOnError("lambda"),
+    onError: createTRPCOnError("lambda"),
   });
 };
 

--- a/apps/dashboard/src/lib/trpc/shared.ts
+++ b/apps/dashboard/src/lib/trpc/shared.ts
@@ -2,6 +2,7 @@ import type { AppRouter } from "@openstatus/api";
 import * as Sentry from "@sentry/nextjs";
 import type { HTTPBatchLinkOptions, HTTPHeaders, TRPCLink } from "@trpc/client";
 import { httpBatchLink, loggerLink } from "@trpc/client";
+import type { TRPCError } from "@trpc/server";
 import superjson from "superjson";
 
 /**
@@ -35,7 +36,7 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
 
 // Expected client errors (4xx). These are not bugs, so we don't log them —
 // captureConsoleIntegration would otherwise ship every console.error to Sentry.
-const EXPECTED_TRPC_CODES = new Set([
+const EXPECTED_TRPC_CODES = new Set<TRPCError["code"]>([
   "BAD_REQUEST",
   "UNAUTHORIZED",
   "FORBIDDEN",
@@ -51,7 +52,7 @@ const EXPECTED_TRPC_CODES = new Set([
  * integration doesn't report them as noise.
  */
 export function createOnError(label: string) {
-  return ({ error }: { error: { code: string; message: string } }) => {
+  return ({ error }: { error: Pick<TRPCError, "code" | "message"> }) => {
     if (EXPECTED_TRPC_CODES.has(error.code)) return;
     console.log(`Error in tRPC handler (${label})`);
     console.error(error);

--- a/apps/dashboard/src/lib/trpc/shared.ts
+++ b/apps/dashboard/src/lib/trpc/shared.ts
@@ -2,7 +2,6 @@ import type { AppRouter } from "@openstatus/api";
 import * as Sentry from "@sentry/nextjs";
 import type { HTTPBatchLinkOptions, HTTPHeaders, TRPCLink } from "@trpc/client";
 import { httpBatchLink, loggerLink } from "@trpc/client";
-import type { TRPCError } from "@trpc/server";
 import superjson from "superjson";
 
 /**
@@ -33,31 +32,6 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
       }
     },
   });
-
-// Expected client errors (4xx). These are not bugs, so we don't log them —
-// captureConsoleIntegration would otherwise ship every console.error to Sentry.
-const EXPECTED_TRPC_CODES = new Set<TRPCError["code"]>([
-  "BAD_REQUEST",
-  "UNAUTHORIZED",
-  "FORBIDDEN",
-  "NOT_FOUND",
-  "CONFLICT",
-  "PRECONDITION_FAILED",
-  "TOO_MANY_REQUESTS",
-]);
-
-/**
- * Shared onError handler for tRPC route handlers. Only genuine server errors
- * are logged; expected client errors are dropped so Sentry's console
- * integration doesn't report them as noise.
- */
-export function createOnError(label: string) {
-  return ({ error }: { error: Pick<TRPCError, "code" | "message"> }) => {
-    if (EXPECTED_TRPC_CODES.has(error.code)) return;
-    console.log(`Error in tRPC handler (${label})`);
-    console.error(error);
-  };
-}
 
 /**
  * Filter out requests that don't come from our tRPC clients.

--- a/apps/dashboard/src/lib/trpc/shared.ts
+++ b/apps/dashboard/src/lib/trpc/shared.ts
@@ -33,11 +33,26 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
     },
   });
 
+// Expected client errors (4xx). These are not bugs, so we don't log them —
+// captureConsoleIntegration would otherwise ship every console.error to Sentry.
+const EXPECTED_TRPC_CODES = new Set([
+  "BAD_REQUEST",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "CONFLICT",
+  "PRECONDITION_FAILED",
+  "TOO_MANY_REQUESTS",
+]);
+
 /**
- * Shared onError handler for tRPC route handlers.
+ * Shared onError handler for tRPC route handlers. Only genuine server errors
+ * are logged; expected client errors are dropped so Sentry's console
+ * integration doesn't report them as noise.
  */
 export function createOnError(label: string) {
   return ({ error }: { error: { code: string; message: string } }) => {
+    if (EXPECTED_TRPC_CODES.has(error.code)) return;
     console.log(`Error in tRPC handler (${label})`);
     console.error(error);
   };

--- a/apps/status-page/sentry.edge.config.ts
+++ b/apps/status-page/sentry.edge.config.ts
@@ -2,15 +2,8 @@
 // The config you add here will be used whenever one of the edge features is loaded.
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+import { isExpectedTRPCError } from "@openstatus/api/src/trpc-errors";
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
-
-// tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "UNAUTHORIZED",
-  "NOT_FOUND",
-  "BAD_REQUEST",
-];
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -23,10 +16,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (
-      hint.originalException instanceof TRPCError &&
-      IGNORED_TRPC_CODES.includes(hint.originalException.code)
-    ) {
+    if (isExpectedTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/status-page/sentry.server.config.ts
+++ b/apps/status-page/sentry.server.config.ts
@@ -2,15 +2,8 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { isExpectedTRPCError } from "@openstatus/api/src/trpc-errors";
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
-
-// tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "UNAUTHORIZED",
-  "NOT_FOUND",
-  "BAD_REQUEST",
-];
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -23,10 +16,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (
-      hint.originalException instanceof TRPCError &&
-      IGNORED_TRPC_CODES.includes(hint.originalException.code)
-    ) {
+    if (isExpectedTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/status-page/src/app/api/trpc/lambda/[trpc]/route.ts
+++ b/apps/status-page/src/app/api/trpc/lambda/[trpc]/route.ts
@@ -1,9 +1,10 @@
 import { appRouter, createTRPCContext } from "@openstatus/api";
+import { createTRPCOnError } from "@openstatus/api/src/trpc-errors";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { NextRequest } from "next/server";
 
 import { auth } from "../../../../../lib/auth";
-import { createOnError, guardTRPCSource } from "../../../../../lib/trpc/shared";
+import { guardTRPCSource } from "../../../../../lib/trpc/shared";
 
 // Runs on the Node.js runtime (Vercel Fluid compute). The whole tRPC surface
 // is served here — several routers pull Node-only deps (@slack/web-api, email
@@ -18,7 +19,7 @@ const handler = (req: NextRequest) => {
     router: appRouter,
     req: req,
     createContext: () => createTRPCContext({ req, auth }),
-    onError: createOnError("lambda"),
+    onError: createTRPCOnError("lambda"),
   });
 };
 

--- a/apps/status-page/src/lib/trpc/shared.ts
+++ b/apps/status-page/src/lib/trpc/shared.ts
@@ -2,7 +2,6 @@ import type { AppRouter } from "@openstatus/api";
 import * as Sentry from "@sentry/nextjs";
 import type { HTTPBatchLinkOptions, HTTPHeaders, TRPCLink } from "@trpc/client";
 import { httpBatchLink, loggerLink } from "@trpc/client";
-import type { TRPCError } from "@trpc/server";
 import superjson from "superjson";
 
 /**
@@ -33,16 +32,6 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
       }
     },
   });
-
-/**
- * Shared onError handler for tRPC route handlers.
- */
-export function createOnError(label: string) {
-  return ({ error }: { error: TRPCError }) => {
-    console.log(`Error in tRPC handler (${label})`);
-    console.error(error);
-  };
-}
 
 /**
  * Filter out requests that don't come from our tRPC clients.

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -2,17 +2,10 @@
 // The config you add here will be used whenever one of the edge features is loaded.
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+import { isExpectedTRPCError } from "@openstatus/api/src/trpc-errors";
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
 
 import { env } from "@/env";
-
-// tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "UNAUTHORIZED",
-  "NOT_FOUND",
-  "BAD_REQUEST",
-];
 
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN,
@@ -25,10 +18,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (
-      hint.originalException instanceof TRPCError &&
-      IGNORED_TRPC_CODES.includes(hint.originalException.code)
-    ) {
+    if (isExpectedTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -2,17 +2,10 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { isExpectedTRPCError } from "@openstatus/api/src/trpc-errors";
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
 
 import { env } from "@/env";
-
-// tRPC error codes that should not be reported to Sentry (expected client errors)
-const IGNORED_TRPC_CODES: TRPCError["code"][] = [
-  "UNAUTHORIZED",
-  "NOT_FOUND",
-  "BAD_REQUEST",
-];
 
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN,
@@ -25,10 +18,7 @@ Sentry.init({
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
 
   beforeSend(event, hint) {
-    if (
-      hint.originalException instanceof TRPCError &&
-      IGNORED_TRPC_CODES.includes(hint.originalException.code)
-    ) {
+    if (isExpectedTRPCError(hint.originalException)) {
       return null;
     }
     return event;

--- a/apps/web/src/app/api/trpc/lambda/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/lambda/[trpc]/route.ts
@@ -1,8 +1,9 @@
 import { appRouter, createTRPCContext } from "@openstatus/api";
+import { createTRPCOnError } from "@openstatus/api/src/trpc-errors";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { NextRequest } from "next/server";
 
-import { createOnError, guardTRPCSource } from "../../../../../trpc/shared";
+import { guardTRPCSource } from "../../../../../trpc/shared";
 
 // Runs on the Node.js runtime (Vercel Fluid compute). The whole tRPC surface
 // is served here — several routers pull Node-only deps (@slack/web-api, email
@@ -17,7 +18,7 @@ const handler = (req: NextRequest) => {
     router: appRouter,
     req: req,
     createContext: () => createTRPCContext({ req }),
-    onError: createOnError("lambda"),
+    onError: createTRPCOnError("lambda"),
   });
 };
 

--- a/apps/web/src/trpc/shared.ts
+++ b/apps/web/src/trpc/shared.ts
@@ -34,16 +34,6 @@ export const sentryLoggerLink = (): TRPCLink<AppRouter> =>
   });
 
 /**
- * Shared onError handler for tRPC route handlers.
- */
-export function createOnError(label: string) {
-  return ({ error }: { error: { code: string; message: string } }) => {
-    console.log(`Error in tRPC handler (${label})`);
-    console.error(error);
-  };
-}
-
-/**
  * Filter out requests that don't come from our tRPC clients.
  * Our server and client links always set `x-trpc-source`.
  * This is a convention filter for bots/crawlers, not a security boundary —

--- a/packages/api/src/trpc-errors.test.ts
+++ b/packages/api/src/trpc-errors.test.ts
@@ -1,0 +1,102 @@
+import { expect } from "@std/expect";
+import { describe, test } from "@std/testing/bdd";
+import { TRPCError } from "@trpc/server";
+
+import {
+  EXPECTED_TRPC_CODES,
+  createTRPCOnError,
+  isExpectedTRPCError,
+  isExpectedTRPCErrorCode,
+} from "./trpc-errors";
+
+// Simulates the cross-bundle case: a TRPCError from the app bundle whose class
+// identity differs from this module's `@trpc/server`, so only name + code match.
+function fakeTRPCError(code: string): unknown {
+  return Object.assign(new Error("boom"), { name: "TRPCError", code });
+}
+
+function captureConsole(fn: () => void): { error: number; log: number } {
+  const origError = console.error;
+  const origLog = console.log;
+  let error = 0;
+  let log = 0;
+  console.error = () => {
+    error++;
+  };
+  console.log = () => {
+    log++;
+  };
+  try {
+    fn();
+  } finally {
+    console.error = origError;
+    console.log = origLog;
+  }
+  return { error, log };
+}
+
+describe("isExpectedTRPCErrorCode", () => {
+  test("true for every expected client code", () => {
+    for (const code of EXPECTED_TRPC_CODES) {
+      expect(isExpectedTRPCErrorCode(code)).toBe(true);
+    }
+  });
+
+  test("false for server errors", () => {
+    expect(isExpectedTRPCErrorCode("INTERNAL_SERVER_ERROR")).toBe(false);
+    expect(isExpectedTRPCErrorCode("TIMEOUT")).toBe(false);
+  });
+});
+
+describe("isExpectedTRPCError", () => {
+  test("true for a real TRPCError with an expected code", () => {
+    const err = new TRPCError({ code: "NOT_FOUND", message: "not found" });
+    expect(isExpectedTRPCError(err)).toBe(true);
+  });
+
+  test("false for a real TRPCError with a server-error code", () => {
+    const err = new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
+    expect(isExpectedTRPCError(err)).toBe(false);
+  });
+
+  test("true for a cross-bundle TRPCError matched by name + code", () => {
+    expect(isExpectedTRPCError(fakeTRPCError("NOT_FOUND"))).toBe(true);
+  });
+
+  test("false for a cross-bundle TRPCError with a server-error code", () => {
+    expect(isExpectedTRPCError(fakeTRPCError("INTERNAL_SERVER_ERROR"))).toBe(
+      false,
+    );
+  });
+
+  test("false for a plain Error that is not a TRPCError", () => {
+    expect(isExpectedTRPCError(new Error("NOT_FOUND"))).toBe(false);
+  });
+
+  test("false for non-error values", () => {
+    expect(isExpectedTRPCError(null)).toBe(false);
+    expect(isExpectedTRPCError(undefined)).toBe(false);
+    expect(isExpectedTRPCError("NOT_FOUND")).toBe(false);
+    expect(isExpectedTRPCError({ code: "NOT_FOUND" })).toBe(false);
+  });
+});
+
+describe("createTRPCOnError", () => {
+  test("does not log expected client errors", () => {
+    const onError = createTRPCOnError("lambda");
+    const counts = captureConsole(() =>
+      onError({ error: { code: "NOT_FOUND", message: "not found" } }),
+    );
+    expect(counts.error).toBe(0);
+    expect(counts.log).toBe(0);
+  });
+
+  test("logs genuine server errors", () => {
+    const onError = createTRPCOnError("lambda");
+    const counts = captureConsole(() =>
+      onError({ error: { code: "INTERNAL_SERVER_ERROR", message: "boom" } }),
+    );
+    expect(counts.error).toBe(1);
+    expect(counts.log).toBe(1);
+  });
+});

--- a/packages/api/src/trpc-errors.ts
+++ b/packages/api/src/trpc-errors.ts
@@ -1,0 +1,47 @@
+import type { TRPCError } from "@trpc/server";
+
+/**
+ * tRPC error codes that map to 4xx client errors. These are expected outcomes
+ * (missing resource, bad input, unauthorized), not bugs, so they should not be
+ * reported to Sentry.
+ */
+export const EXPECTED_TRPC_CODES: readonly TRPCError["code"][] = [
+  "BAD_REQUEST",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "CONFLICT",
+  "PRECONDITION_FAILED",
+  "TOO_MANY_REQUESTS",
+];
+
+export function isExpectedTRPCErrorCode(code: TRPCError["code"]): boolean {
+  return EXPECTED_TRPC_CODES.includes(code);
+}
+
+/**
+ * Duck-typed guard for Sentry's `beforeSend`. Matches on the error name + code
+ * rather than `instanceof TRPCError`: the thrown error comes from the app
+ * bundle, whose `@trpc/server` class identity differs from the copy an
+ * instrumentation config would import at runtime, so `instanceof` gives false
+ * negatives.
+ */
+export function isExpectedTRPCError(err: unknown): err is TRPCError {
+  return (
+    err instanceof Error &&
+    err.name === "TRPCError" &&
+    isExpectedTRPCErrorCode((err as TRPCError).code)
+  );
+}
+
+/**
+ * tRPC route-handler `onError`. Logs genuine server errors but drops expected
+ * client errors, so Sentry's `captureConsoleIntegration` never reports them.
+ */
+export function createTRPCOnError(label: string) {
+  return ({ error }: { error: Pick<TRPCError, "code" | "message"> }) => {
+    if (isExpectedTRPCErrorCode(error.code)) return;
+    console.log(`Error in tRPC handler (${label})`);
+    console.error(error);
+  };
+}


### PR DESCRIPTION
Extracts tRPC error handling logic into a shared, testable module to eliminate duplication across Sentry configurations and tRPC route handlers.

## Summary

Moves error classification and filtering logic from individual Sentry configs into `@openstatus/api/src/trpc-errors`, making it reusable and testable. This follows the project's convention of centralizing business logic in `packages/` for reuse across tRPC, Hono, and background jobs.

## Changes

- **New module:** `packages/api/src/trpc-errors.ts` exports:
  - `EXPECTED_TRPC_CODES`: list of 4xx client error codes (BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND, CONFLICT, PRECONDITION_FAILED, TOO_MANY_REQUESTS)
  - `isExpectedTRPCErrorCode()`: checks if a code is in the expected list
  - `isExpectedTRPCError()`: duck-typed guard for Sentry's `beforeSend` that matches on error name + code (handles cross-bundle class identity issues)
  - `createTRPCOnError()`: factory for tRPC route-handler `onError` that logs server errors but silently drops expected client errors

- **New tests:** `packages/api/src/trpc-errors.test.ts` covers:
  - Code classification (expected vs. server errors)
  - Cross-bundle TRPCError matching (name + code duck-typing)
  - Sentry filtering behavior
  - Console logging for genuine errors only

- **Removed duplication:** Deleted `createOnError()` from three app-specific `shared.ts` files (dashboard, status-page, web)

- **Updated Sentry configs:** All six Sentry config files (edge + server for each of dashboard, status-page, web) now import and use `isExpectedTRPCError()` instead of local `IGNORED_TRPC_CODES` lists

- **Updated route handlers:** Three tRPC lambda route handlers now import `createTRPCOnError` from the API package instead of local `createOnError`

## Implementation Details

The `isExpectedTRPCError()` guard uses duck-typing (checking `name === "TRPCError"` + code validation) rather than `instanceof` because thrown errors come from the app bundle, whose `@trpc/server` class identity differs from the copy imported by instrumentation configs at runtime. This ensures Sentry filtering works correctly in both development and production.

https://claude.ai/code/session_01EGFu8ChhYtctyi2WatLPo6

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

