### PR TITLE
Fix formatMillisecondsRange to handle sub-second ranges correctly

### DIFF
--- a/apps/status-page/src/lib/formatter.test.ts
+++ b/apps/status-page/src/lib/formatter.test.ts
@@ -6,6 +6,8 @@ import {
   formatDateRange,
   formatDateRangeParts,
   formatDateTime,
+  formatMilliseconds,
+  formatMillisecondsRange,
   formatTime,
 } from "./formatter";
 
@@ -57,6 +59,36 @@ describe("formatter UTC rendering", () => {
     test("does not shift a late-UTC time into the next day's hours", () => {
       expect(formatTime(new Date("2024-01-15T23:30:00Z"))).toBe("11:30 PM");
     });
+  });
+});
+
+describe("formatMilliseconds", () => {
+  test("renders sub-second values with the millisecond unit", () => {
+    expect(formatMilliseconds(111)).toBe("111 ms");
+  });
+
+  test("converts values above 1000ms to seconds", () => {
+    expect(formatMilliseconds(1500)).toBe("1.5 sec");
+  });
+});
+
+describe("formatMillisecondsRange", () => {
+  // Regression: both endpoints below 1000ms must stay in milliseconds — the
+  // `min` side was previously divided by 1000, rendering 111ms as "0.111".
+  test("keeps both endpoints in milliseconds when both are below 1000", () => {
+    expect(formatMillisecondsRange(111, 155)).toBe("111 - 155 ms");
+  });
+
+  test("does not divide the min endpoint by 1000 for sub-second ranges", () => {
+    expect(formatMillisecondsRange(111, 155)).not.toContain("0.111");
+  });
+
+  test("shares the seconds unit when both endpoints exceed 1000", () => {
+    expect(formatMillisecondsRange(1500, 2300)).toBe("1.5 - 2.3 sec");
+  });
+
+  test("formats each endpoint with its own unit for a mixed range", () => {
+    expect(formatMillisecondsRange(500, 1500)).toBe("500 ms - 1.5 sec");
   });
 });
 

--- a/apps/status-page/src/lib/formatter.ts
+++ b/apps/status-page/src/lib/formatter.ts
@@ -17,10 +17,17 @@ export function formatMilliseconds(ms: number) {
 }
 
 export function formatMillisecondsRange(min: number, max: number) {
-  if ((min > 1000 && max > 1000) || (min < 1000 && max < 1000)) {
-    return `${formatNumber(min / 1000)} - ${formatMilliseconds(max)}`;
+  // Both above 1000ms: share the seconds unit, so only `max` carries it.
+  if (min > 1000 && max > 1000) {
+    return `${formatNumber(min / 1000, { maximumFractionDigits: 2 })} - ${formatMilliseconds(max)}`;
   }
 
+  // Both below 1000ms: share the milliseconds unit, so only `max` carries it.
+  if (min < 1000 && max < 1000) {
+    return `${formatNumber(min)} - ${formatMilliseconds(max)}`;
+  }
+
+  // Mixed: format each endpoint with its own unit.
   return `${formatMilliseconds(min)} - ${formatMilliseconds(max)}`;
 }
 


### PR DESCRIPTION
## Summary

Fixed a regression in `formatMillisecondsRange` where the minimum endpoint of sub-second ranges was incorrectly divided by 1000, causing values like 111ms to render as "0.111".

## Changes

- **Split the conditional logic** in `formatMillisecondsRange` to handle three distinct cases:
  - Both endpoints ≥ 1000ms: share the seconds unit (only `max` carries it)
  - Both endpoints < 1000ms: share the milliseconds unit (only `max` carries it) — **fixes the regression**
  - Mixed range: format each endpoint with its own unit

- **Added comprehensive test coverage** for `formatMilliseconds` and `formatMillisecondsRange`:
  - Sub-second formatting
  - Conversion to seconds above 1000ms
  - Sub-second range handling (regression test)
  - Shared unit formatting for both-above and both-below cases
  - Mixed-range formatting with separate units

## Implementation Details

The original code attempted to handle both the "both above 1000ms" and "both below 1000ms" cases in a single condition, but incorrectly divided `min` by 1000 in both scenarios. The fix separates these cases so that when both values are below 1000ms, `min` is formatted as-is without division, preserving the millisecond unit.

https://claude.ai/code/session_019Ey9aBbaSKC8LuF1JQQBot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

