### PR TITLE
feat(web): add "How it works" section to marketing landing page

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { HowItWorks } from "@/components/marketing/how-it-works";
 import { CustomMDX } from "../../content/mdx";
 import { getHomePage } from "../../content/utils";
 import { JsonLd } from "../../lib/metadata/json-ld";
@@ -33,6 +34,7 @@ export default function Page() {
       <JsonLd graph={jsonLDGraph} />
       <h1>{homePage.metadata.hero ?? homePage.metadata.title}</h1>
       <p className="text-lg">{homePage.metadata.description}</p>
+      <HowItWorks />
       <CustomMDX source={homePage.content} />
     </div>
   );

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -15,6 +15,7 @@ type Step = {
   icon: LucideIcon;
   title: string;
   description: string;
+  status: string;
 };
 
 const steps: Step[] = [
@@ -23,18 +24,21 @@ const steps: Step[] = [
     title: "Add your monitors",
     description:
       "Connect your websites and APIs in seconds. Set your check frequency and regions.",
+    status: "Monitoring active",
   },
   {
     icon: Bell,
     title: "Get notified instantly",
     description:
       "Receive alerts via email, Slack, or SMS the moment downtime is detected.",
+    status: "Alerts enabled",
   },
   {
     icon: Globe,
     title: "Share your status",
     description:
       "Publish a beautiful public status page to keep your users informed.",
+    status: "Page published",
   },
 ];
 
@@ -62,18 +66,23 @@ export function HowItWorks() {
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-0 top-9 hidden items-center justify-between px-[16.6%] md:flex"
         >
-          <div className="h-px w-full border-t border-border border-dashed" />
+          <div className="h-px w-full border-t border-green-500/30 border-dashed" />
         </div>
 
         {steps.map((step, index) => {
           const Icon = step.icon;
           return (
             <div key={step.title} className="relative flex flex-col">
-              <Card className="relative h-full bg-background transition-colors hover:border-foreground/20">
+              <Card className="relative h-full overflow-hidden bg-background transition-colors hover:border-green-500/40">
+                {/* Green accent bar along the top */}
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-x-0 top-0 h-0.5 bg-green-500"
+                />
                 {/* Numbered badge */}
                 <span
                   aria-hidden="true"
-                  className="-top-3 -right-3 absolute flex h-8 w-8 items-center justify-center rounded-full border bg-background font-medium text-muted-foreground text-sm shadow-sm"
+                  className="-top-3 -right-3 absolute flex h-8 w-8 items-center justify-center rounded-full border border-green-500/30 bg-green-500/10 font-medium text-green-600 text-sm shadow-sm dark:text-green-400"
                 >
                   {index + 1}
                 </span>
@@ -81,17 +90,30 @@ export function HowItWorks() {
                   <span
                     className={cn(
                       "mb-2 flex h-11 w-11 items-center justify-center rounded-lg",
-                      "bg-muted text-foreground",
+                      "border border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400",
                     )}
                   >
                     <Icon className="h-5 w-5" aria-hidden="true" />
                   </span>
-                  <CardTitle className="text-lg">{step.title}</CardTitle>
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    {step.title}
+                  </CardTitle>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-3">
                   <CardDescription className="text-pretty leading-relaxed">
                     {step.description}
                   </CardDescription>
+                  {/* Small operational-style status detail */}
+                  <span className="inline-flex items-center gap-1.5 font-medium text-green-600 text-xs dark:text-green-400">
+                    <span
+                      aria-hidden="true"
+                      className="relative flex h-2 w-2"
+                    >
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
+                      <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+                    </span>
+                    {step.status}
+                  </span>
                 </CardContent>
               </Card>
             </div>

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -1,0 +1,103 @@
+import { Bell, Globe, Monitor } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@openstatus/ui/components/ui/card";
+
+import { cn } from "@/lib/utils";
+
+type Step = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+const steps: Step[] = [
+  {
+    icon: Monitor,
+    title: "Add your monitors",
+    description:
+      "Connect your websites and APIs in seconds. Set your check frequency and regions.",
+  },
+  {
+    icon: Bell,
+    title: "Get notified instantly",
+    description:
+      "Receive alerts via email, Slack, or SMS the moment downtime is detected.",
+  },
+  {
+    icon: Globe,
+    title: "Share your status",
+    description:
+      "Publish a beautiful public status page to keep your users informed.",
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section
+      aria-labelledby="how-it-works-heading"
+      className="not-prose my-16 rounded-2xl border bg-muted/40 px-4 py-14 sm:px-8"
+    >
+      <div className="mx-auto flex max-w-2xl flex-col items-center text-center">
+        <h2
+          id="how-it-works-heading"
+          className="text-balance font-cal text-3xl sm:text-4xl"
+        >
+          How it works
+        </h2>
+        <p className="mt-3 text-pretty text-muted-foreground leading-relaxed">
+          Go from zero to full observability in three simple steps.
+        </p>
+      </div>
+
+      <div className="relative mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3">
+        {/* Connecting dotted line across steps on desktop */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-9 hidden items-center justify-between px-[16.6%] md:flex"
+        >
+          <div className="h-px w-full border-t border-border border-dashed" />
+        </div>
+
+        {steps.map((step, index) => {
+          const Icon = step.icon;
+          return (
+            <div key={step.title} className="relative flex flex-col">
+              <Card className="relative h-full bg-background transition-colors hover:border-foreground/20">
+                {/* Numbered badge */}
+                <span
+                  aria-hidden="true"
+                  className="-top-3 -right-3 absolute flex h-8 w-8 items-center justify-center rounded-full border bg-background font-medium text-muted-foreground text-sm shadow-sm"
+                >
+                  {index + 1}
+                </span>
+                <CardHeader>
+                  <span
+                    className={cn(
+                      "mb-2 flex h-11 w-11 items-center justify-center rounded-lg",
+                      "bg-muted text-foreground",
+                    )}
+                  >
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <CardTitle className="text-lg">{step.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="text-pretty leading-relaxed">
+                    {step.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new "How it works" section to the marketing landing page
(apps/web) to help visitors quickly understand the OpenStatus workflow.

## What changed
- Created apps/web/src/components/marketing/how-it-works.tsx
- Imported and placed the section in apps/web/src/app/(marketing)/page.tsx
  between the Hero section and the Features section

## Type of change
- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring

## Details
The section includes 3 steps:
1. Add your monitors
2. Get notified instantly
3. Share your status page

Built using the existing stack: Next.js + Tailwind CSS + shadcn/ui + lucide-react.
Fully responsive and dark/light mode compatible.

## Screenshots
<img width="1090" height="919" alt="image" src="https://github.com/user-attachments/assets/0441fe87-c7dd-4514-b05a-a75409655f46" />

## Checklist
- [x] Follows existing coding conventions and style guide
- [x] Uses existing shadcn/ui components
- [x] Dark/light mode compatible
- [x] Mobile responsive
- [x] No new dependencies added

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

