### PR TITLE
fix: ensure HTTP failures are properly reported and ingested

### DIFF
--- a/apps/checker/checker/http.go
+++ b/apps/checker/checker/http.go
@@ -122,20 +122,25 @@ func Http(ctx context.Context, client *http.Client, inputData request.HttpChecke
 	latency := time.Since(start).Milliseconds()
 
 	if err != nil {
+		errorMsg := err.Error()
 
 		var urlErr *url.Error
 		if errors.As(err, &urlErr) && urlErr.Timeout() {
-			return Response{
-				Latency:   latency,
-				Timing:    timing,
-				Timestamp: start.UTC().UnixMilli(),
-				Error:     fmt.Sprintf("Timeout after %d ms", latency),
-			}, nil
+			errorMsg = fmt.Sprintf("Timeout after %d ms", latency)
 		}
 
 		logger.Error().Err(err).Msg("error while pinging")
 
-		return Response{}, err
+		// Return Response with error field instead of returning a Go error
+		// This ensures all failures (timeouts, connection refused, DNS failures, etc.)
+		// are properly ingested and displayed in the dashboard
+		return Response{
+			Latency:   latency,
+			Timing:    timing,
+			Timestamp: start.UTC().UnixMilli(),
+			Error:     errorMsg,
+			Status:    0,
+		}, nil
 	}
 
 	defer response.Body.Close()

--- a/apps/checker/checker/http_test.go
+++ b/apps/checker/checker/http_test.go
@@ -73,7 +73,7 @@ func Test_ping(t *testing.T) {
 			want: checker.Response{Status: 500, Body: "OK"}, wantErr: false},
 
 		{name: "Wrong url should return an error", args: args{client: &http.Client{}, inputData: request.HttpCheckerRequest{URL: "https://somethingthatwillfail.ed", CronTimestamp: 1}},
-			want: checker.Response{Status: 0}, wantErr: true},
+			want: checker.Response{Status: 0}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -90,6 +90,11 @@ func Test_ping(t *testing.T) {
 
 			if got.Body != tt.want.Body {
 				t.Errorf("Ping() = %v, want %v", got, tt.want)
+			}
+
+			// For the error test case, verify Response.Error is populated
+			if tt.name == "Wrong url should return an error" && got.Error == "" {
+				t.Errorf("Expected Response.Error to be populated for transport failure")
 			}
 		})
 	}

--- a/apps/checker/handlers/checker.go
+++ b/apps/checker/handlers/checker.go
@@ -167,6 +167,7 @@ func (h Handler) HTTPCheckerHandler(c *gin.Context) {
 			Body:          string(res.Body),
 			Trigger:       trigger,
 			RequestStatus: requestStatus,
+			Message:       res.Error,
 		}
 
 		var isSuccessfull bool = true
@@ -332,6 +333,12 @@ func (h Handler) HTTPCheckerHandler(c *gin.Context) {
 }
 
 func EvaluateHTTPAssertions(raw []json.RawMessage, data PingData, res checker.Response) (bool, error) {
+	// If there's a transport error, always fail regardless of assertions
+	// This prevents false positives where empty responses might satisfy assertions
+	if res.Error != "" {
+		return false, nil
+	}
+
 	statusCode := statusCode(res.Status)
 	if len(raw) == 0 {
 		return statusCode.IsSuccessful(), nil

--- a/apps/checker/handlers/ping.go
+++ b/apps/checker/handlers/ping.go
@@ -112,11 +112,6 @@ func (h Handler) PingRegionHandler(c *gin.Context) {
 			return fmt.Errorf("unable to ping: %w", err)
 		}
 
-		// Check for transport failures which are now in Response.Error
-		if r.Error != "" {
-			return fmt.Errorf("unable to ping: %s", r.Error)
-		}
-
 		timingAsString, err := json.Marshal(r.Timing)
 		if err != nil {
 			return fmt.Errorf("error while parsing timing data %s: %w", req.URL, err)

--- a/apps/checker/handlers/ping.go
+++ b/apps/checker/handlers/ping.go
@@ -112,6 +112,11 @@ func (h Handler) PingRegionHandler(c *gin.Context) {
 			return fmt.Errorf("unable to ping: %w", err)
 		}
 
+		// Check for transport failures which are now in Response.Error
+		if r.Error != "" {
+			return fmt.Errorf("unable to ping: %s", r.Error)
+		}
+
 		timingAsString, err := json.Marshal(r.Timing)
 		if err != nil {
 			return fmt.Errorf("error while parsing timing data %s: %w", req.URL, err)

--- a/apps/checker/pkg/job/http_job_test.go
+++ b/apps/checker/pkg/job/http_job_test.go
@@ -47,11 +47,14 @@ func TestHTTPJob_Failure(t *testing.T) {
 	}
 
 	data, err := job.NewJobRunner().HTTPJob(context.Background(), monitor, "test-region")
-	if err == nil {
-		t.Fatalf("expected error, got nil")
+	if err != nil {
+		t.Fatalf("expected no Go error, got %v", err)
 	}
-	if data != nil {
-		t.Errorf("expected data to be nil on error, got %+v", data)
+	if data == nil {
+		t.Fatalf("expected data to be populated, got nil")
+	}
+	if data.Message == "" {
+		t.Errorf("expected error message to be populated for transport failure")
 	}
 }
 

--- a/apps/checker/pkg/job/otel_wiring_test.go
+++ b/apps/checker/pkg/job/otel_wiring_test.go
@@ -115,8 +115,9 @@ func TestHTTPJob_RecordsOTelOnFailure(t *testing.T) {
 		OtelConfig: &v1.OtelConfig{Endpoint: otlp.server.URL},
 	}
 
-	_, err := job.NewJobRunner().HTTPJob(context.Background(), monitor, "test-region")
-	require.Error(t, err)
+	data, err := job.NewJobRunner().HTTPJob(context.Background(), monitor, "test-region")
+	require.NoError(t, err)
+	require.NotEmpty(t, data.Message, "Expected error message to be populated for transport failure")
 	otlp.requireMetric(t, "openstatus.error")
 }
 


### PR DESCRIPTION
When HTTP requests fail (connection refused, DNS failures, etc.), the checker now returns a Response with error details instead of returning a Go error. This prevents the probe from stopping status reporting when services go down.

Previously, returning 'Response{}, err' would cause the task to fail and stop scheduling. Now all failures are properly ingested and displayed in the dashboard.

Resolves https://github.com/openstatusHQ/openstatus/issues/2452

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

