### PR TITLE
fix(private-location): change TCP status from 'active' to 'success'

### DIFF
--- a/apps/checker/pkg/job/otel_wiring_test.go
+++ b/apps/checker/pkg/job/otel_wiring_test.go
@@ -148,7 +148,7 @@ func TestTCPJob_RecordsOTelMetrics(t *testing.T) {
 
 	data, err := job.NewJobRunner().TCPJob(context.Background(), monitor, "test-region")
 	require.NoError(t, err)
-	assert.Equal(t, "active", data.RequestStatus)
+	assert.Equal(t, "success", data.RequestStatus)
 	otlp.requireMetric(t, "openstatus.status")
 }
 

--- a/apps/checker/pkg/job/tcp_job.go
+++ b/apps/checker/pkg/job/tcp_job.go
@@ -81,7 +81,7 @@ func (jobRunner) TCPJob(ctx context.Context, monitor *v1.TCPMonitor, region stri
 		latency := res.TCPDone - res.TCPStart
 		lastResult = checker.TCPResponse{Latency: latency, Timing: res}
 
-		var requestStatus = "active"
+		var requestStatus = "success"
 
 		if degradedAfter > 0 && latency > degradedAfter {
 			requestStatus = "degraded"

--- a/apps/checker/pkg/job/tcp_job_test.go
+++ b/apps/checker/pkg/job/tcp_job_test.go
@@ -19,8 +19,8 @@ func TestTCPJob_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if data.RequestStatus != "active" {
-		t.Errorf("expected RequestStatus 'active', got '%s'", data.RequestStatus)
+	if data.RequestStatus != "success" {
+		t.Errorf("expected RequestStatus 'success', got '%s'", data.RequestStatus)
 	}
 	if data.Error != 0 {
 		t.Errorf("expected Error 0, got %d", data.Error)


### PR DESCRIPTION
TCP monitors were reporting status as 'active' which the dashboard doesn't recognize, causing display issues and preventing logs from loading. Changed to 'success' to match HTTP monitors and ensure proper dashboard integration.

Resolves https://github.com/openstatusHQ/openstatus/issues/2454

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

