### PR TITLE
fix(status-page): render info icon before latency badge

### DIFF
--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/client.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/client.tsx
@@ -432,6 +432,7 @@ function ComponentCard({
       <StatusComponentHeader>
         <StatusComponentHeaderLeft>
           <StatusComponentTitle>{name}</StatusComponentTitle>
+          <StatusComponentDescription>{description}</StatusComponentDescription>
           {latency ? (
             latency.value ? (
               <Link
@@ -451,7 +452,6 @@ function ComponentCard({
               <StatusComponentLatencySkeleton className="shrink-0" />
             ) : null
           ) : null}
-          <StatusComponentDescription>{description}</StatusComponentDescription>
         </StatusComponentHeaderLeft>
         <StatusComponentHeaderRight>
           {showUptime ? (


### PR DESCRIPTION
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017sdeBy6ZDY4yQvsbCxNYnZ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

