### PR TITLE
perf: resolve active workspace once per request instead of per procedure

### DIFF
--- a/packages/api/src/trpc.test.ts
+++ b/packages/api/src/trpc.test.ts
@@ -1,0 +1,121 @@
+import { expect } from "@std/expect";
+import { test } from "@std/testing/bdd";
+import { NextRequest } from "next/server.js";
+
+import type { ResolveActiveWorkspaceResult } from "./auth/resolve-active-workspace";
+import {
+  createInnerTRPCContext,
+  createTRPCContext,
+  createTRPCRouter,
+  protectedProcedure,
+} from "./trpc";
+
+const testRouter = createTRPCRouter({
+  whoami: protectedProcedure.query(({ ctx }) => ({
+    userId: ctx.user.id,
+    workspaceSlug: ctx.workspace.slug,
+  })),
+});
+
+function makeRequest(cookie?: string) {
+  return new NextRequest("http://localhost:3000/api/trpc/lambda", {
+    headers: cookie ? { cookie } : undefined,
+  });
+}
+
+test("protected procedure rejects without a session", async () => {
+  const ctx = createInnerTRPCContext({ session: null });
+  const caller = testRouter.createCaller(ctx);
+
+  await expect(caller.whoami()).rejects.toThrow("UNAUTHORIZED");
+});
+
+test("protected procedure resolves seeded user and workspace", async () => {
+  const ctx = await createTRPCContext({
+    req: makeRequest("workspace-slug=love-openstatus"),
+    auth: async () => ({ user: { id: "1" } }),
+  });
+  const caller = testRouter.createCaller(ctx);
+
+  const result = await caller.whoami();
+
+  expect(result).toEqual({ userId: 1, workspaceSlug: "love-openstatus" });
+});
+
+test("falls back to the first workspace when the cookie slug is stale", async () => {
+  const ctx = await createTRPCContext({
+    req: makeRequest("workspace-slug=does-not-exist"),
+    auth: async () => ({ user: { id: "1" } }),
+  });
+  const caller = testRouter.createCaller(ctx);
+
+  const result = await caller.whoami();
+
+  expect(result).toEqual({ userId: 1, workspaceSlug: "love-openstatus" });
+});
+
+test("resolveWorkspace memoizes the resolution within one request context", async () => {
+  const ctx = await createTRPCContext({
+    req: makeRequest(),
+    auth: async () => ({ user: { id: "1" } }),
+  });
+
+  const first = ctx.resolveWorkspace?.({ userId: 1 });
+  const second = ctx.resolveWorkspace?.({ userId: 1 });
+
+  expect(second).toBe(first);
+
+  const resolved = await first;
+  expect(resolved?.ok).toBe(true);
+});
+
+test("resolveWorkspace is not shared across request contexts", async () => {
+  const auth = async () => ({ user: { id: "1" } });
+  const a = await createTRPCContext({ req: makeRequest(), auth });
+  const b = await createTRPCContext({ req: makeRequest(), auth });
+
+  const resolvedA = a.resolveWorkspace?.({ userId: 1 });
+  const resolvedB = b.resolveWorkspace?.({ userId: 1 });
+
+  expect(resolvedB).not.toBe(resolvedA);
+  await Promise.all([resolvedA, resolvedB]);
+});
+
+test("middleware uses the context resolver instead of querying directly", async () => {
+  let calls = 0;
+  const resolveWorkspace = (_args: {
+    userId: number;
+    workspaceSlug?: string;
+  }): Promise<ResolveActiveWorkspaceResult> => {
+    calls++;
+    // safe because the middleware only reads user.id and workspace.slug
+    return Promise.resolve({
+      ok: true,
+      value: { user: { id: 42 }, workspace: { slug: "stubbed-workspace" } },
+    } as unknown as ResolveActiveWorkspaceResult);
+  };
+
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "42" } },
+    resolveWorkspace,
+  });
+  const caller = testRouter.createCaller(ctx);
+
+  const result = await caller.whoami();
+
+  expect(result).toEqual({ userId: 42, workspaceSlug: "stubbed-workspace" });
+  expect(calls).toBe(1);
+});
+
+test("middleware surfaces workspace_not_found as UNAUTHORIZED", async () => {
+  const resolveWorkspace = (): Promise<ResolveActiveWorkspaceResult> =>
+    Promise.resolve({ ok: false, error: { kind: "workspace_not_found" } });
+
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "42" } },
+    resolveWorkspace,
+  });
+  const caller = testRouter.createCaller(ctx);
+
+  await expect(caller.whoami()).rejects.toThrow("Workspace Not Found");
+});

--- a/packages/api/src/trpc.test.ts
+++ b/packages/api/src/trpc.test.ts
@@ -60,8 +60,8 @@ test("resolveWorkspace memoizes the resolution within one request context", asyn
     auth: async () => ({ user: { id: "1" } }),
   });
 
-  const first = ctx.resolveWorkspace?.({ userId: 1 });
-  const second = ctx.resolveWorkspace?.({ userId: 1 });
+  const first = ctx.resolveWorkspace?.();
+  const second = ctx.resolveWorkspace?.();
 
   expect(second).toBe(first);
 
@@ -74,8 +74,8 @@ test("resolveWorkspace is not shared across request contexts", async () => {
   const a = await createTRPCContext({ req: makeRequest(), auth });
   const b = await createTRPCContext({ req: makeRequest(), auth });
 
-  const resolvedA = a.resolveWorkspace?.({ userId: 1 });
-  const resolvedB = b.resolveWorkspace?.({ userId: 1 });
+  const resolvedA = a.resolveWorkspace?.();
+  const resolvedB = b.resolveWorkspace?.();
 
   expect(resolvedB).not.toBe(resolvedA);
   await Promise.all([resolvedA, resolvedB]);
@@ -83,10 +83,7 @@ test("resolveWorkspace is not shared across request contexts", async () => {
 
 test("middleware uses the context resolver instead of querying directly", async () => {
   let calls = 0;
-  const resolveWorkspace = (_args: {
-    userId: number;
-    workspaceSlug?: string;
-  }): Promise<ResolveActiveWorkspaceResult> => {
+  const resolveWorkspace = (): Promise<ResolveActiveWorkspaceResult> => {
     calls++;
     // safe because the middleware only reads user.id and workspace.slug
     return Promise.resolve({

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -11,7 +11,10 @@ import { type NextRequest, after } from "next/server.js";
 import superjson from "superjson";
 import { ZodError, treeifyError } from "zod";
 
-import { resolveActiveWorkspace } from "./auth/resolve-active-workspace";
+import {
+  type ResolveActiveWorkspaceResult,
+  resolveActiveWorkspace,
+} from "./auth/resolve-active-workspace";
 
 // Generic session type that works with both User and Viewer
 type Session = {
@@ -39,6 +42,7 @@ type CreateContextOptions = {
     userAgent?: string;
     location?: string;
   };
+  resolveWorkspace?: typeof resolveActiveWorkspace;
 };
 
 type Meta = {
@@ -77,10 +81,19 @@ export const createTRPCContext = async (opts: {
   const workspace = null;
   const user = null;
 
+  // Context is per HTTP request while middleware runs per procedure — a
+  // batched request would otherwise re-run the same user×workspaces query
+  // once per procedure. userId/slug are constant within a request, so the
+  // first call's promise is safe to share.
+  let resolution: Promise<ResolveActiveWorkspaceResult> | undefined;
+  const resolveWorkspace: typeof resolveActiveWorkspace = (args) =>
+    (resolution ??= resolveActiveWorkspace(args));
+
   return createInnerTRPCContext({
     session,
     workspace,
     user,
+    resolveWorkspace,
     req: opts.req,
     metadata: {
       userAgent: opts.req.headers.get("user-agent") ?? undefined,
@@ -174,7 +187,8 @@ const enforceUserIsAuthed = t.middleware(async (opts) => {
    */
   const workspaceSlug = ctx.req?.cookies.get("workspace-slug")?.value;
 
-  const resolved = await resolveActiveWorkspace({
+  const resolve = ctx.resolveWorkspace ?? resolveActiveWorkspace;
+  const resolved = await resolve({
     userId: Number(ctx.session.user.id),
     workspaceSlug,
   });

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -42,7 +42,7 @@ type CreateContextOptions = {
     userAgent?: string;
     location?: string;
   };
-  resolveWorkspace?: typeof resolveActiveWorkspace;
+  resolveWorkspace?: () => Promise<ResolveActiveWorkspaceResult>;
 };
 
 type Meta = {
@@ -83,11 +83,14 @@ export const createTRPCContext = async (opts: {
 
   // Context is per HTTP request while middleware runs per procedure — a
   // batched request would otherwise re-run the same user×workspaces query
-  // once per procedure. userId/slug are constant within a request, so the
-  // first call's promise is safe to share.
+  // once per procedure. Zero-arg by design: userId/slug are bound here so
+  // the first call's promise is safe to share across the whole batch.
   let resolution: Promise<ResolveActiveWorkspaceResult> | undefined;
-  const resolveWorkspace: typeof resolveActiveWorkspace = (args) =>
-    (resolution ??= resolveActiveWorkspace(args));
+  const resolveWorkspace = () =>
+    (resolution ??= resolveActiveWorkspace({
+      userId: Number(session?.user?.id),
+      workspaceSlug: opts.req.cookies.get("workspace-slug")?.value,
+    }));
 
   return createInnerTRPCContext({
     session,
@@ -187,11 +190,12 @@ const enforceUserIsAuthed = t.middleware(async (opts) => {
    */
   const workspaceSlug = ctx.req?.cookies.get("workspace-slug")?.value;
 
-  const resolve = ctx.resolveWorkspace ?? resolveActiveWorkspace;
-  const resolved = await resolve({
-    userId: Number(ctx.session.user.id),
-    workspaceSlug,
-  });
+  const resolved = await (ctx.resolveWorkspace
+    ? ctx.resolveWorkspace()
+    : resolveActiveWorkspace({
+        userId: Number(ctx.session.user.id),
+        workspaceSlug,
+      }));
 
   if (!resolved.ok) {
     throw new TRPCError({


### PR DESCRIPTION
## Summary
- Batched tRPC requests no longer re-run auth workspace resolution per procedure — a 7-op batch previously fired 7 identical user×workspaces Turso queries; it now fires one.
- The resolution is memoized on the request-scoped tRPC context (`createTRPCContext`), so all procedures in a batch share the first call's promise. Context is created per HTTP request at every call site, so nothing can go stale across requests.
- Middleware falls back to a direct `resolveActiveWorkspace` call when the memoizer is absent (test contexts via `createInnerTRPCContext`), leaving existing tests untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

