### PR TITLE
feat(api): log per-procedure timing to expose intra-batch latency

### DIFF
--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -150,17 +150,19 @@ export const mergeRouters = t.mergeRouters;
 const timingMiddleware = t.middleware(async (opts) => {
   const start = performance.now();
   const result = await opts.next();
-  const durationMs = Math.round(performance.now() - start);
-  console.info(
-    JSON.stringify({
-      msg: "trpc.timing",
-      path: opts.path,
-      type: opts.type,
-      durationMs,
-      ok: result.ok,
-      region: process.env.VERCEL_REGION,
-    }),
-  );
+  if (process.env.NODE_ENV !== "test") {
+    const durationMs = Math.round(performance.now() - start);
+    console.info(
+      JSON.stringify({
+        msg: "trpc.timing",
+        path: opts.path,
+        type: opts.type,
+        durationMs,
+        ok: result.ok,
+        region: process.env.VERCEL_REGION,
+      }),
+    );
+  }
   return result;
 });
 

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -147,6 +147,23 @@ export const t = initTRPC
 export const createTRPCRouter = t.router;
 export const mergeRouters = t.mergeRouters;
 
+const timingMiddleware = t.middleware(async (opts) => {
+  const start = performance.now();
+  const result = await opts.next();
+  const durationMs = Math.round(performance.now() - start);
+  console.info(
+    JSON.stringify({
+      msg: "trpc.timing",
+      path: opts.path,
+      type: opts.type,
+      durationMs,
+      ok: result.ok,
+      region: process.env.VERCEL_REGION,
+    }),
+  );
+  return result;
+});
+
 /**
  * Public (unauthed) procedure
  *
@@ -154,7 +171,7 @@ export const mergeRouters = t.mergeRouters;
  * tRPC API. It does not guarantee that a user querying is authorized, but you
  * can still access user session data if they are logged in
  */
-export const publicProcedure = t.procedure;
+export const publicProcedure = t.procedure.use(timingMiddleware);
 
 /**
  * Reusable middleware that enforces users are logged in before running the
@@ -278,4 +295,6 @@ export const formdataMiddleware = t.middleware(async (opts) => {
  *
  * @see https://trpc.io/docs/procedures
  */
-export const protectedProcedure = t.procedure.use(enforceUserIsAuthed);
+export const protectedProcedure = t.procedure
+  .use(timingMiddleware)
+  .use(enforceUserIsAuthed);


### PR DESCRIPTION
## Summary
- Adds a tRPC middleware that logs `{path, type, durationMs, ok, region}` per procedure, so Vercel logs show the intra-batch split instead of only whole-batch durations.
- Applied to both `publicProcedure` and `protectedProcedure`, before auth — so the duration includes the workspace-resolution round trip.
- Includes `VERCEL_REGION` per invocation to compare latency across the three function regions (iad1/fra1/sin1) and test the round-trip-latency vs `withBusyRetry` hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

