### PR TITLE
docs: add Neon AI Gateway configuration section

### DIFF
--- a/apps/web/src/content/pages/docs/guides/self-hosting-openstatus.mdx
+++ b/apps/web/src/content/pages/docs/guides/self-hosting-openstatus.mdx
@@ -263,7 +263,7 @@ openstatus ships an in-dashboard AI assistant. It is **off by default** when sel
 
 ### Option 1: OpenAI-compatible endpoint (bring your own model)
 
-Use any OpenAI-compatible API — [NVIDIA NIM](https://build.nvidia.com/), vLLM, Ollama, OpenRouter, [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview), LM Studio, or a private gateway. This is the recommended path for self-hosting: the model and key stay on your own infrastructure.
+Use any OpenAI-compatible API — [NVIDIA NIM](https://build.nvidia.com/), vLLM, Ollama, OpenRouter, Neon AI Gateway, LM Studio, or a private gateway. This is the recommended path for self-hosting: the model and key stay on your own infrastructure.
 
 ```env
 AI_BASE_URL=https://integrate.api.nvidia.com/v1
@@ -282,15 +282,19 @@ AI_BASE_URL=http://localhost:11434/v1
 AI_MODEL=llama3.1
 ```
 
-Each Neon branch has its own [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) host, so `AI_BASE_URL` is that host plus `/v1` and `AI_API_KEY` is a Neon credential with the `ai_gateway:invoke` scope:
+#### Example: Neon AI Gateway
+
+[Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) serves an OpenAI-compatible API, so it goes through the same three variables. Every Neon branch has its own gateway host, which the Neon console shows as `NEON_AI_GATEWAY_BASE_URL` next to a `NEON_AI_GATEWAY_TOKEN` credential. The host is bare, so add `/v1` when you copy it, and give the credential the `ai_gateway:invoke` scope.
 
 ```env
-AI_BASE_URL=https://br-winter-pond-aptw82ef-api.ai.c-2.us-east-2.aws.neon.tech/v1
-AI_API_KEY=nt_live_xxxxx
+AI_BASE_URL=<NEON_AI_GATEWAY_BASE_URL>/v1
+AI_API_KEY=<NEON_AI_GATEWAY_TOKEN>
 AI_MODEL=gpt-5-mini
 ```
 
-Neon's own docs call these two values `NEON_AI_GATEWAY_BASE_URL` and `NEON_AI_GATEWAY_TOKEN`, and the base URL they show is the bare host, so add `/v1` when you copy it. Pick an `AI_MODEL` from the [Neon model catalog](https://neon.com/docs/ai-gateway/models) that lists `chat/completions` among its endpoints. AI Gateway is in beta, requires a paid Neon plan, and runs only in AWS US East (Ohio) (`aws-us-east-2`).
+Any entry in the [Neon model catalog](https://neon.com/docs/ai-gateway/models) that lists `chat/completions` among its endpoints works as `AI_MODEL`, and the `gpt-5-mini` above is one example rather than a default. Pick a model that supports tool calling. Neon does not record that per model, so check the flag on [Models.dev](https://models.dev/providers/neon/) first. This path has not been validated through a complete assistant workflow, so exercise a real monitor or status-page change before you depend on it.
+
+<Aside type="note">AI Gateway is in beta, requires a paid Neon plan, and runs only in AWS US East (Ohio) (`aws-us-east-2`).</Aside>
 
 ### Option 2: Vercel AI Gateway
 


### PR DESCRIPTION
Follow-up to #2436, which documented the Neon AI Gateway as a loose paragraph at the end of the OpenAI-compatible section. This gives it its own `#### Example: Neon AI Gateway` subsection so it reads as one worked example rather than trailing prose.

### What changed

- **Dedicated subsection** instead of an unheaded paragraph. Neon is still listed in the provider sentence at the top of Option 1, just without the duplicate link now that the subsection carries it.
- **Placeholders instead of a sample host and key.** The example previously pasted a real-looking branch hostname and an `nt_live_…` token; it now uses `<NEON_AI_GATEWAY_BASE_URL>/v1` and `<NEON_AI_GATEWAY_TOKEN>`, which are the names the Neon console shows, so the `/v1` suffix rule is visible in the snippet itself.
- **`AI_MODEL` framed as an example, not a default.**
- **Tool-calling requirement called out.** Option 1 already says the model must support tool/function calling; Neon's catalog does not record that per model, so the text points at [Models.dev](https://models.dev/providers/neon/) for the flag and at the [Neon catalog](https://neon.com/docs/ai-gateway/models) for the `chat/completions` endpoint.
- **Beta/plan/region caveat moved into an `<Aside type="note">`**, matching how the rest of the docs render notes.

### Not native support

This is not a Neon integration. Neon AI Gateway serves an OpenAI-compatible API, so it goes through the existing `AI_BASE_URL` / `AI_API_KEY` / `AI_MODEL` variables with no code change. The section is an example of Option 1, nothing more.

### Validation

The docs page compiles through the repo's pipeline (`@mdx-js/mdx` with `remark-gfm`, matching `next-mdx-remote/rsc` in `src/content/mdx.tsx`), frontmatter parses, `Aside` resolves against the registered MDX components, heading hierarchy has no skipped levels, `git diff --check` is clean, and all three external links return 200.

**Caveat, stated in the page too:** this path has not been exercised through a complete openstatus assistant workflow. The gateway's OpenAI-compatible surface and the variable mapping are what's verified; end-to-end tool-calling against a real monitor or status-page change is not. The wording asks the reader to try a real change before depending on it rather than implying it is proven.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

