### PR TITLE
Fix proto3 JSON deserialization of unset scalar fields

### DIFF
--- a/apps/server/src/routes/rpc/handlers/status-page/__tests__/status-page.test.ts
+++ b/apps/server/src/routes/rpc/handlers/status-page/__tests__/status-page.test.ts
@@ -559,7 +559,9 @@ describe("StatusPageService.GetPageComponent", () => {
     expect(data.component.name).toBe(`${TEST_PREFIX}-component`);
     expect(data.component.pageId).toBe(String(testPageId));
     expect(data.component.type).toBe("PAGE_COMPONENT_TYPE_STATIC");
-    expect(data.component.monitorId).toBe("");
+    // proto3 omits default-valued scalars from JSON, so an unset monitor
+    // arrives as either "" or undefined.
+    expect(data.component.monitorId ?? "").toBe("");
   });
 
   test("returns 401 when no auth key provided", async () => {


### PR DESCRIPTION
## Summary
Updated a test assertion to handle proto3's JSON serialization behavior, where default-valued scalars (like empty strings) may be omitted from the JSON response and arrive as `undefined` instead of an empty string.

## Changes
- Modified the `monitorId` assertion in `StatusPageService.GetPageComponent` test to account for proto3's optional omission of default values
- Changed from strict equality check (`toBe("")`) to a nullish coalescing pattern (`?? ""`) that accepts both `""` and `undefined` as equivalent
- Added a clarifying comment explaining the proto3 JSON serialization behavior

## Implementation Details
Proto3 omits fields with default values from JSON output for efficiency. When deserializing, an omitted scalar field may arrive as `undefined` rather than its zero value. This change makes the test more robust to this valid behavior without changing the actual service logic.

https://claude.ai/code/session_01HRhe4vxcmbm49puA4ZL57M

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

