### PR TITLE
perf(dashboard): call tRPC in-process from RSC instead of over HTTP

### DIFF
--- a/apps/dashboard/src/lib/trpc/server.tsx
+++ b/apps/dashboard/src/lib/trpc/server.tsx
@@ -1,54 +1,48 @@
 import "server-only";
-import type { AppRouter } from "@openstatus/api";
+import { type AppRouter, appRouter, createTRPCContext } from "@openstatus/api";
 import { HydrationBoundary } from "@tanstack/react-query";
 import { dehydrate } from "@tanstack/react-query";
-import { TRPCClientError, createTRPCClient } from "@trpc/client";
+import { TRPCClientError } from "@trpc/client";
 import {
   type ResolverDef,
   type TRPCQueryOptions,
   createTRPCOptionsProxy,
 } from "@trpc/tanstack-react-query";
-import { cookies } from "next/headers";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { NextRequest } from "next/server";
 import { cache } from "react";
 
+import { auth } from "@/lib/auth";
+
 import { makeQueryClient } from "./query-client";
-import { endingLink, sentryLoggerLink } from "./shared";
 
 // IMPORTANT: Create a stable getter for the query client that
 //            will return the same client during the same request.
 export const getQueryClient = cache(makeQueryClient);
 
+/**
+ * RSC has no `NextRequest`, so synthesize one from the incoming headers —
+ * `NextRequest` derives `.cookies` from the `cookie` header, which is all
+ * the tRPC context reads (workspace-slug) besides UA / forwarded-for.
+ * The URL is a placeholder; nothing in the context inspects it.
+ */
+const createRSCContext = cache(async () => {
+  const headerList = await headers();
+  const req = new NextRequest("https://dashboard.internal/rsc", {
+    headers: headerList,
+  });
+  return createTRPCContext({ req, auth });
+});
+
+// Calls procedures in-process. This used to be an httpBatchLink pointed back
+// at our own /api/trpc/lambda, which meant every RSC render paid a real HTTPS
+// round-trip, a second lambda invocation and a second `auth()` before any
+// query ran. Both run on Node, so there is nothing to bridge.
 export const trpc = createTRPCOptionsProxy<AppRouter>({
+  router: appRouter,
+  ctx: createRSCContext,
   queryClient: getQueryClient,
-  client: createTRPCClient({
-    links: [
-      sentryLoggerLink(),
-      endingLink({
-        headers: {
-          "x-trpc-source": "server",
-        },
-        // `typeof fetch` carries a `preconnect` static (React 19 typings) that
-        // tRPC's link will never invoke — cast the call-signature wrapper.
-        fetch: (async (url, options) => {
-          const cookieStore = await cookies();
-          console.log("[dashboard trpc server] fetch", {
-            hasSessionToken:
-              !!cookieStore.get("__Secure-authjs.session-token")?.value ||
-              !!cookieStore.get("authjs.session-token")?.value,
-          });
-          return fetch(url, {
-            ...options,
-            credentials: "include",
-            headers: {
-              ...options?.headers,
-              cookie: cookieStore.toString(),
-            },
-          });
-        }) as typeof fetch,
-      }),
-    ],
-  }),
 });
 
 export function HydrateClient(props: { children: React.ReactNode }) {
@@ -104,9 +98,23 @@ export async function fetchQueryOrNotFound<
       ReturnType<Extract<T["queryFn"], (...args: never[]) => unknown>>
     >;
   } catch (error) {
-    if (error instanceof TRPCClientError && error.data?.code === "NOT_FOUND") {
-      notFound();
-    }
+    if (isNotFound(error)) notFound();
     throw error;
   }
+}
+
+/**
+ * The in-process caller throws `TRPCError`; `TRPCClientError` only appears if
+ * a caller still goes over the wire. Matched on `name` rather than
+ * `instanceof` — a duplicated `@trpc/server` copy in the RSC bundle would
+ * break identity and silently turn every `notFound()` gate into a 500. tRPC
+ * duck-types the same way internally (`getTRPCErrorFromUnknown`).
+ */
+function isNotFound(error: unknown): boolean {
+  if (error instanceof TRPCClientError) return error.data?.code === "NOT_FOUND";
+  return (
+    error instanceof Error &&
+    error.name === "TRPCError" &&
+    (error as { code?: string }).code === "NOT_FOUND"
+  );
 }


### PR DESCRIPTION
## Summary

- Dashboard renders no longer make an HTTPS round-trip to themselves. Server-side prefetches went through an `httpBatchLink` pointed at our own `/api/trpc/lambda`, so every page render paid a real network hop to `app.openstatus.dev`, a second lambda invocation and a second `auth()` before any query ran. RSC and the route handler both run on Node, so there was nothing to bridge — this was left over from the old Edge/Node split.
- Preview deployments stop prefetching against production. `getBaseUrl()` returns the hardcoded prod domain whenever `VERCEL_URL` is set, which meant every preview and branch deploy read prod data on the server path. No fetch, no problem.
- Fixes a latent 404→500 bug. `fetchQueryOrNotFound` tested `instanceof TRPCClientError`, but the in-process caller throws `TRPCError` — every `notFound()` gate (monitor, status page, chat session, status report layouts) would have thrown a 500 instead of rendering a 404. Matched on error name the way tRPC does internally, so a duplicated `@trpc/server` copy can't silently break it either.

## Context

Chasing a ~1s TTFB on the `page.list,monitor.list,workspace.get,workspace.list,user.get` batch. That request is the layout's five prefetches — issued by the server, not the browser. This removes the transport overhead; it does not touch query time.

## Verification

- `next build` passes — `appRouter` bundles into the RSC graph cleanly.
- A temporary probe route returned `{"errorName":"TRPCError","errorCode":"UNAUTHORIZED"}`. `TRPCError` rather than `TRPCClientError` is direct evidence the call never left the process, and it confirmed the `fetchQueryOrNotFound` bug was real rather than theoretical.
- `tsc`, oxlint, oxfmt clean.
- Per-procedure timing from #2472 lives on the procedure in `trpc.ts`, not the route handler, so RSC-path calls stay instrumented.

## Not yet verified — worth a look before/after merge

- **The authenticated path has not been run.** The probe returned at `UNAUTHORIZED`, which fires before `opts.next()`, so everything past the auth check is unexercised — including `after()` in `enforceUserIsAuthed`, which now runs during an RSC render rather than a route handler. Next supports `after()` in Server Components, but it hasn't been observed here.
- **Cold-start trade-off is unmeasured.** Every page function now carries the full router's dependency tree (Slack SDK, Stripe, email, Tinybird) instead of that living only in the lambda. If the added cold start exceeds the removed hop, this doesn't achieve the goal. The `trpc.timing` logs plus Vercel function durations should show it once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

