### PR TITLE
Feature OG images for public pages

### DIFF
--- a/apps/web/src/app/api/og/_components/status-hero.tsx
+++ b/apps/web/src/app/api/og/_components/status-hero.tsx
@@ -1,0 +1,225 @@
+import type { StatusVariant } from "@openstatus/tracker";
+
+import type { DayCell } from "../page/aggregate";
+import { UptimeBars, ogColors } from "./uptime-bars";
+
+const variantContent: Record<
+  StatusVariant,
+  { eyebrow: string; accent: string; iconBg: string; iconColor: string }
+> = {
+  up: {
+    eyebrow: "LIVE",
+    accent: ogColors.ok,
+    iconBg: ogColors.ok,
+    iconColor: "#0b120c",
+  },
+  degraded: {
+    eyebrow: "DEGRADED",
+    accent: ogColors.warn,
+    iconBg: ogColors.warn,
+    iconColor: "#1c1204",
+  },
+  down: {
+    eyebrow: "OUTAGE",
+    accent: ogColors.err,
+    iconBg: ogColors.err,
+    iconColor: "#2b0505",
+  },
+  incident: {
+    eyebrow: "DOWNTIME",
+    accent: ogColors.err,
+    iconBg: ogColors.err,
+    iconColor: "#2b0505",
+  },
+  maintenance: {
+    eyebrow: "MAINTENANCE",
+    accent: ogColors.info,
+    iconBg: ogColors.info,
+    iconColor: "#0b1226",
+  },
+  empty: {
+    eyebrow: "STATUS",
+    accent: ogColors.mfg,
+    iconBg: ogColors.mfg,
+    iconColor: "#171717",
+  },
+};
+
+export function StatusHero({
+  title,
+  icon,
+  variant,
+  statusLong,
+  subline,
+  lookbackDays,
+  days,
+}: {
+  title: string;
+  icon: string | null;
+  variant: StatusVariant;
+  statusLong: string;
+  subline: string | null;
+  lookbackDays: number;
+  days: DayCell[];
+}) {
+  const content = variantContent[variant];
+  // satori only decodes raster formats — .svg/.ico icons render as a blank box
+  const showImage = Boolean(
+    icon?.startsWith("http") && /\.(png|jpe?g|webp|gif)(\?|$)/i.test(icon),
+  );
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        width: "100%",
+        height: "100%",
+        padding: "60px 64px",
+        background: ogColors.bg,
+        color: ogColors.fg,
+        fontFamily: "Inter",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          {showImage && icon ? (
+            <img
+              src={icon}
+              width={52}
+              height={52}
+              style={{ borderRadius: 12 }}
+            />
+          ) : (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 52,
+                height: 52,
+                borderRadius: 12,
+                background: ogColors.fg,
+                color: ogColors.bg,
+                fontFamily: "CommitMono",
+                fontWeight: 700,
+                fontSize: 30,
+              }}
+            >
+              {(title[0] ?? "?").toUpperCase()}
+            </div>
+          )}
+          <span style={{ fontSize: 26, fontWeight: 500, letterSpacing: -0.26 }}>
+            {title}
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <div
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 999,
+              background: content.accent,
+              boxShadow: `0 0 0 5px ${content.accent}47`,
+            }}
+          />
+          <span
+            style={{
+              fontFamily: "CommitMono",
+              fontSize: 15,
+              letterSpacing: 2.1,
+              color: variant === "up" ? ogColors.mfg : content.accent,
+            }}
+          >
+            {content.eyebrow}
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 26 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 76,
+            height: 76,
+            borderRadius: 14,
+            background: content.iconBg,
+            color: content.iconColor,
+          }}
+        >
+          {variant === "up" ? <Check /> : <Alert />}
+        </div>
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <span
+            style={{
+              fontFamily: "Cal",
+              fontSize: 56,
+              letterSpacing: -1.12,
+              lineHeight: 1.05,
+            }}
+          >
+            {statusLong}
+          </span>
+          {subline ? (
+            <span
+              style={{
+                fontFamily: "CommitMono",
+                fontSize: 17,
+                color: ogColors.mfg,
+                marginTop: 8,
+              }}
+            >
+              {subline}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <UptimeBars days={days} placeholderCount={lookbackDays} />
+    </div>
+  );
+}
+
+function Check() {
+  return (
+    <svg
+      width="44"
+      height="44"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+function Alert() {
+  return (
+    <svg
+      width="44"
+      height="44"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 5v9" />
+      <path d="M12 18.5h.01" />
+    </svg>
+  );
+}

--- a/apps/web/src/app/api/og/_components/status-hero.tsx
+++ b/apps/web/src/app/api/og/_components/status-hero.tsx
@@ -1,6 +1,6 @@
 import type { StatusVariant } from "@openstatus/tracker";
 
-import type { DayCell } from "../page/aggregate";
+import { type DayCell, safeIconUrl } from "../page/aggregate";
 import { UptimeBars, ogColors } from "./uptime-bars";
 
 const variantContent: Record<
@@ -63,10 +63,7 @@ export function StatusHero({
   days: DayCell[];
 }) {
   const content = variantContent[variant];
-  // satori only decodes raster formats — .svg/.ico icons render as a blank box
-  const showImage = Boolean(
-    icon?.startsWith("http") && /\.(png|jpe?g|webp|gif)(\?|$)/i.test(icon),
-  );
+  const iconUrl = safeIconUrl(icon);
 
   return (
     <div
@@ -90,9 +87,9 @@ export function StatusHero({
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
-          {showImage && icon ? (
+          {iconUrl ? (
             <img
-              src={icon}
+              src={iconUrl}
               width={52}
               height={52}
               style={{ borderRadius: 12 }}
@@ -113,7 +110,7 @@ export function StatusHero({
                 fontSize: 30,
               }}
             >
-              {(title[0] ?? "?").toUpperCase()}
+              {(Array.from(title)[0] ?? "?").toUpperCase()}
             </div>
           )}
           <span style={{ fontSize: 26, fontWeight: 500, letterSpacing: -0.26 }}>

--- a/apps/web/src/app/api/og/_components/status-minimal.tsx
+++ b/apps/web/src/app/api/og/_components/status-minimal.tsx
@@ -1,0 +1,51 @@
+import { ogColors } from "./uptime-bars";
+
+export function StatusMinimal({
+  title,
+  domain,
+}: {
+  title: string;
+  domain: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 34,
+        width: "100%",
+        height: "100%",
+        background: ogColors.bg,
+        color: ogColors.fg,
+        fontFamily: "Inter",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
+        <div
+          style={{
+            width: 34,
+            height: 34,
+            borderRadius: 999,
+            background: ogColors.mfg,
+            boxShadow: `0 0 0 12px ${ogColors.mfg}29`,
+          }}
+        />
+        <span style={{ fontFamily: "Cal", fontSize: 84, letterSpacing: -2.5 }}>
+          {title}
+        </span>
+      </div>
+      <span
+        style={{
+          fontFamily: "CommitMono",
+          fontSize: 17,
+          color: ogColors.mfg,
+          letterSpacing: 0.34,
+        }}
+      >
+        {domain}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/og/_components/uptime-bars.tsx
+++ b/apps/web/src/app/api/og/_components/uptime-bars.tsx
@@ -1,0 +1,47 @@
+import type { DayCell } from "../page/aggregate";
+
+// hex-translated from the design's oklch tokens — satori supports neither
+// oklch() nor color-mix()
+export const ogColors = {
+  bg: "#171717",
+  fg: "#fafafa",
+  mfg: "#a3a3a3",
+  ok: "#22c55e",
+  warn: "#f59e0b",
+  err: "#f87171",
+  info: "#3b82f6",
+  dim: "rgba(34,197,94,0.22)",
+} as const;
+
+const barColors: Record<DayCell["status"], string> = {
+  success: ogColors.ok,
+  degraded: ogColors.warn,
+  error: ogColors.err,
+  info: ogColors.info,
+  empty: ogColors.dim,
+};
+
+export function UptimeBars({
+  days,
+  placeholderCount,
+  height = 58,
+}: {
+  days: DayCell[];
+  placeholderCount: number;
+  height?: number;
+}) {
+  const cells = days.length
+    ? days.map((day) => barColors[day.status])
+    : Array.from({ length: placeholderCount }, () => ogColors.dim);
+
+  return (
+    <div style={{ display: "flex", gap: 3, width: "100%" }}>
+      {cells.map((color, i) => (
+        <div
+          key={i}
+          style={{ flex: 1, height, borderRadius: 3, background: color }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/api/og/page/aggregate.test.ts
+++ b/apps/web/src/app/api/og/page/aggregate.test.ts
@@ -5,6 +5,7 @@ import {
   type ComponentUptime,
   aggregatePageDays,
   aggregateUptime,
+  safeIconUrl,
   stateContext,
 } from "./aggregate";
 
@@ -121,6 +122,45 @@ describe("aggregateUptime", () => {
   test("returns null when an uptime value is unparsable", () => {
     expect(
       aggregateUptime([monitor("n/a", []), monitor("100%", [])]),
+    ).toBeNull();
+  });
+});
+
+describe("safeIconUrl", () => {
+  const BLOB = "https://abc123.public.blob.vercel-storage.com/acme/icon.png";
+
+  test("returns null for missing or non-URL values", () => {
+    expect(safeIconUrl(null)).toBeNull();
+    expect(safeIconUrl(undefined)).toBeNull();
+    expect(safeIconUrl("")).toBeNull();
+    expect(safeIconUrl("favicon.ico")).toBeNull();
+  });
+
+  test("accepts raster icons on the upload storage host", () => {
+    expect(safeIconUrl(BLOB)).toBe(BLOB);
+    expect(safeIconUrl(`${BLOB}?v=1`)).toBe(`${BLOB}?v=1`);
+  });
+
+  test("rejects non-https URLs even on the allowed host", () => {
+    expect(
+      safeIconUrl("http://abc123.public.blob.vercel-storage.com/x.png"),
+    ).toBeNull();
+  });
+
+  test("rejects other hosts, including lookalike suffixes", () => {
+    expect(safeIconUrl("https://evil.com/icon.png")).toBeNull();
+    expect(safeIconUrl("https://server:3000/internal.png")).toBeNull();
+    expect(
+      safeIconUrl("https://x.public.blob.vercel-storage.com.evil.com/a.png"),
+    ).toBeNull();
+  });
+
+  test("rejects non-raster paths on the allowed host", () => {
+    expect(
+      safeIconUrl("https://abc123.public.blob.vercel-storage.com/icon.svg"),
+    ).toBeNull();
+    expect(
+      safeIconUrl("https://abc123.public.blob.vercel-storage.com/favicon.ico"),
     ).toBeNull();
   });
 });

--- a/apps/web/src/app/api/og/page/aggregate.test.ts
+++ b/apps/web/src/app/api/og/page/aggregate.test.ts
@@ -1,0 +1,218 @@
+import { expect } from "@std/expect";
+import { describe, test } from "@std/testing/bdd";
+
+import {
+  type ComponentUptime,
+  aggregatePageDays,
+  aggregateUptime,
+  stateContext,
+} from "./aggregate";
+
+function day(iso: string, bar: ComponentUptime["data"][number]["bar"]) {
+  return { day: `${iso}T00:00:00.000Z`, bar };
+}
+
+function monitor(
+  uptime: string,
+  data: ComponentUptime["data"],
+): ComponentUptime {
+  return { type: "monitor", uptime, data };
+}
+
+describe("aggregatePageDays", () => {
+  test("returns empty array for no components", () => {
+    expect(aggregatePageDays([])).toEqual([]);
+  });
+
+  test("takes the worst status across components on the same day", () => {
+    const a = monitor("100%", [
+      day("2026-07-16", [{ status: "success", height: 100 }]),
+    ]);
+    const b = monitor("98%", [
+      day("2026-07-16", [
+        { status: "success", height: 90 },
+        { status: "error", height: 10 },
+      ]),
+    ]);
+    expect(aggregatePageDays([a, b])).toEqual([
+      { day: "2026-07-16", status: "error" },
+    ]);
+  });
+
+  test("ignores zero-height segments", () => {
+    const a = monitor("100%", [
+      day("2026-07-16", [
+        { status: "success", height: 100 },
+        { status: "error", height: 0 },
+      ]),
+    ]);
+    expect(aggregatePageDays([a])).toEqual([
+      { day: "2026-07-16", status: "success" },
+    ]);
+  });
+
+  test("ranks degraded above info and info above success", () => {
+    const a = monitor("100%", [
+      day("2026-07-15", [
+        { status: "info", height: 20 },
+        { status: "degraded", height: 10 },
+        { status: "success", height: 70 },
+      ]),
+      day("2026-07-16", [
+        { status: "info", height: 30 },
+        { status: "success", height: 70 },
+      ]),
+    ]);
+    expect(aggregatePageDays([a])).toEqual([
+      { day: "2026-07-15", status: "degraded" },
+      { day: "2026-07-16", status: "info" },
+    ]);
+  });
+
+  test("marks days without positive segments as empty", () => {
+    const a = monitor("100%", [day("2026-07-16", [])]);
+    expect(aggregatePageDays([a])).toEqual([
+      { day: "2026-07-16", status: "empty" },
+    ]);
+  });
+
+  test("includes days missing from one component and sorts ascending", () => {
+    const a = monitor("100%", [
+      day("2026-07-16", [{ status: "success", height: 100 }]),
+    ]);
+    const b = monitor("100%", [
+      day("2026-07-15", [{ status: "success", height: 100 }]),
+      day("2026-07-16", [{ status: "success", height: 100 }]),
+    ]);
+    expect(aggregatePageDays([a, b])).toEqual([
+      { day: "2026-07-15", status: "success" },
+      { day: "2026-07-16", status: "success" },
+    ]);
+  });
+});
+
+describe("aggregateUptime", () => {
+  test("returns null for no monitor components", () => {
+    expect(aggregateUptime([])).toBeNull();
+    expect(
+      aggregateUptime([{ type: "static", uptime: "100%", data: [] }]),
+    ).toBeNull();
+  });
+
+  test("returns the single monitor's uptime unchanged", () => {
+    expect(aggregateUptime([monitor("99.98%", [])])).toBe("99.98%");
+  });
+
+  test("averages multiple monitors floored to two decimals", () => {
+    expect(aggregateUptime([monitor("100%", []), monitor("99.96%", [])])).toBe(
+      "99.98%",
+    );
+  });
+
+  test("excludes non-monitor components from the average", () => {
+    expect(
+      aggregateUptime([
+        monitor("99.5%", []),
+        { type: "static", uptime: "100%", data: [] },
+      ]),
+    ).toBe("99.5%");
+  });
+
+  test("returns null when an uptime value is unparsable", () => {
+    expect(
+      aggregateUptime([monitor("n/a", []), monitor("100%", [])]),
+    ).toBeNull();
+  });
+});
+
+describe("stateContext", () => {
+  const NOW = new Date("2026-07-17T15:00:00.000Z");
+
+  test("returns null for operational and empty variants", () => {
+    expect(stateContext("up", {}, NOW)).toBeNull();
+    expect(stateContext("empty", {}, NOW)).toBeNull();
+  });
+
+  test("degraded uses the active report title and earliest update time", () => {
+    const context = stateContext(
+      "degraded",
+      {
+        statusReports: [
+          { title: "Resolved one", status: "resolved" },
+          {
+            title: "Elevated error rates",
+            status: "investigating",
+            statusReportUpdates: [
+              { date: new Date("2026-07-17T14:40:00.000Z") },
+              { date: new Date("2026-07-17T14:22:00.000Z") },
+            ],
+          },
+        ],
+      },
+      NOW,
+    );
+    expect(context).toBe("Elevated error rates · started Jul 17, 14:22 UTC");
+  });
+
+  test("degraded without updates falls back to the title", () => {
+    expect(
+      stateContext(
+        "degraded",
+        { statusReports: [{ title: "API issues", status: "identified" }] },
+        NOW,
+      ),
+    ).toBe("API issues");
+  });
+
+  test("maintenance shows the active window end", () => {
+    expect(
+      stateContext(
+        "maintenance",
+        {
+          maintenances: [
+            {
+              title: "Database upgrade",
+              from: new Date("2026-07-17T14:00:00.000Z"),
+              to: new Date("2026-07-17T16:30:00.000Z"),
+            },
+          ],
+        },
+        NOW,
+      ),
+    ).toBe("Database upgrade · until Jul 17, 16:30 UTC");
+  });
+
+  test("incident uses the ongoing incident start time", () => {
+    expect(
+      stateContext(
+        "incident",
+        {
+          incidents: [
+            {
+              startedAt: new Date("2026-07-17T13:05:00.000Z"),
+              resolvedAt: null,
+            },
+          ],
+        },
+        NOW,
+      ),
+    ).toBe("Ongoing incident · started Jul 17, 13:05 UTC");
+  });
+
+  test("down without an ongoing incident returns null", () => {
+    expect(
+      stateContext(
+        "down",
+        {
+          incidents: [
+            {
+              startedAt: new Date("2026-07-17T10:00:00.000Z"),
+              resolvedAt: new Date("2026-07-17T11:00:00.000Z"),
+            },
+          ],
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/app/api/og/page/aggregate.ts
+++ b/apps/web/src/app/api/og/page/aggregate.ts
@@ -1,0 +1,125 @@
+type BarStatus = "success" | "degraded" | "error" | "info" | "empty";
+
+type ComponentDay = {
+  day: string;
+  bar: { status: BarStatus; height: number }[];
+};
+
+export type ComponentUptime = {
+  type: string;
+  uptime: string;
+  data: ComponentDay[];
+};
+
+export type DayCell = { day: string; status: BarStatus };
+
+const severity: Record<BarStatus, number> = {
+  error: 4,
+  degraded: 3,
+  info: 2,
+  success: 1,
+  empty: 0,
+};
+
+export function aggregatePageDays(components: ComponentUptime[]): DayCell[] {
+  const byDay = new Map<string, BarStatus>();
+  for (const component of components) {
+    for (const { day, bar } of component.data) {
+      const key = day.slice(0, 10);
+      let worst = byDay.get(key) ?? "empty";
+      for (const segment of bar) {
+        if (segment.height <= 0) continue;
+        if (severity[segment.status] > severity[worst]) worst = segment.status;
+      }
+      byDay.set(key, worst);
+    }
+  }
+  return [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, status]) => ({ day, status }));
+}
+
+type DateLike = Date | string | number;
+
+type ActiveEvents = {
+  statusReports?: {
+    title: string;
+    status: string;
+    statusReportUpdates?: { date: DateLike }[];
+  }[];
+  maintenances?: { title: string; from: DateLike; to: DateLike }[];
+  incidents?: {
+    startedAt: DateLike | null;
+    resolvedAt: DateLike | null;
+  }[];
+};
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+// manual UTC formatting — date-fns format() uses the server's local timezone
+function formatUtc(date: Date): string {
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const mm = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}, ${hh}:${mm} UTC`;
+}
+
+export function stateContext(
+  variant: string,
+  events: ActiveEvents,
+  now = new Date(),
+): string | null {
+  if (variant === "maintenance") {
+    const active = events.maintenances?.find(
+      (m) =>
+        new Date(m.from).getTime() <= now.getTime() &&
+        new Date(m.to).getTime() >= now.getTime(),
+    );
+    return active
+      ? `${active.title} · until ${formatUtc(new Date(active.to))}`
+      : null;
+  }
+  if (variant === "degraded") {
+    const active = events.statusReports?.find(
+      (r) => !["monitoring", "resolved"].includes(r.status),
+    );
+    if (!active) return null;
+    const started = active.statusReportUpdates
+      ?.map((u) => new Date(u.date).getTime())
+      .sort((a, b) => a - b)[0];
+    return started
+      ? `${active.title} · started ${formatUtc(new Date(started))}`
+      : active.title;
+  }
+  if (variant === "incident" || variant === "down") {
+    const ongoing = events.incidents?.find((i) => i.startedAt && !i.resolvedAt);
+    return ongoing?.startedAt
+      ? `Ongoing incident · started ${formatUtc(new Date(ongoing.startedAt))}`
+      : null;
+  }
+  return null;
+}
+
+export function aggregateUptime(components: ComponentUptime[]): string | null {
+  const monitors = components.filter((c) => c.type === "monitor");
+  if (monitors.length === 0) return null;
+  if (monitors.length === 1) return monitors[0].uptime;
+  const values = monitors.map((c) => Number.parseFloat(c.uptime));
+  if (values.some((value) => Number.isNaN(value))) return null;
+  // average in integer hundredths to avoid float artifacts like 99.97999...
+  const cents = values.map((value) => Math.round(value * 100));
+  const avg = cents.reduce((sum, value) => sum + value, 0) / cents.length;
+  return `${Math.floor(avg) / 100}%`;
+}

--- a/apps/web/src/app/api/og/page/aggregate.ts
+++ b/apps/web/src/app/api/og/page/aggregate.ts
@@ -112,6 +112,26 @@ export function stateContext(
   return null;
 }
 
+// satori fetches the icon server-side during render — restrict to our upload
+// storage so a stored URL can't be used as an SSRF primitive, and to raster
+// formats since satori renders .svg/.ico as blank boxes
+const ALLOWED_ICON_HOSTS = [/\.public\.blob\.vercel-storage\.com$/i];
+const RASTER_ICON = /\.(png|jpe?g|webp|gif)$/i;
+
+export function safeIconUrl(icon: string | null | undefined): string | null {
+  if (!icon) return null;
+  let url: URL;
+  try {
+    url = new URL(icon);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:") return null;
+  if (!ALLOWED_ICON_HOSTS.some((host) => host.test(url.hostname))) return null;
+  if (!RASTER_ICON.test(url.pathname)) return null;
+  return url.toString();
+}
+
 export function aggregateUptime(components: ComponentUptime[]): string | null {
   const monitors = components.filter((c) => c.type === "monitor");
   if (monitors.length === 0) return null;

--- a/apps/web/src/app/api/og/page/route.tsx
+++ b/apps/web/src/app/api/og/page/route.tsx
@@ -1,3 +1,4 @@
+import { pageConfigurationSchema } from "@openstatus/db/src/schema";
 import { Tracker } from "@openstatus/tracker";
 import { ImageResponse } from "next/og";
 
@@ -5,25 +6,32 @@ import { DESCRIPTION, TITLE } from "../../../../lib/metadata/shared-metadata";
 import { api } from "../../../../trpc/server";
 import { BasicLayout } from "../_components/basic-layout";
 import { StatusCheck } from "../_components/status-check";
-import { SIZE, calSemiBold, interLight, interRegular } from "../utils";
+import { StatusHero } from "../_components/status-hero";
+import { StatusMinimal } from "../_components/status-minimal";
+import {
+  SIZE,
+  calSemiBold,
+  commitMonoBold,
+  commitMonoRegular,
+  interLight,
+  interMedium,
+  interRegular,
+} from "../utils";
+import { aggregatePageDays, aggregateUptime, stateContext } from "./aggregate";
 
 export const runtime = "edge";
 
-// TODO: legacy Tracker - use api.statusPage.get.query instead
+const CACHE_CONTROL =
+  "public, max-age=0, s-maxage=300, stale-while-revalidate=600";
 
 export async function GET(req: Request) {
-  const [interRegularData, interLightData, calSemiBoldData] = await Promise.all(
-    [interRegular, interLight, calSemiBold],
-  );
-
   const { searchParams } = new URL(req.url);
 
-  const slug = searchParams.has("slug") ? searchParams.get("slug") : undefined;
+  const slug = searchParams.get("slug") ?? "";
 
-  const page = await api.statusPage.getLight.query({ slug: slug || "" });
+  const page = await api.statusPage.getLight.query({ slug });
   const _protected = page?.accessType !== "public";
   const title = page ? page.title : TITLE;
-  const description = page ? "" : DESCRIPTION;
 
   // REMINDER: if password protected, we keep the status 'operational' by default, hiding the actual status
   const tracker = new Tracker({
@@ -32,32 +40,142 @@ export async function GET(req: Request) {
     maintenances: _protected ? undefined : page?.maintenances,
   });
 
-  return new ImageResponse(
-    <BasicLayout title={title} description={description} tw="py-24 px-24">
-      <StatusCheck tracker={tracker} />
-    </BasicLayout>,
+  // protected (and unknown) pages keep the legacy neutral image — the
+  // data-rich hero is for public pages only
+  if (_protected) {
+    const [interRegularData, interLightData, calSemiBoldData] =
+      await Promise.all([interRegular, interLight, calSemiBold]);
+
+    return new ImageResponse(
+      <BasicLayout
+        title={title}
+        description={page ? "" : DESCRIPTION}
+        tw="py-24 px-24"
+      >
+        <StatusCheck tracker={tracker} />
+      </BasicLayout>,
+      {
+        ...SIZE,
+        headers: { "cache-control": CACHE_CONTROL },
+        fonts: [
+          {
+            name: "Inter",
+            data: interRegularData,
+            style: "normal",
+            weight: 400,
+          },
+          {
+            name: "Inter",
+            data: interLightData,
+            style: "normal",
+            weight: 300,
+          },
+          {
+            name: "Cal",
+            data: calSemiBoldData,
+            style: "normal",
+            weight: 600,
+          },
+        ],
+      },
+    );
+  }
+
+  const [regular, medium, cal, mono, monoBold] = await Promise.all([
+    interRegular,
+    interMedium,
+    calSemiBold,
+    commitMonoRegular,
+    commitMonoBold,
+  ]);
+
+  const fonts = [
     {
-      ...SIZE,
-      fonts: [
-        {
-          name: "Inter",
-          data: interRegularData,
-          style: "normal",
-          weight: 400,
-        },
-        {
-          name: "Inter",
-          data: interLightData,
-          style: "normal",
-          weight: 300,
-        },
-        {
-          name: "Cal",
-          data: calSemiBoldData,
-          style: "normal",
-          weight: 600,
-        },
-      ],
+      name: "Inter",
+      data: regular,
+      style: "normal" as const,
+      weight: 400 as const,
     },
+    {
+      name: "Inter",
+      data: medium,
+      style: "normal" as const,
+      weight: 500 as const,
+    },
+    { name: "Cal", data: cal, style: "normal" as const, weight: 600 as const },
+    {
+      name: "CommitMono",
+      data: mono,
+      style: "normal" as const,
+      weight: 400 as const,
+    },
+    {
+      name: "CommitMono",
+      data: monoBold,
+      style: "normal" as const,
+      weight: 700 as const,
+    },
+  ];
+
+  const cfgResult = pageConfigurationSchema.safeParse(
+    page?.configuration ?? {},
+  );
+  const cfg = cfgResult.success
+    ? cfgResult.data
+    : pageConfigurationSchema.parse({});
+
+  const componentIds = page
+    ? page.pageComponents
+        .filter((component) => component.type === "monitor")
+        .map((component) => String(component.id))
+    : [];
+
+  // bars are decorative on the preview — a failing uptime read must not break it
+  const components = componentIds.length
+    ? await api.statusPage.getUptime
+        .query({
+          slug,
+          pageComponentIds: componentIds,
+          cardType: cfg.value,
+          barType: cfg.type,
+        })
+        .catch(() => null)
+    : null;
+
+  const days = aggregatePageDays(components ?? []);
+  const uptime = cfg.uptime ? aggregateUptime(components ?? []) : null;
+  const details = tracker.currentDetails;
+
+  // operational pages without any bar data get the neutral minimal treatment;
+  // active events always take their state layout even without data
+  const noData = !days.some((day) => day.status !== "empty");
+  if (details.variant === "up" && noData) {
+    const domain =
+      page?.customDomain || (page ? `${page.slug}.openstatus.dev` : "");
+    return new ImageResponse(<StatusMinimal title={title} domain={domain} />, {
+      ...SIZE,
+      headers: { "cache-control": CACHE_CONTROL },
+      fonts,
+    });
+  }
+
+  const subline =
+    stateContext(details.variant, {
+      statusReports: page?.statusReports,
+      maintenances: page?.maintenances,
+      incidents: page?.incidents,
+    }) ?? (uptime ? `${uptime} uptime · last ${days.length} days` : null);
+
+  return new ImageResponse(
+    <StatusHero
+      title={title}
+      icon={page?.icon ?? null}
+      variant={details.variant}
+      statusLong={details.long}
+      subline={subline}
+      lookbackDays={days.length || cfg.days}
+      days={days}
+    />,
+    { ...SIZE, headers: { "cache-control": CACHE_CONTROL }, fonts },
   );
 }

--- a/deno.lock
+++ b/deno.lock
@@ -54,6 +54,248 @@
       "dependencies": [
         "npm:turbo@2.9.14"
       ]
+    },
+    "members": {
+      "apps/server": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "apps/status-page": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "apps/web": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/ai": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/api": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/db": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/emails": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/header-analysis": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/importers": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/base": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/bird-whatsapp": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/discord": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/google-chat": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/grafana-oncall": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/ms-teams": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/ntfy": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/opsgenie": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/pagerduty": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/slack": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/telegram": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/twillio-sms": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/notifications/webhook": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/services": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/status-fetcher": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/subscriptions": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/test-utils": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/theme-store": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/tinybird": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/tracker": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      },
+      "packages/utils": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@jsr/std__expect@^1.0.19",
+            "npm:@jsr/std__testing@^1.0.19"
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaces the generic status-page link preview with data-driven, state-aware OG images. The endpoint and contract are unchanged (`GET /api/og/page?slug={slug}` → 1200×630 PNG, consumed by the status-page layout), so no migration is needed anywhere else.

- **Public pages** unfurl a hero preview: page title + icon (letter-block fallback for non-raster icons), live status headline from `@openstatus/tracker`, a state context line, and the page's aggregated uptime bars for the configured lookback (30/45 days).
- **State-specific styles** — each page state renders its own tailored design, no user configuration:
  - *Operational* → green **LIVE** hero with uptime + bars
  - *Degraded* → amber hero with the active report title and started-at time
  - *Downtime* → red hero with the ongoing incident start time
  - *Maintenance* → blue hero with the maintenance title and window end
  - *Operational but no data* → neutral ultra-minimal card (title + domain)
- **Password-protected and unknown pages keep the legacy neutral image verbatim** — no status data leaks through the preview.
- Fonts reuse the existing OG pipeline (Inter, Cal Sans, CommitMono) — no new font assets.
- `Cache-Control: public, max-age=0, s-maxage=300, stale-while-revalidate=600` so unfurls refresh within minutes of a state change instead of caching a stale "operational" image during an incident.

## Implementation

- `apps/web/src/app/api/og/page/aggregate.ts` — pure helpers: worst-status-per-day aggregation across page components, uptime averaging in integer hundredths (avoids float artifacts like `99.97` for `(100 + 99.96) / 2`), and UTC state-context strings. Dates are coerced with `new Date(...)` since values arrive serialized over the tRPC loopback.
- `apps/web/src/app/api/og/_components/` — `status-hero.tsx`, `status-minimal.tsx`, `uptime-bars.tsx`: satori-safe components (flex-only layout, hex palette translated from the design's oklch tokens, raster-only icon whitelist since satori renders `.svg`/`.ico` as blank boxes).
- `apps/web/src/app/api/og/page/route.tsx` — protected/unknown pages short-circuit to the legacy layout first; public pages parse the page configuration, fetch uptime failure-tolerantly (bars are decorative — a failing read must not break the preview), and pick the variant.

## Screenshots

<!-- rendered previews of the new designs (operational / degraded / minimal) to be added -->

## Testing

- `aggregate.test.ts` — 17 deno tests covering day aggregation (worst-status ranking, zero-height segments, missing days), uptime averaging, and exact state-context strings.
- `pnpm tsc` clean; lint clean on touched files.
- Manually verified renders against the seeded dev stack: operational hero, degraded (seeded status report), no-data minimal, and the protected legacy image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuFYWv9tx7QpJ1UFpR7mvs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
