### PR TITLE
fix(docker): run database migrations automatically in docker-compose

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -11,7 +11,7 @@ cp .env.docker.example .env.docker
 # 2. Configure required variables (see Configuration section)
 vim .env.docker
 
-# 3. Build and start services (migrations will run automatically)
+# 3. Build and start services (database migrations run automatically)
 export DOCKER_BUILDKIT=1
 docker compose up -d
 
@@ -87,29 +87,26 @@ docker builder prune
 
 ### Automatic Migrations
 
-Migrations run **automatically** when you start the stack with `docker compose up -d`.
+Database migrations run **automatically** when you start the stack with
+`docker compose up -d`. A dedicated one-shot `db-migrate` service handles them:
 
-**Verifying migrations:**
+- It waits for `libsql` to become healthy, then applies the migrations and exits.
+- Application services start only after `db-migrate` completes successfully.
+- Migrations are idempotent — already-applied migrations are skipped, so re-running is safe.
+
+**Verification:**
+
 ```bash
-# Check workflows logs for migration output
-docker compose logs workflows | grep -A 5 "Running database migrations"
+docker compose logs db-migrate
 
-# Should show:
-# openstatus-workflows  | Running database migrations...
-# openstatus-workflows  | Migrated successfully
-# openstatus-workflows  | Starting workflows service...
+# Running migrations
+# Migrated successfully
 ```
 
-**Manual migration:**
-
-If you need to re-run migrations or troubleshoot:
+**Manual re-run:**
 
 ```bash
-# Run migrations using workflows container
-docker compose exec workflows sh -c "cd /app/packages/db && deno run -A src/migrate.mts"
-
-# Or restart workflows to trigger migrations again
-docker compose restart workflows
+docker compose up db-migrate
 ```
 
 ### Seeding Test Data (Optional)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,29 @@ services:
             start_period: 10s
         restart: unless-stopped
 
+    # One-shot migrations. The workflows runtime image is distroless (compiled
+    # binary entrypoint, no shell/Deno/source), so it cannot migrate itself and
+    # start.sh is unused. This runs the migrator from the workflows build stage
+    # once, before the app services start. Mirrors docker-compose-lightweight.yaml.
+    db-migrate:
+        container_name: openstatus-db-migrate
+        build:
+            context: .
+            dockerfile: apps/workflows/Dockerfile
+            target: build
+        networks:
+            - openstatus
+        working_dir: /app/packages/db
+        env_file:
+            - .env.docker
+        environment:
+            - DATABASE_URL=http://libsql:8080
+        command: ["deno", "run", "-A", "src/migrate.mts"]
+        depends_on:
+            libsql:
+                condition: service_healthy
+        restart: "no"
+
     tinybird-local:
         container_name: openstatus-tinybird
         image: tinybirdco/tinybird-local:latest
@@ -72,6 +95,8 @@ services:
             - DATABASE_URL=http://libsql:8080
             - PORT=3000
         depends_on:
+            db-migrate:
+                condition: service_completed_successfully
             libsql:
                 condition: service_healthy
         healthcheck:


### PR DESCRIPTION
## Summary

This restores automatic database migrations for the standard Docker Compose setup.

## Problem

On a fresh self-hosted setup, `docker compose up -d` does not automatically run database migrations. The application services start before the database is initialized, requiring manual intervention.

## Solution

- Add a one-shot `db-migrate` service that reuses the workflows Dockerfile build stage.
- Wait for `libsql` to become healthy before running migrations.
- Start application services only after migrations complete successfully.
- Update `DOCKER.md` to document the new migration workflow.

## Verification

- Ran `docker compose down -v`
- Ran `docker compose up -d --build`
- Verified `db-migrate` completed successfully
- Verified application services started successfully after migrations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

