### PR TITLE
fix: add ErrFunc to TCP monitor tasks to prevent indefinite hangs

### DIFF
--- a/apps/checker/pkg/scheduler/scheduler.go
+++ b/apps/checker/pkg/scheduler/scheduler.go
@@ -147,6 +147,9 @@ func (mm *MonitorManager) UpdateMonitors(ctx context.Context) {
 			RunOnce:  false,
 			// StartAfter: time.Now().Add(5 * time.Millisecond),
 			RunSingleInstance: true,
+			ErrFunc: func(e error) {
+				log.Printf("An error occurred when executing TCP task  %s", e)
+			},
 			FuncWithTaskContext: func(ctx tasks.TaskContext) error {
 
 				monitor := m


### PR DESCRIPTION
TCP monitor tasks were missing an error handler (ErrFunc), causing them to stop scheduling entirely when encountering errors like unreachable endpoints or connection timeouts. This meant the probe would hang indefinitely and never report status again.

This fix adds ErrFunc to TCP tasks matching the HTTP task pattern, allowing errors to be logged while the task continues scheduling normally.

Resolves https://github.com/openstatusHQ/openstatus/issues/2459

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

