### PR TITLE
Reapply "small prefetch"

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/chat/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/chat/layout.tsx
@@ -11,7 +11,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
@@ -23,8 +23,7 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   // Prefetch the conversation list so the right sidebar paints immediately.
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.chatSession.list.queryOptions());
+  prefetch(trpc.chatSession.list.queryOptions());
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/invite/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/invite/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import type { SearchParams } from "nuqs";
 
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
@@ -15,8 +15,7 @@ export default async function InvitePage(props: {
     return redirect("/overview");
   }
 
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.invitation.get.queryOptions({ token }));
+  prefetch(trpc.invitation.get.queryOptions({ token }));
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -12,7 +12,7 @@ import {
   LEFT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 export default async function Layout({
   children,
@@ -44,14 +44,13 @@ export default async function Layout({
   );
 }
 
-async function HydrateSidebar({ children }: { children: React.ReactNode }) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
-    queryClient.prefetchQuery(trpc.workspace.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.user.get.queryOptions()),
+function HydrateSidebar({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.page.list.queryOptions(),
+    trpc.monitor.list.queryOptions(),
+    trpc.workspace.get.queryOptions(),
+    trpc.workspace.list.queryOptions(),
+    trpc.user.get.queryOptions(),
   ]);
 
   return <HydrateClient>{children}</HydrateClient>;

--- a/apps/dashboard/src/app/(dashboard)/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/content/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/apps/dashboard/src/app/(dashboard)/monitors/(list)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/(list)/page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "nuqs";
 
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
@@ -10,13 +10,11 @@ export default async function Page({
 }: {
   searchParams: Promise<SearchParams>;
 }) {
-  const queryClient = getQueryClient();
-
-  await Promise.all([
-    searchParamsCache.parse(searchParams),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions()),
+  batchPrefetch([
+    trpc.monitor.list.queryOptions(),
+    trpc.monitorTag.list.queryOptions(),
   ]);
+  await searchParamsCache.parse(searchParams);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/edit/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/edit/layout.tsx
@@ -1,14 +1,9 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.monitorTag.list.queryOptions(),
+    trpc.privateLocation.list.queryOptions(),
   ]);
 
   return <HydrateClient>{children}</HydrateClient>;

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/incidents/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/incidents/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { getQueryClient, trpc } from "@/lib/trpc/server";
+import { prefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -15,11 +15,8 @@ export default async function Layout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const queryClient = getQueryClient();
   const { id } = await params;
-  await queryClient.prefetchQuery(
-    trpc.incident.list.queryOptions({ monitorId: Number.parseInt(id) }),
-  );
+  prefetch(trpc.incident.list.queryOptions({ monitorId: Number.parseInt(id) }));
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/layout.tsx
@@ -6,8 +6,8 @@ import {
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
 import {
   HydrateClient,
+  batchPrefetch,
   fetchQueryOrNotFound,
-  getQueryClient,
   trpc,
 } from "@/lib/trpc/server";
 
@@ -23,15 +23,14 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
+  batchPrefetch([
+    trpc.notification.list.queryOptions(),
+    trpc.privateLocation.list.queryOptions(),
+  ]);
   await fetchQueryOrNotFound(
     trpc.monitor.get.queryOptions({ id: Number.parseInt(id) }),
   );
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.notification.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
-  ]);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/monitors/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/loading.tsx
@@ -1,0 +1,6 @@
+import { PageSkeleton } from "@/components/content/page-skeleton";
+
+// Sits above `[id]/layout.tsx`, whose `fetchQueryOrNotFound` gate suspends.
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/apps/dashboard/src/app/(dashboard)/notifications/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/notifications/layout.tsx
@@ -4,18 +4,13 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.notification.list.queryOptions());
+export default function Layout({ children }: { children: React.ReactNode }) {
+  prefetch(trpc.notification.list.queryOptions());
   return (
     <HydrateClient>
       <AppHeader>

--- a/apps/dashboard/src/app/(dashboard)/overview/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/overview/layout.tsx
@@ -4,25 +4,19 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-
+export default function Layout({ children }: { children: React.ReactNode }) {
   // inputs must match page.tsx's queries exactly — a differing input misses the cache
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.incident.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.statusReport.list.queryOptions({})),
-    queryClient.prefetchQuery(trpc.maintenance.list.queryOptions()),
+  batchPrefetch([
+    trpc.monitor.list.queryOptions(),
+    trpc.page.list.queryOptions(),
+    trpc.incident.list.queryOptions(),
+    trpc.statusReport.list.queryOptions({}),
+    trpc.maintenance.list.queryOptions(),
   ]);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/settings/account/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/account/layout.tsx
@@ -4,19 +4,14 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.member.list.queryOptions());
+export default function Layout({ children }: { children: React.ReactNode }) {
+  prefetch(trpc.member.list.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/settings/audit-logs/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/audit-logs/layout.tsx
@@ -4,19 +4,14 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.auditLog.list.queryOptions({}));
+export default function Layout({ children }: { children: React.ReactNode }) {
+  prefetch(trpc.auditLog.list.queryOptions({}));
   return (
     <HydrateClient>
       <div>

--- a/apps/dashboard/src/app/(dashboard)/settings/general/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/general/layout.tsx
@@ -4,22 +4,17 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.member.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.invitation.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.apiKey.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.member.list.queryOptions(),
+    trpc.invitation.list.queryOptions(),
+    trpc.apiKey.list.queryOptions(),
   ]);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/settings/integrations/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/integrations/layout.tsx
@@ -4,21 +4,16 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.integrationRouter.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.integrationRouter.list.queryOptions(),
+    trpc.workspace.get.queryOptions(),
   ]);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/settings/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/content/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/apps/dashboard/src/app/(dashboard)/settings/private-locations/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/private-locations/layout.tsx
@@ -4,21 +4,16 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.notification.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.notification.list.queryOptions(),
+    trpc.privateLocation.list.queryOptions(),
   ]);
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/status-pages/(list)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/(list)/page.tsx
@@ -1,11 +1,9 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 
-export default async function Page() {
-  const queryClient = getQueryClient();
-
-  await queryClient.prefetchQuery(trpc.page.list.queryOptions());
+export default function Page() {
+  prefetch(trpc.page.list.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/components/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/components/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -16,16 +16,11 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
-  await Promise.all([
-    queryClient.prefetchQuery(
-      trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
-    ),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(
-      trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
-    ),
+  batchPrefetch([
+    trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
+    trpc.monitor.list.queryOptions(),
+    trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
   ]);
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -16,16 +16,11 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
-  await Promise.all([
-    queryClient.prefetchQuery(
-      trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
-    ),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(
-      trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
-    ),
+  batchPrefetch([
+    trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
+    trpc.monitor.list.queryOptions(),
+    trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
   ]);
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "nuqs";
 
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
@@ -13,13 +13,12 @@ export default async function Page({
   searchParams: Promise<SearchParams>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
-  // NOTE: store in cache to avoid flicker on clients first render
-  await searchParamsCache.parse(searchParams);
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.page.getUptimeHistory.queryOptions({ id: Number.parseInt(id) }),
   );
+  // NOTE: store in cache to avoid flicker on clients first render
+  await searchParamsCache.parse(searchParams);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/layout.tsx
@@ -7,7 +7,7 @@ import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
 import {
   HydrateClient,
   fetchQueryOrNotFound,
-  getQueryClient,
+  prefetch,
   trpc,
 } from "@/lib/trpc/server";
 
@@ -23,12 +23,11 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
+  prefetch(trpc.monitor.list.queryOptions());
   await fetchQueryOrNotFound(
     trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
   );
-  await queryClient.prefetchQuery(trpc.monitor.list.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -16,9 +16,8 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.maintenance.list.queryOptions({
       pageId: Number.parseInt(id),
     }),

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/status-reports/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/status-reports/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -15,9 +15,8 @@ export default async function Layout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const queryClient = getQueryClient();
   const { id } = await params;
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.statusReport.list.queryOptions({ pageId: Number.parseInt(id) }),
   );
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/subscribers/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/subscribers/layout.tsx
@@ -1,4 +1,4 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 export default async function Layout({
   children,
@@ -7,10 +7,9 @@ export default async function Layout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const queryClient = getQueryClient();
   const { id } = await params;
 
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.pageSubscriber.list.queryOptions({ pageId: Number.parseInt(id) }),
   );
 

--- a/apps/dashboard/src/app/(dashboard)/status-pages/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/loading.tsx
@@ -1,0 +1,6 @@
+import { PageSkeleton } from "@/components/content/page-skeleton";
+
+// Sits above `[id]/layout.tsx`, whose `fetchQueryOrNotFound` gate suspends.
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/apps/dashboard/src/app/onboarding/layout.tsx
+++ b/apps/dashboard/src/app/onboarding/layout.tsx
@@ -1,16 +1,11 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
-    queryClient.prefetchQuery(trpc.user.get.queryOptions()),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.workspace.get.queryOptions(),
+    trpc.user.get.queryOptions(),
+    trpc.monitor.list.queryOptions(),
+    trpc.page.list.queryOptions(),
   ]);
 
   return <HydrateClient>{children}</HydrateClient>;

--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -2,7 +2,12 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import type { SearchParams } from "nuqs";
 
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import {
+  HydrateClient,
+  getQueryClient,
+  prefetch,
+  trpc,
+} from "@/lib/trpc/server";
 
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
@@ -52,10 +57,12 @@ export default async function Page({
   }
 
   const queryClient = getQueryClient();
+  // only monitors/pages gate the step redirect below — the key list just needs
+  // to be in the dehydrated cache for the client
+  prefetch(trpc.apiKey.list.queryOptions());
   const [monitors, pages] = await Promise.all([
     queryClient.fetchQuery(trpc.monitor.list.queryOptions()),
     queryClient.fetchQuery(trpc.page.list.queryOptions()),
-    queryClient.fetchQuery(trpc.apiKey.list.queryOptions()),
   ]);
 
   const updates: {

--- a/apps/dashboard/src/components/content/page-skeleton.tsx
+++ b/apps/dashboard/src/components/content/page-skeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from "@openstatus/ui/components/ui/skeleton";
+
+import {
+  Section,
+  SectionGroup,
+  SectionHeader,
+} from "@/components/content/section";
+import { AppHeader, AppHeaderContent } from "@/components/nav/app-header";
+import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
+import { DataTableSkeleton } from "@/components/ui/data-table/data-table-skeleton";
+
+/** Route-level fallback for `loading.tsx`; mirrors the AppHeader + Section shell. */
+export function PageSkeleton() {
+  return (
+    <div>
+      <AppHeader>
+        <AppHeaderContent>
+          <AppSidebarTrigger />
+          <Skeleton className="h-4 w-32" />
+        </AppHeaderContent>
+      </AppHeader>
+      <main className="w-full flex-1">
+        <SectionGroup>
+          <Section>
+            <SectionHeader>
+              <Skeleton className="h-6 w-40" />
+              <Skeleton className="h-4 w-64" />
+            </SectionHeader>
+            <DataTableSkeleton />
+          </Section>
+        </SectionGroup>
+      </main>
+    </div>
+  );
+}

--- a/apps/dashboard/src/lib/trpc/server.tsx
+++ b/apps/dashboard/src/lib/trpc/server.tsx
@@ -32,11 +32,6 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
         // tRPC's link will never invoke — cast the call-signature wrapper.
         fetch: (async (url, options) => {
           const cookieStore = await cookies();
-          console.log("[dashboard trpc server] fetch", {
-            hasSessionToken:
-              !!cookieStore.get("__Secure-authjs.session-token")?.value ||
-              !!cookieStore.get("authjs.session-token")?.value,
-          });
           return fetch(url, {
             ...options,
             credentials: "include",


### PR DESCRIPTION
Recreates #2466, which was reverted in #2467, so we can keep iterating on the prefetch / page-skeleton work.

Leaving this open as a working branch — not ready to merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

