### PR TITLE
fix: respect status code assertions instead of defaulting to 2xx check

### DIFF
--- a/apps/checker/pkg/job/http_job.go
+++ b/apps/checker/pkg/job/http_job.go
@@ -154,7 +154,14 @@ func (jr jobRunner) HTTPJob(ctx context.Context, monitor *v1.HTTPMonitor, region
 		}
 
 		status := statusCode(res.Status)
+		// Only use default 2xx check if no status assertions exist
+		// If status assertions are configured, let them determine success
+		hasStatusAssertions := len(monitor.StatusCodeAssertions) > 0
 		isSuccessful := status.IsSuccessful()
+		if hasStatusAssertions {
+			isSuccessful = true // Start with true, assertions will override
+		}
+
 		if len(monitor.HeaderAssertions) > 0 {
 			headersAsString, err := json.Marshal(res.Headers)
 			if err != nil {


### PR DESCRIPTION
When status assertions are configured, the monitor should respect the configured status codes rather than defaulting to 2xx success check.

Previously, isSuccessful was initialized based on whether status was 2xx, then AND-ed with assertion results. This meant a 404 with an assertion expecting 404 would still be marked as down (false && true = false).

Now when status assertions exist, isSuccessful starts as true and assertions fully control the success determination.

Resolves https://github.com/openstatusHQ/openstatus/issues/2461

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

