### PR TITLE
fix: configure TINYBIRD_URL for audit logs in workflows and server

### DIFF
--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -7,6 +7,7 @@ export const env = createEnv({
     UNKEY_API_ID: z.string().min(1),
     UNKEY_TOKEN: z.string().min(1),
     TINY_BIRD_API_KEY: z.string().min(1),
+    TINYBIRD_URL: z.string().default("https://api.tinybird.co"),
     UPSTASH_REDIS_REST_URL: z.string().min(1),
     UPSTASH_REDIS_REST_TOKEN: z.string().min(1),
     FLY_REGION: z.enum(monitorRegions),

--- a/apps/server/src/utils/audit-log.ts
+++ b/apps/server/src/utils/audit-log.ts
@@ -2,7 +2,7 @@ import { AuditLog, Tinybird } from "@openstatus/tinybird";
 
 import { env } from "@/env";
 
-const tb = new Tinybird({ 
+const tb = new Tinybird({
   token: env.TINY_BIRD_API_KEY,
   baseUrl: env.TINYBIRD_URL,
 });

--- a/apps/server/src/utils/audit-log.ts
+++ b/apps/server/src/utils/audit-log.ts
@@ -2,6 +2,9 @@ import { AuditLog, Tinybird } from "@openstatus/tinybird";
 
 import { env } from "@/env";
 
-const tb = new Tinybird({ token: env.TINY_BIRD_API_KEY });
+const tb = new Tinybird({ 
+  token: env.TINY_BIRD_API_KEY,
+  baseUrl: env.TINYBIRD_URL,
+});
 
 export const checkerAudit = new AuditLog({ tb });

--- a/apps/workflows/src/env.ts
+++ b/apps/workflows/src/env.ts
@@ -15,6 +15,7 @@ export const env = () =>
       DATABASE_AUTH_TOKEN: z.string().prefault(""),
       RESEND_API_KEY: z.string().prefault(""),
       TINY_BIRD_API_KEY: z.string().prefault(""),
+      TINYBIRD_URL: z.string().prefault("https://api.tinybird.co"),
       QSTASH_TOKEN: z.string().prefault(""),
       SCREENSHOT_SERVICE_URL: z.string().prefault(""),
       TWILLIO_AUTH_TOKEN: z.string().prefault(""),

--- a/apps/workflows/src/utils/audit-log.ts
+++ b/apps/workflows/src/utils/audit-log.ts
@@ -2,7 +2,7 @@ import { AuditLog, Tinybird } from "@openstatus/tinybird";
 
 import { env } from "../env";
 
-const tb = new Tinybird({ 
+const tb = new Tinybird({
   token: env().TINY_BIRD_API_KEY,
   baseUrl: env().TINYBIRD_URL,
 });

--- a/apps/workflows/src/utils/audit-log.ts
+++ b/apps/workflows/src/utils/audit-log.ts
@@ -2,6 +2,9 @@ import { AuditLog, Tinybird } from "@openstatus/tinybird";
 
 import { env } from "../env";
 
-const tb = new Tinybird({ token: env().TINY_BIRD_API_KEY });
+const tb = new Tinybird({ 
+  token: env().TINY_BIRD_API_KEY,
+  baseUrl: env().TINYBIRD_URL,
+});
 
 export const checkerAudit = new AuditLog({ tb });


### PR DESCRIPTION
Workflows (and server) was using Tinybird client without specifying baseUrl, causing it to default to production Tinybird API instead of using the configured TINYBIRD_URL (e.g., tinybird-local for development).

This caused 'Unable to ingest to audit_log__v0: Unauthorized' errors because the local token was being sent to production Tinybird.

Changes:
- Added TINYBIRD_URL to env.ts schema (defaults to production API)
- Updated audit-log.ts to pass baseUrl to Tinybird constructor

This fixes notifications for private-location monitors by enabling audit log ingestion, which is required for status updates to succeed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

