### PR TITLE
fix: prevent input text from overlapping copy button in dark mode

### DIFF
--- a/packages/ui/src/components/blocks/status-updates.tsx
+++ b/packages/ui/src/components/blocks/status-updates.tsx
@@ -126,7 +126,7 @@ export function StatusUpdatesCopyInput({
             withToast: true,
           })
         }
-        className="absolute top-1/2 right-2 size-6 -translate-y-1/2"
+        className="absolute top-1/2 right-2 size-6 -translate-y-1/2 backdrop-blur-xs"
       >
         {isCopied ? <Check /> : <Copy />}
         <span className="sr-only">{labels.ariaCopyLink}</span>


### PR DESCRIPTION
Cause: The button's outline variant uses dark:bg-input/30
which resolves to a semi-transparent background in dark mode,
letting input text show through.

Fix: Add backdrop blur to the button.

| Before | After |
| -------- | -------- |
| <img width="393" height="199" alt="image" src="https://github.com/user-attachments/assets/253c9377-21fc-450f-8c7b-9f554b2278cb" /> | <img width="407" height="202" alt="image" src="https://github.com/user-attachments/assets/36cae600-d0e3-4f59-9f40-d7bf3701b673" /> |

Fixes: #2441 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

