### PR TITLE
test(tracker): cover the date helpers and blacklist lookup

### DIFF
--- a/packages/tracker/src/blacklist.test.ts
+++ b/packages/tracker/src/blacklist.test.ts
@@ -1,0 +1,15 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { blacklistDates, isInBlacklist } from "./blacklist";
+
+describe("isInBlacklist", () => {
+  it("returns the stored reason for a blacklisted day", () => {
+    const key = "Fri Aug 25 2023";
+    expect(isInBlacklist(new Date(key))).toBe(blacklistDates[key]);
+  });
+
+  it("returns undefined for a day that is not blacklisted", () => {
+    expect(isInBlacklist(new Date("2024-01-01T12:00:00.000Z"))).toBeUndefined();
+  });
+});

--- a/packages/tracker/src/utils.test.ts
+++ b/packages/tracker/src/utils.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { endOfDay, isSameDay, startOfDay } from "./utils";
+
+describe("startOfDay", () => {
+  it("returns midnight UTC of the given day", () => {
+    expect(startOfDay(new Date("2026-03-15T14:30:45.123Z")).toISOString()).toBe(
+      "2026-03-15T00:00:00.000Z",
+    );
+  });
+
+  it("does not mutate the input date", () => {
+    const input = new Date("2026-03-15T14:30:45.123Z");
+    startOfDay(input);
+    expect(input.toISOString()).toBe("2026-03-15T14:30:45.123Z");
+  });
+});
+
+describe("endOfDay", () => {
+  it("returns the last millisecond of the day in UTC", () => {
+    expect(endOfDay(new Date("2026-03-15T00:00:00.000Z")).toISOString()).toBe(
+      "2026-03-15T23:59:59.999Z",
+    );
+  });
+});
+
+describe("isSameDay", () => {
+  it("is true for two times on the same UTC day", () => {
+    expect(
+      isSameDay(
+        new Date("2026-03-15T00:00:00.000Z"),
+        new Date("2026-03-15T23:59:59.999Z"),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false across a UTC midnight boundary", () => {
+    expect(
+      isSameDay(
+        new Date("2026-03-15T23:59:59.999Z"),
+        new Date("2026-03-16T00:00:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
The helpers in `packages/tracker/src` had no tests, so I added them.

* `startOfDay` and `endOfDay`: return midnight and the last millisecond of the day in UTC, and do not mutate the input.
* `isSameDay`: true for two times on the same UTC day, false across a UTC midnight boundary.
* `isInBlacklist`: returns the stored reason for a blacklisted day and undefined for a normal one.

Everything is UTC based, so the tests are deterministic regardless of the local timezone.

```
cd packages/tracker
deno test --parallel -A --no-check --sloppy-imports src/utils.test.ts src/blacklist.test.ts
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

