### PR TITLE
fix(docker): migrate lightweight db-migrate service to Deno

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -22,7 +22,7 @@ docker compose ps
 docker run --rm --network openstatus \
   -e DATABASE_URL=http://libsql:8080 \
   $(docker build -q -f apps/workflows/Dockerfile --target build .) \
-  sh -c "cd /app/packages/db && deno run -A src/seed.mts"
+  sh -c "cd /app/packages/db && deno run -A --sloppy-imports src/seed.mts"
 
 # 6. (Optional) Deploy Tinybird local - requires tb CLI
 cd packages/tinybird
@@ -122,7 +122,7 @@ After migrations complete, seed the database with sample data:
 docker run --rm --network openstatus \
   -e DATABASE_URL=http://libsql:8080 \
   $(docker build -q -f apps/workflows/Dockerfile --target build .) \
-  sh -c "cd /app/packages/db && deno run -A src/seed.mts"
+  sh -c "cd /app/packages/db && deno run -A --sloppy-imports src/seed.mts"
 ```
 
 This creates:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -22,7 +22,7 @@ docker compose ps
 docker run --rm --network openstatus \
   -e DATABASE_URL=http://libsql:8080 \
   $(docker build -q -f apps/workflows/Dockerfile --target build .) \
-  sh -c "cd /app/packages/db && bun src/seed.mts"
+  sh -c "cd /app/packages/db && deno run -A src/seed.mts"
 
 # 6. (Optional) Deploy Tinybird local - requires tb CLI
 cd packages/tinybird
@@ -106,7 +106,7 @@ If you need to re-run migrations or troubleshoot:
 
 ```bash
 # Run migrations using workflows container
-docker compose exec workflows sh -c "cd /app/packages/db && bun src/migrate.mts"
+docker compose exec workflows sh -c "cd /app/packages/db && deno run -A src/migrate.mts"
 
 # Or restart workflows to trigger migrations again
 docker compose restart workflows
@@ -122,7 +122,7 @@ After migrations complete, seed the database with sample data:
 docker run --rm --network openstatus \
   -e DATABASE_URL=http://libsql:8080 \
   $(docker build -q -f apps/workflows/Dockerfile --target build .) \
-  sh -c "cd /app/packages/db && bun src/seed.mts"
+  sh -c "cd /app/packages/db && deno run -A src/seed.mts"
 ```
 
 This creates:

--- a/docker-compose-lightweight.yaml
+++ b/docker-compose-lightweight.yaml
@@ -35,17 +35,18 @@ services:
 
     db-migrate:
         container_name: openstatus-db-migrate
-        image: oven/bun:1.3.6
+        build:
+            context: .
+            dockerfile: apps/workflows/Dockerfile
+            target: build
         networks:
             - openstatus
         working_dir: /app/packages/db
-        volumes:
-            - .:/app
         env_file:
             - .env.docker
         environment:
             - DATABASE_URL=http://libsql:8080
-        command: ["sh", "-c", "bun install && bun run migrate"]
+        command: ["deno", "run", "-A", "src/migrate.mts"]
         depends_on:
             libsql:
                 condition: service_healthy


### PR DESCRIPTION
## Summary

This updates the `db-migrate` service used by `docker-compose-lightweight.yaml` to use the Deno-based migration flow.

The lightweight compose setup includes a dedicated one-shot migration service that runs before the dashboard and status page start. During the Bun → Deno migration, this service was left using the old Bun image.

Instead of introducing a separate migration image, this reuses the existing `apps/workflows` build stage, which already provides the environment needed to run the Deno migration script.

## Changes

- replace the Bun-based `db-migrate` image with the existing Deno build stage
- run `src/migrate.mts` with Deno
- update the Docker documentation to reflect the new migration command

## Testing

Tested locally with a clean build:

```bash
docker compose -f docker-compose-lightweight.yaml up -d --build
```

Verified that:

- `db-migrate` completes successfully and exits with code `0`
- the database migrations are applied successfully
- `dashboard` and `status-page` start after the migration completes
- rerunning the migration is idempotent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

