### PR TITLE
fix(checker): apply header assertion result to request status for private locations

### DIFF
--- a/apps/checker/pkg/job/http_job.go
+++ b/apps/checker/pkg/job/http_job.go
@@ -158,7 +158,7 @@ func (jr jobRunner) HTTPJob(ctx context.Context, monitor *v1.HTTPMonitor, region
 					Target:     assertion.Target,
 					Key:        assertion.Key,
 				}
-				assert.HeaderEvaluate(string(headersAsString))
+				isSuccessful = isSuccessful && assert.HeaderEvaluate(string(headersAsString))
 			}
 		}
 

--- a/apps/checker/pkg/job/http_job_test.go
+++ b/apps/checker/pkg/job/http_job_test.go
@@ -2,6 +2,8 @@ package job_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/openstatushq/openstatus/apps/checker/pkg/job"
@@ -144,4 +146,55 @@ func TestProtoNumberAssertionToComparator(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHTTPJob_HeaderAssertions ensures that header assertions influence the
+// request status for the private location scheduler, matching the behaviour of
+// the public checker. Regression test for a bug where the result of
+// HeaderEvaluate was discarded, so a failing header assertion was still
+// reported as a success.
+func TestHTTPJob_HeaderAssertions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Custom", "actual")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	newMonitor := func(target string) *v1.HTTPMonitor {
+		return &v1.HTTPMonitor{
+			Url:     srv.URL,
+			Method:  "GET",
+			Timeout: 10000,
+			Retry:   1,
+			HeaderAssertions: []*v1.HeaderAssertion{
+				{
+					Key:        "X-Custom",
+					Comparator: v1.StringComparator_STRING_COMPARATOR_EQUAL,
+					Target:     target,
+				},
+			},
+		}
+	}
+
+	t.Run("failing header assertion marks request as error", func(t *testing.T) {
+		monitor := newMonitor("expected")
+
+		data, err := job.NewJobRunner().HTTPJob(context.Background(), monitor, "test-region")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		assert.Equal(t, "error", data.RequestStatus)
+		assert.Equal(t, uint8(1), data.Error)
+	})
+
+	t.Run("passing header assertion keeps request successful", func(t *testing.T) {
+		monitor := newMonitor("actual")
+
+		data, err := job.NewJobRunner().HTTPJob(context.Background(), monitor, "test-region")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		assert.Equal(t, "success", data.RequestStatus)
+		assert.Equal(t, uint8(0), data.Error)
+	})
 }


### PR DESCRIPTION
## Problem

For monitors running on **private locations**, header assertions are evaluated but their result is ignored, so a request that fails a header assertion is still classified as a **success**.

Fixes #2374

## Root cause

In the private-location scheduler (`apps/checker/pkg/job/http_job.go`), the header-assertion loop called `HeaderEvaluate` but threw the boolean result away:

```go
assert.HeaderEvaluate(string(headersAsString))
```

The status-code and body assertion loops right below it correctly fold the result into `isSuccessful` (`isSuccessful = isSuccessful && ...`), and so does the public checker (`apps/checker/handlers/checker.go:351`). Only the header path in the private-location job dropped it.

## Fix

Combine the header-assertion result into `isSuccessful`, matching the sibling assertions and the public checker:

```go
isSuccessful = isSuccessful && assert.HeaderEvaluate(string(headersAsString))
```

## How I verified

Added `TestHTTPJob_HeaderAssertions` in `apps/checker/pkg/job/http_job_test.go`, which spins up an `httptest` server returning a known header and checks both directions:

- a **failing** header assertion → `RequestStatus == "error"` (`Error == 1`)
- a **passing** header assertion → `RequestStatus == "success"` (`Error == 0`)

I confirmed the test **fails on `main`** (the failing assertion was reported as a success) and **passes with the fix**. `go test ./pkg/job/ ./pkg/assertions/` and `go vet ./pkg/job/` are green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

