### PR TITLE
test(services): cover redactSensitiveHeaders

### DIFF
--- a/packages/services/src/monitor/__tests__/response-logs-internal.test.ts
+++ b/packages/services/src/monitor/__tests__/response-logs-internal.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { redactSensitiveHeaders } from "../response-logs-internal";
+
+describe("redactSensitiveHeaders", () => {
+  it("returns an empty object for null", () => {
+    expect(redactSensitiveHeaders(null)).toEqual({});
+  });
+
+  it("redacts headers whose name is a known sensitive header", () => {
+    expect(
+      redactSensitiveHeaders({
+        authorization: "Bearer abc",
+        cookie: "sid=1",
+        "x-api-key": "k",
+      }),
+    ).toEqual({
+      authorization: "[redacted]",
+      cookie: "[redacted]",
+      "x-api-key": "[redacted]",
+    });
+  });
+
+  it("matches sensitive names case insensitively", () => {
+    expect(
+      redactSensitiveHeaders({ Authorization: "Bearer abc", COOKIE: "sid=1" }),
+    ).toEqual({ Authorization: "[redacted]", COOKIE: "[redacted]" });
+  });
+
+  it("redacts headers whose name contains a sensitive part", () => {
+    expect(
+      redactSensitiveHeaders({
+        "x-session-id": "s",
+        "refresh-token": "t",
+        "x-secret-value": "v",
+        "my-credential": "c",
+      }),
+    ).toEqual({
+      "x-session-id": "[redacted]",
+      "refresh-token": "[redacted]",
+      "x-secret-value": "[redacted]",
+      "my-credential": "[redacted]",
+    });
+  });
+
+  it("keeps non-sensitive headers and their values untouched", () => {
+    expect(
+      redactSensitiveHeaders({
+        "content-type": "application/json",
+        "user-agent": "curl/8",
+      }),
+    ).toEqual({
+      "content-type": "application/json",
+      "user-agent": "curl/8",
+    });
+  });
+});


### PR DESCRIPTION
The header redactor used before response logs are stored had no tests, so I added them.

`redactSensitiveHeaders` covers:

* `null` input returns an empty object;
* headers matched by an exact sensitive name (authorization, cookie, x-api-key) are replaced with the redacted marker;
* the name match is case insensitive;
* headers whose name contains a sensitive part (session, token, secret, credential) are also redacted;
* non-sensitive headers keep their original values.

Pure function, no database needed.

```
cd packages/services
deno test --no-check --sloppy-imports -A src/monitor/__tests__/response-logs-internal.test.ts
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

