### PR TITLE
docs: document Neon AI Gateway endpoint

### DIFF
--- a/apps/web/src/content/pages/docs/guides/self-hosting-openstatus.mdx
+++ b/apps/web/src/content/pages/docs/guides/self-hosting-openstatus.mdx
@@ -183,7 +183,7 @@ openstatus ships an in-dashboard AI assistant. It is **off by default** when sel
 
 ### Option 1: OpenAI-compatible endpoint (bring your own model)
 
-Use any OpenAI-compatible API — [NVIDIA NIM](https://build.nvidia.com/), vLLM, Ollama, OpenRouter, LM Studio, or a private gateway. This is the recommended path for self-hosting: the model and key stay on your own infrastructure.
+Use any OpenAI-compatible API — [NVIDIA NIM](https://build.nvidia.com/), vLLM, Ollama, OpenRouter, [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview), LM Studio, or a private gateway. This is the recommended path for self-hosting: the model and key stay on your own infrastructure.
 
 ```env
 AI_BASE_URL=https://integrate.api.nvidia.com/v1
@@ -201,6 +201,16 @@ A fully local, keyless setup with Ollama:
 AI_BASE_URL=http://localhost:11434/v1
 AI_MODEL=llama3.1
 ```
+
+Each Neon branch has its own [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) host, so `AI_BASE_URL` is that host plus `/v1` and `AI_API_KEY` is a Neon credential with the `ai_gateway:invoke` scope:
+
+```env
+AI_BASE_URL=https://br-winter-pond-aptw82ef-api.ai.c-2.us-east-2.aws.neon.tech/v1
+AI_API_KEY=nt_live_xxxxx
+AI_MODEL=gpt-5-mini
+```
+
+Neon's own docs call these two values `NEON_AI_GATEWAY_BASE_URL` and `NEON_AI_GATEWAY_TOKEN`, and the base URL they show is the bare host, so add `/v1` when you copy it. Pick an `AI_MODEL` from the [Neon model catalog](https://neon.com/docs/ai-gateway/models) that lists `chat/completions` among its endpoints. AI Gateway is in beta, requires a paid Neon plan, and runs only in AWS US East (Ohio) (`aws-us-east-2`).
 
 ### Option 2: Vercel AI Gateway
 


### PR DESCRIPTION
## Summary

Self-hosters who already run a Neon project can point the AI assistant at it without setting up a separate model provider. The self-hosting guide now lists Neon AI Gateway among the OpenAI-compatible endpoints and shows a worked `.env` block next to the existing NVIDIA NIM and Ollama ones.

## Why this is docs only

`resolveChatModel` in `packages/ai/src/resolve-model.ts` already builds the self-host provider with `createOpenAICompatible({ baseURL, apiKey })` from `AI_BASE_URL`, `AI_API_KEY` and `AI_MODEL`, and its doc comment lists NVIDIA NIM, vLLM, Ollama and OpenRouter as examples of that path. Neon AI Gateway is reached the same way, so no code changes and the PR does not claim native Neon support.

## Sources for the added facts

* Each branch has its own gateway host, and the OpenAI-compatible base URL is that host plus `/v1`: <https://neon.com/docs/ai-gateway/chat-completions>
* The credential is a Neon token carrying the `ai_gateway:invoke` scope, and `NEON_AI_GATEWAY_BASE_URL` is the bare host: <https://neon.com/docs/ai-gateway/get-started>
* Beta, paid Neon plan, AWS US East (Ohio) (`aws-us-east-2`) only: <https://neon.com/docs/ai-gateway/overview>
* `gpt-5-mini` is in the catalog and serves `chat/completions`: <https://neon.com/docs/ai-gateway/models>

The example host is the one Neon's own quickstart uses. The bullet above the new block already states that `AI_MODEL` must support tool calling, so the added paragraph sends readers to the catalog instead of repeating it.

## Checks

Run locally:

* Compiled the whole page with `@mdx-js/mdx` and `remark-gfm`, matching the pipeline in `apps/web/src/content/mdx.tsx`. It compiles clean, code fences are balanced, and the frontmatter still parses through `gray-matter` with `category`, `title` and `description` intact.
* Both added links return 200.

Not run:

* `pnpm install` fails here because corepack cannot reach the registry through a TLS-inspecting proxy, so `pnpm check` and `pnpm format` were not executed. Neither covers this file in any case: `apps/web` defines no `check` script, and `oxfmt.config.ts` ignores `**/*.mdx`.
* No `next build` of `apps/web`. The change adds no file, heading or nav entry, so `validateDocsNav` is unaffected.

Happy to adjust the placement or trim the block if you would rather keep the provider list short.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

