### PR TITLE
fix(web): restore "Search..." label in docs cmdk trigger

### DIFF
--- a/apps/web/src/content/cmdk.tsx
+++ b/apps/web/src/content/cmdk.tsx
@@ -314,7 +314,7 @@ export function CmdK({
         onClick={() => setOpen(true)}
       >
         <span className="text-muted-foreground truncate">
-          SearchIcon<span className="text-xs">...</span>
+          Search<span className="text-xs">...</span>
         </span>
         <kbd className="bg-muted text-muted-foreground pointer-events-none ml-auto inline-flex h-5 items-center gap-1 border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none">
           <span className="text-xs">⌘</span>K
@@ -328,7 +328,7 @@ export function CmdK({
           }}
           className="top-[15%] translate-y-0 overflow-hidden rounded-none p-0 font-mono shadow-2xl lg:max-w-2xl xl:max-w-3xl"
         >
-          <DialogTitle className="sr-only">SearchIcon</DialogTitle>
+          <DialogTitle className="sr-only">Search</DialogTitle>
           <Command
             onKeyDown={(e) => {
               // e.key === "Escape" ||


### PR DESCRIPTION
The lucide -> nucleo icon migration renamed the `Search` import to
`SearchIcon` and the rename also hit two JSX text nodes, so the navbar
trigger rendered "SearchIcon..." and the sr-only dialog title read
"SearchIcon".

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016qwFLVY2k5DjXQw5phVsuV

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

