### PR TITLE
chore: slash command in slack agent dashboard page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/agents/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/agents/page.tsx
@@ -38,6 +38,21 @@ const messages = [
   },
 ];
 
+const commands = [
+  {
+    command: "/openstatus subscribe <status-page-url>",
+    description: "Subscribe this channel to a status page.",
+  },
+  {
+    command: "/openstatus unsubscribe <status-page-url>",
+    description: "Unsubscribe this channel from a status page.",
+  },
+  {
+    command: "/openstatus subscriptions",
+    description: "Show this channel's subscriptions.",
+  },
+];
+
 export default function Page() {
   const trpc = useTRPC();
   const { data: workspace } = useQuery(trpc.workspace.get.queryOptions());
@@ -87,6 +102,29 @@ export default function Page() {
                 {message.description}
               </p>
               <Code>{message.message}</Code>
+            </li>
+          ))}
+        </ul>
+      </Section>
+      <Section>
+        <SectionHeader>
+          <SectionTitle>Commands</SectionTitle>
+          <SectionDescription>
+            Slash commands to manage which status pages notify this channel.
+          </SectionDescription>
+        </SectionHeader>
+        <Note size="sm">
+          <Info />
+          Subscribing also joins the bot to the channel. Private channels
+          require /invite @openstatus first.
+        </Note>
+        <ul className="flex flex-col gap-2">
+          {commands.map((command, i) => (
+            <li key={i} className="flex flex-col gap-0.5">
+              <p className="text-muted-foreground text-xs">
+                {command.description}
+              </p>
+              <Code>{command.command}</Code>
             </li>
           ))}
         </ul>

--- a/apps/dashboard/src/app/(dashboard)/agents/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/agents/page.tsx
@@ -111,6 +111,7 @@ export default function Page() {
           <SectionTitle>Commands</SectionTitle>
           <SectionDescription>
             Slash commands to manage which status pages notify this channel.
+            Also useful for Slack Connect channels shared with customers.
           </SectionDescription>
         </SectionHeader>
         <Note size="sm">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

