### PR TITLE
fix: add WORKFLOWS_URL to private-location in github-packages compose

### DIFF
--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -144,6 +144,7 @@ services:
         environment:
             - DB_URL=http://libsql:8080
             - TINYBIRD_URL=http://tinybird-local:7181
+            - WORKFLOWS_URL=http://workflows:3000
             - GIN_MODE=release
             - PORT=8080
         depends_on:


### PR DESCRIPTION
Adds WORKFLOWS_URL=http://workflows:3000 to the private-location service environment in docker-compose.github-packages.yaml to match the configuration in docker-compose.yaml.

This fixes 401 unauthorized errors appearing in dashboard logs when using GitHub packages deployment.

Resolves https://github.com/openstatusHQ/openstatus/issues/2453

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

