### PR TITLE
refactor(ui): update landing page section layout, spacing, and typography

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -102,25 +102,25 @@ export function HowItWorks() {
                 )}
 
                 {/* Card */}
-                <div className="relative flex w-full flex-col items-center rounded-lg border border-border bg-background p-4 shadow-xs transition-shadow hover:shadow-sm">
+                <div className="relative flex w-full flex-col items-center gap-1 rounded-lg border border-border bg-background p-4 shadow-xs transition-shadow hover:shadow-sm">
                   {/* Numbered badge */}
                   <span
                     aria-hidden="true"
-                    className="absolute right-2.5 top-2.5 flex h-4 w-4 items-center justify-center rounded-full bg-muted text-[9px] font-semibold tabular-nums text-muted-foreground"
+                    className="absolute right-2.5 top-2.5 flex h-4 w-4 items-center justify-center rounded-full bg-muted font-mono text-[9px] font-semibold tabular-nums text-muted-foreground"
                   >
                     {step.number}
                   </span>
 
                   {/* Icon */}
-                  <div className="mb-2.5 flex h-10 w-10 items-center justify-center rounded-full border border-border bg-muted">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-muted">
                     <Icon className="h-4 w-4 text-foreground" aria-hidden="true" />
                   </div>
 
                   {/* Text */}
-                  <h3 className="mb-1 text-sm font-semibold text-foreground">
+                  <h3 className="font-mono text-sm font-semibold text-foreground">
                     {step.title}
                   </h3>
-                  <p className="text-xs leading-relaxed text-muted-foreground">
+                  <p className="font-sans text-xs leading-relaxed text-muted-foreground">
                     {step.description}
                   </p>
                 </div>

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -36,17 +36,17 @@ export function HowItWorks() {
   return (
     <section
       aria-labelledby="how-it-works-heading"
-      className="not-prose -mx-4 my-0 bg-muted/40 px-4 py-6 sm:py-8"
+      className="not-prose -mx-4 my-0 bg-muted/40 px-4 py-5 sm:py-6"
     >
       {/* Section header */}
-      <div className="mb-6 text-center sm:mb-8">
+      <div className="mb-4 text-center">
         <h2
           id="how-it-works-heading"
           className="font-mono text-balance text-xl font-semibold tracking-tight text-foreground sm:text-2xl"
         >
           How it works
         </h2>
-        <p className="mt-1.5 font-sans text-balance text-sm text-muted-foreground">
+        <p className="mt-1 font-sans text-balance text-sm text-muted-foreground">
           Get up and running in minutes — no configuration overhead.
         </p>
       </div>
@@ -102,7 +102,7 @@ export function HowItWorks() {
                 )}
 
                 {/* Card */}
-                <div className="relative flex h-full w-full flex-col items-center gap-1 rounded-lg border border-border bg-background p-4 shadow-xs transition-shadow hover:shadow-sm">
+                <div className="relative flex h-full w-full flex-col items-center justify-between rounded-lg border border-border bg-background p-5 shadow-xs transition-shadow hover:shadow-sm">
                   {/* Numbered badge */}
                   <span
                     aria-hidden="true"
@@ -111,16 +111,18 @@ export function HowItWorks() {
                     {step.number}
                   </span>
 
-                  {/* Icon */}
-                  <div className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-muted">
-                    <Icon className="h-4 w-4 text-foreground" aria-hidden="true" />
+                  {/* Top: icon + title tightly grouped */}
+                  <div className="flex flex-col items-center gap-1.5">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-muted">
+                      <Icon className="h-4 w-4 text-foreground" aria-hidden="true" />
+                    </div>
+                    <h3 className="font-mono text-sm font-semibold text-foreground">
+                      {step.title}
+                    </h3>
                   </div>
 
-                  {/* Text */}
-                  <h3 className="font-mono text-sm font-semibold text-foreground">
-                    {step.title}
-                  </h3>
-                  <p className="font-sans text-xs leading-relaxed text-muted-foreground">
+                  {/* Bottom: description anchored below */}
+                  <p className="mt-2 font-sans text-xs leading-relaxed text-muted-foreground">
                     {step.description}
                   </p>
                 </div>

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -36,17 +36,17 @@ export function HowItWorks() {
   return (
     <section
       aria-labelledby="how-it-works-heading"
-      className="not-prose -mx-4 my-6 bg-muted/40 px-4 py-8 font-sans sm:py-10"
+      className="not-prose -mx-4 my-0 bg-muted/40 px-4 py-6 sm:py-8"
     >
       {/* Section header */}
       <div className="mb-6 text-center sm:mb-8">
         <h2
           id="how-it-works-heading"
-          className="text-balance text-xl font-semibold tracking-tight text-foreground sm:text-2xl"
+          className="font-mono text-balance text-xl font-semibold tracking-tight text-foreground sm:text-2xl"
         >
           How it works
         </h2>
-        <p className="mt-2 text-balance text-sm text-muted-foreground">
+        <p className="mt-1.5 font-sans text-balance text-sm text-muted-foreground">
           Get up and running in minutes — no configuration overhead.
         </p>
       </div>
@@ -82,7 +82,7 @@ export function HowItWorks() {
             return (
               <li
                 key={step.number}
-                className="relative flex flex-col items-center text-center"
+                className="relative flex flex-col items-stretch text-center"
               >
                 {/* Mobile step connector */}
                 {step.number < steps.length && (
@@ -102,7 +102,7 @@ export function HowItWorks() {
                 )}
 
                 {/* Card */}
-                <div className="relative flex w-full flex-col items-center gap-1 rounded-lg border border-border bg-background p-4 shadow-xs transition-shadow hover:shadow-sm">
+                <div className="relative flex h-full w-full flex-col items-center gap-1 rounded-lg border border-border bg-background p-4 shadow-xs transition-shadow hover:shadow-sm">
                   {/* Numbered badge */}
                   <span
                     aria-hidden="true"

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -36,17 +36,17 @@ export function HowItWorks() {
   return (
     <section
       aria-labelledby="how-it-works-heading"
-      className="not-prose -mx-4 my-8 bg-muted/40 px-4 py-12 sm:py-16"
+      className="not-prose -mx-4 my-6 bg-muted/40 px-4 py-8 font-sans sm:py-10"
     >
       {/* Section header */}
-      <div className="mb-10 text-center sm:mb-12">
+      <div className="mb-6 text-center sm:mb-8">
         <h2
           id="how-it-works-heading"
-          className="text-balance text-2xl font-semibold tracking-tight text-foreground sm:text-3xl"
+          className="text-balance text-xl font-semibold tracking-tight text-foreground sm:text-2xl"
         >
           How it works
         </h2>
-        <p className="mt-3 text-balance text-sm text-muted-foreground sm:text-base">
+        <p className="mt-2 text-balance text-sm text-muted-foreground">
           Get up and running in minutes — no configuration overhead.
         </p>
       </div>
@@ -56,7 +56,7 @@ export function HowItWorks() {
         {/* Desktop connector line */}
         <div
           aria-hidden="true"
-          className="absolute inset-x-0 top-8 hidden items-center px-[calc(16.67%+1rem)] md:flex"
+          className="absolute inset-x-0 top-7 hidden items-center px-[calc(16.67%+1rem)] md:flex"
         >
           <div className="h-px flex-1 border-t border-dashed border-border" />
           <svg
@@ -76,7 +76,7 @@ export function HowItWorks() {
           </svg>
         </div>
 
-        <ol className="relative grid gap-4 md:grid-cols-3 md:gap-6">
+        <ol className="relative grid gap-3 md:grid-cols-3 md:gap-4">
           {steps.map((step) => {
             const Icon = step.icon;
             return (
@@ -90,9 +90,9 @@ export function HowItWorks() {
                     aria-hidden="true"
                     className="absolute left-1/2 top-full mt-0 flex -translate-x-1/2 flex-col items-center py-1 md:hidden"
                   >
-                    <div className="h-4 w-px border-l border-dashed border-border" />
+                    <div className="h-3 w-px border-l border-dashed border-border" />
                     <svg
-                      className="h-2.5 w-2.5 text-muted-foreground"
+                      className="h-2 w-2 text-muted-foreground"
                       viewBox="0 0 12 12"
                       fill="none"
                     >
@@ -102,22 +102,22 @@ export function HowItWorks() {
                 )}
 
                 {/* Card */}
-                <div className="relative flex w-full flex-col items-center rounded-lg border border-border bg-background p-6 shadow-xs transition-shadow hover:shadow-sm">
+                <div className="relative flex w-full flex-col items-center rounded-lg border border-border bg-background p-4 shadow-xs transition-shadow hover:shadow-sm">
                   {/* Numbered badge */}
                   <span
                     aria-hidden="true"
-                    className="absolute right-3 top-3 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] font-semibold tabular-nums text-muted-foreground"
+                    className="absolute right-2.5 top-2.5 flex h-4 w-4 items-center justify-center rounded-full bg-muted text-[9px] font-semibold tabular-nums text-muted-foreground"
                   >
                     {step.number}
                   </span>
 
                   {/* Icon */}
-                  <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-border bg-muted">
-                    <Icon className="h-5 w-5 text-foreground" aria-hidden="true" />
+                  <div className="mb-2.5 flex h-10 w-10 items-center justify-center rounded-full border border-border bg-muted">
+                    <Icon className="h-4 w-4 text-foreground" aria-hidden="true" />
                   </div>
 
                   {/* Text */}
-                  <h3 className="mb-2 text-sm font-semibold text-foreground">
+                  <h3 className="mb-1 text-sm font-semibold text-foreground">
                     {step.title}
                   </h3>
                   <p className="text-xs leading-relaxed text-muted-foreground">

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -1,0 +1,134 @@
+import { Bell, Globe, Monitor } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface Step {
+  number: number;
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+const steps: Step[] = [
+  {
+    number: 1,
+    icon: Monitor,
+    title: "Add your monitors",
+    description:
+      "Connect your websites and APIs in seconds. Set your check frequency and regions.",
+  },
+  {
+    number: 2,
+    icon: Bell,
+    title: "Get notified instantly",
+    description:
+      "Receive alerts via email, Slack, or SMS the moment downtime is detected.",
+  },
+  {
+    number: 3,
+    icon: Globe,
+    title: "Share your status",
+    description:
+      "Publish a beautiful public status page to keep your users informed.",
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section
+      aria-labelledby="how-it-works-heading"
+      className="not-prose -mx-4 my-8 bg-muted/40 px-4 py-12 sm:py-16"
+    >
+      {/* Section header */}
+      <div className="mb-10 text-center sm:mb-12">
+        <h2
+          id="how-it-works-heading"
+          className="text-balance text-2xl font-semibold tracking-tight text-foreground sm:text-3xl"
+        >
+          How it works
+        </h2>
+        <p className="mt-3 text-balance text-sm text-muted-foreground sm:text-base">
+          Get up and running in minutes — no configuration overhead.
+        </p>
+      </div>
+
+      {/* Steps grid */}
+      <div className="relative mx-auto max-w-3xl">
+        {/* Desktop connector line */}
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-0 top-8 hidden items-center px-[calc(16.67%+1rem)] md:flex"
+        >
+          <div className="h-px flex-1 border-t border-dashed border-border" />
+          <svg
+            className="mx-1 h-3 w-3 shrink-0 text-muted-foreground"
+            viewBox="0 0 12 12"
+            fill="currentColor"
+          >
+            <path d="M6.5 1.5 11 6l-4.5 4.5M1 6h10" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <div className="h-px flex-1 border-t border-dashed border-border" />
+          <svg
+            className="mx-1 h-3 w-3 shrink-0 text-muted-foreground"
+            viewBox="0 0 12 12"
+            fill="currentColor"
+          >
+            <path d="M6.5 1.5 11 6l-4.5 4.5M1 6h10" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </div>
+
+        <ol className="relative grid gap-4 md:grid-cols-3 md:gap-6">
+          {steps.map((step) => {
+            const Icon = step.icon;
+            return (
+              <li
+                key={step.number}
+                className="relative flex flex-col items-center text-center"
+              >
+                {/* Mobile step connector */}
+                {step.number < steps.length && (
+                  <div
+                    aria-hidden="true"
+                    className="absolute left-1/2 top-full mt-0 flex -translate-x-1/2 flex-col items-center py-1 md:hidden"
+                  >
+                    <div className="h-4 w-px border-l border-dashed border-border" />
+                    <svg
+                      className="h-2.5 w-2.5 text-muted-foreground"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                    >
+                      <path d="M6 1v10M1 6.5l5 4.5 5-4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </div>
+                )}
+
+                {/* Card */}
+                <div className="relative flex w-full flex-col items-center rounded-lg border border-border bg-background p-6 shadow-xs transition-shadow hover:shadow-sm">
+                  {/* Numbered badge */}
+                  <span
+                    aria-hidden="true"
+                    className="absolute right-3 top-3 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] font-semibold tabular-nums text-muted-foreground"
+                  >
+                    {step.number}
+                  </span>
+
+                  {/* Icon */}
+                  <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-border bg-muted">
+                    <Icon className="h-5 w-5 text-foreground" aria-hidden="true" />
+                  </div>
+
+                  {/* Text */}
+                  <h3 className="mb-2 text-sm font-semibold text-foreground">
+                    {step.title}
+                  </h3>
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    {step.description}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/trusted-by.tsx
+++ b/apps/web/src/components/marketing/trusted-by.tsx
@@ -1,0 +1,35 @@
+const companies = [
+  { name: "Cal.com", href: "https://status.cal.com" },
+  { name: "Documenso", href: "https://status.documenso.com" },
+  { name: "WhiteBIT", href: "https://status.whitebit.com" },
+  { name: "Traefik", href: "/customers/traefik" },
+  { name: "OpenPanel", href: "https://status.openpanel.dev" },
+  { name: "Probo", href: "https://probostatus.com" },
+  { name: "Hanko", href: "https://status.hanko.io" },
+  { name: "Superwall", href: "https://status.superwall.com" },
+  { name: "StreamElements", href: "https://status.streamelements.com/" },
+  { name: "Smplrspace", href: "https://status.smplrspace.com" },
+  { name: "Passbolt", href: "https://passboltuptime.com" },
+  { name: "TwentyCRM", href: "/customers/twenty" },
+];
+
+export function TrustedBy() {
+  return (
+    <div className="not-prose -mx-4 px-4 pb-4 pt-6 text-center">
+      <p className="mb-4 font-mono text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Trusted by teams who ship transparency
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
+        {companies.map((company) => (
+          <a
+            key={company.name}
+            href={company.href}
+            className="font-sans text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {company.name}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/content/mdx-components/index.tsx
+++ b/apps/web/src/content/mdx-components/index.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import { HowItWorks } from "../../components/marketing/how-it-works";
 import { LatencyChartTable } from "../latency-chart-table";
 import { Aside } from "./aside";
 import { ButtonLink } from "./button-link";
@@ -45,4 +46,5 @@ export const components = {
   PricingTabs,
   Subtle,
   Suspense: Suspense,
+  HowItWorks,
 };

--- a/apps/web/src/content/mdx-components/index.tsx
+++ b/apps/web/src/content/mdx-components/index.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 
 import { HowItWorks } from "../../components/marketing/how-it-works";
+import { TrustedBy } from "../../components/marketing/trusted-by";
 import { LatencyChartTable } from "../latency-chart-table";
 import { Aside } from "./aside";
 import { ButtonLink } from "./button-link";
@@ -47,4 +48,5 @@ export const components = {
   Subtle,
   Suspense: Suspense,
   HowItWorks,
+  TrustedBy,
 };

--- a/apps/web/src/content/pages/home.mdx
+++ b/apps/web/src/content/pages/home.mdx
@@ -44,22 +44,7 @@ Free to start. Paid plans from $30/mo.
 
 <HowItWorks />
 
-## Trusted by teams who ship transparency
-
-<Grid cols={4}>
-  <a href="https://status.cal.com">Cal.com</a>
-  <a href="https://status.documenso.com">Documenso</a>
-  <a href="https://status.whitebit.com">WhiteBIT</a>
-  <a href="/customers/traefik">Traefik</a>
-  <a href="https://status.openpanel.dev">OpenPanel</a>
-  <a href="https://probostatus.com">Probo</a>
-  <a href="https://status.hanko.io">Hanko</a>
-  <a href="https://status.superwall.com">Superwall</a>
-  <a href="https://status.streamelements.com/">StreamElements</a>
-  <a href="https://status.smplrspace.com">Smplrspace</a>
-  <a href="https://passboltuptime.com">Passbolt</a>
-  <a href="/customers/twenty">TwentyCRM</a>
-</Grid>
+<TrustedBy />
 
 ## The status page that closes enterprise deals
 

--- a/apps/web/src/content/pages/home.mdx
+++ b/apps/web/src/content/pages/home.mdx
@@ -42,6 +42,8 @@ Free to start. Paid plans from $30/mo.
 
 <Image src="/assets/landing/statuspage-meow.png" alt="statuspage" priority />
 
+<HowItWorks />
+
 ## Trusted by teams who ship transparency
 
 <Grid cols={4}>


### PR DESCRIPTION
## 📝 Description
This PR refines the layout, vertical spacing, and typography for the landing page components to improve visual balance and consistency across screen sizes.

### 🔄 Summary of Changes
* **Card Component Layout (`card-step.tsx` / `how-it-works`):**
  * Updated card container to use `flex flex-col justify-between h-full` so all cards lock to uniform heights regardless of content length.
  * Grouped icons and titles in tight vertical flex layout (`gap-1.5`) with anchored descriptions to reduce internal padding anomalies.

* **Trusted By Section (`trusted-by.tsx`):**
  * Converted raw prose headings to a dedicated component.
  * Applied `font-mono text-xs uppercase tracking-wider text-muted-foreground` to demote section header visual weight.
  * Re-aligned logo wall to a inline flex layout (`flex flex-wrap gap-x-6 gap-y-2`) for better inline density.

* **Section Spacing & Hierarchy (`home.mdx`):**
  * Reduced vertical padding/margins between the hero header, card grid, and logo section to eliminate excess whitespace.
  * Updated typography styles across section headers to maintain consistent font rules.

---

## 🧪 How to Test
1. Run the app locally (`npm run dev` or `pnpm dev`).
2. Navigate to the landing page (`/`).
3. Verify that:
   - All three step cards match in height and align properly.
   - The spacing between landing sections feels tighter and balanced.
   - The "Trusted by" section renders cleanly inline without visual overflow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

