### PR TITLE
fix: private location tcp timestamp

### DIFF
--- a/apps/checker/pkg/job/tcp_job.go
+++ b/apps/checker/pkg/job/tcp_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/google/uuid"
@@ -66,11 +67,14 @@ func (jobRunner) TCPJob(ctx context.Context, monitor *v1.TCPMonitor, region stri
 
 			lastResult = checker.TCPResponse{Error: 1}
 
+			// Use current timestamp since connection failed and res.TCPStart would be 0
+			now := time.Now().UnixMilli()
+
 			return &TCPPrivateRegionData{
 				ID:            id.String(),
 				Latency:       0,
-				Timestamp:     res.TCPStart,
-				CronTimestamp: res.TCPStart,
+				Timestamp:     now,
+				CronTimestamp: now,
 				URI:           monitor.Uri,
 				RequestStatus: "error",
 				Error:         1,


### PR DESCRIPTION
Fixes issue where a failing TCP monitor would give a timestamp of 0, causing the ingest server to reject it due to its validation
Resolves #2483

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

