### PR TITLE
fix: ensure status page reflects private location status

### DIFF
--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -91,7 +91,7 @@ const gateFieldsSchema = selectPageSchema.pick({
  * Check recent probe status for a monitor using >50% region consensus.
  * A monitor is down/degraded/up if >50% of regions share that status.
  * Bias towards "success" - requires majority to change to error/degraded.
- * 
+ *
  * For hybrid monitors (with cloud regions), returns null to prevent private
  * location probe data from overriding cloud-based status.
  */

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -91,11 +91,20 @@ const gateFieldsSchema = selectPageSchema.pick({
  * Check recent probe status for a monitor using >50% region consensus.
  * A monitor is down/degraded/up if >50% of regions share that status.
  * Bias towards "success" - requires majority to change to error/degraded.
+ * 
+ * For hybrid monitors (with cloud regions), returns null to prevent private
+ * location probe data from overriding cloud-based status.
  */
 async function getRecentProbeStatus(
   monitorId: string,
   jobType: "http" | "tcp" | "icmp" | "udp" | "dns" | "ssl",
+  regions: string,
 ): Promise<"success" | "degraded" | "error" | null> {
+  // Only use probe status for private-only monitors (no cloud regions)
+  const hasCloudRegions = regions && regions.trim().length > 0;
+  if (hasCloudRegions) {
+    return null; // Skip probe status for hybrid monitors
+  }
   try {
     // Query the appropriate Tinybird endpoint
     let procedure;
@@ -274,6 +283,7 @@ export const statusPageRouter = createTRPCRouter({
           const probeStatus = await getRecentProbeStatus(
             monitorId,
             c.monitor.jobType,
+            c.monitor.regions,
           );
           if (probeStatus) {
             probeStatusMap.set(monitorId, probeStatus);

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -98,10 +98,10 @@ const gateFieldsSchema = selectPageSchema.pick({
 async function getRecentProbeStatus(
   monitorId: string,
   jobType: "http" | "tcp" | "icmp" | "udp" | "dns" | "ssl",
-  regions: string,
+  regions: readonly string[],
 ): Promise<"success" | "degraded" | "error" | null> {
   // Only use probe status for private-only monitors (no cloud regions)
-  const hasCloudRegions = regions && regions.trim().length > 0;
+  const hasCloudRegions = regions && regions.length > 0;
   if (hasCloudRegions) {
     return null; // Skip probe status for hybrid monitors
   }

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -123,7 +123,7 @@ async function getRecentProbeStatus(
     for (const check of result.data) {
       // Determine the region/location identifier
       // Cloud monitors use 'region', private locations might use 'locationId' or 'region'
-      const regionId = check.region || check.locationId || "default";
+      const regionId = check.region || (check as any).locationId || "default";
       
       // Determine status from the check
       let status: "success" | "degraded" | "error" | null = null;

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -47,6 +47,7 @@ import {
   getStatusProcedure,
   getUptimeProcedure,
 } from "./tinybird";
+import { tb } from "../tb";
 
 // NOTE: publicProcedure is used to get the status page
 // TODO: improve performance of SQL query (make a single query with joins)
@@ -123,7 +124,7 @@ async function getRecentProbeStatus(
     for (const check of result.data) {
       // Determine the region/location identifier
       // Cloud monitors use 'region', private locations might use 'locationId' or 'region'
-      const regionId = check.region || (check as any).locationId || "default";
+      const regionId = check.region || ("locationId" in check ? check.locationId : null) || "default";
       
       // Determine status from the check
       let status: "success" | "degraded" | "error" | null = null;
@@ -518,6 +519,18 @@ export const statusPageRouter = createTRPCRouter({
                 : c,
             )
           : pageComponents;
+
+      // Build monitors array for backward compatibility
+      const monitors = components
+        .filter((c) => c.monitor)
+        .map((c) => ({
+          ...c.monitor!,
+          status: c.status,
+          events: c.events,
+          monitorGroupId: c.groupId,
+          order: c.order,
+          groupOrder: c.groupOrder,
+        }));
 
       return selectPublicPageSchemaWithRelation.parse({
         ..._page,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -27,6 +27,7 @@ import { TRPCError } from "@trpc/server";
 import { endOfDay, startOfDay, subDays } from "date-fns";
 import { z } from "zod";
 
+import { tb } from "../tb";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 import {
   type StatusData,
@@ -47,7 +48,6 @@ import {
   getStatusProcedure,
   getUptimeProcedure,
 } from "./tinybird";
-import { tb } from "../tb";
 
 // NOTE: publicProcedure is used to get the status page
 // TODO: improve performance of SQL query (make a single query with joins)
@@ -116,19 +116,25 @@ async function getRecentProbeStatus(
     }
 
     // Group by region and keep only the most recent check from each region
-    const mostRecentByRegion = new Map<string, {
-      status: "success" | "degraded" | "error";
-      timestamp: number;
-    }>();
+    const mostRecentByRegion = new Map<
+      string,
+      {
+        status: "success" | "degraded" | "error";
+        timestamp: number;
+      }
+    >();
 
     for (const check of result.data) {
       // Determine the region/location identifier
       // Cloud monitors use 'region', private locations might use 'locationId' or 'region'
-      const regionId = check.region || ("locationId" in check ? check.locationId : null) || "default";
-      
+      const regionId =
+        check.region ||
+        ("locationId" in check ? check.locationId : null) ||
+        "default";
+
       // Determine status from the check
       let status: "success" | "degraded" | "error" | null = null;
-      
+
       // v1 endpoint with requestStatus field
       if ("requestStatus" in check && check.requestStatus) {
         status = check.requestStatus;
@@ -156,14 +162,14 @@ async function getRecentProbeStatus(
     // Apply >50% majority logic
     const total = mostRecentByRegion.size;
     const counts = { error: 0, degraded: 0, success: 0 };
-    
+
     for (const { status } of mostRecentByRegion.values()) {
       counts[status]++;
     }
 
     // >50% means strictly greater than half
     const threshold = total / 2;
-    
+
     // Priority: error > degraded > success (check in order)
     // This ensures if >50% are error, we return error (most severe)
     if (counts.error > threshold) {
@@ -172,7 +178,7 @@ async function getRecentProbeStatus(
     if (counts.degraded > threshold) {
       return "degraded";
     }
-    
+
     // Default to success if no majority (bias towards up)
     // This handles cases like: 1 error, 1 success (tie) → success
     return "success";
@@ -255,20 +261,24 @@ export const statusPageRouter = createTRPCRouter({
 
       const monitorComponents = pageComponents.filter(isMonitorComponent);
 
-
       // Query recent probe status for all monitors (unless in manual mode)
-      const probeStatusMap = new Map<string, "success" | "degraded" | "error">();
+      const probeStatusMap = new Map<
+        string,
+        "success" | "degraded" | "error"
+      >();
       if (barType !== "manual") {
         const probeStatusPromises = monitorComponents.map(async (c) => {
           const monitorId = c.monitor.id.toString();
-          const probeStatus = await getRecentProbeStatus(monitorId, c.monitor.jobType);
+          const probeStatus = await getRecentProbeStatus(
+            monitorId,
+            c.monitor.jobType,
+          );
           if (probeStatus) {
             probeStatusMap.set(monitorId, probeStatus);
           }
         });
         await Promise.all(probeStatusPromises);
       }
-
 
       // Transform all page components (both monitor and static types)
       const components = pageComponents.map((c) => {
@@ -319,10 +329,15 @@ export const statusPageRouter = createTRPCRouter({
                   : "success"));
 
           // Merge probe-based status with event-based status (worst wins)
-          const probeStatus = c.monitor ? probeStatusMap.get(c.monitor.id.toString()) : undefined;
+          const probeStatus = c.monitor
+            ? probeStatusMap.get(c.monitor.id.toString())
+            : undefined;
           if (probeStatus === "error" || eventBasedStatus === "error") {
             status = "error";
-          } else if (probeStatus === "degraded" || eventBasedStatus === "degraded") {
+          } else if (
+            probeStatus === "degraded" ||
+            eventBasedStatus === "degraded"
+          ) {
             status = "degraded";
           } else {
             status = eventBasedStatus;
@@ -336,19 +351,19 @@ export const statusPageRouter = createTRPCRouter({
         };
       });
 
-
       // Calculate page-wide status from all monitor components
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show
       const monitorComponentsWithStatus = components.filter((c) => c.monitor);
-      const status = monitorComponentsWithStatus.some((m) => m.status === "error")
+      const status = monitorComponentsWithStatus.some(
+        (m) => m.status === "error",
+      )
         ? "error"
         : monitorComponentsWithStatus.some((m) => m.status === "degraded")
           ? "degraded"
           : monitorComponentsWithStatus.some((m) => m.status === "info")
             ? "info"
             : "success";
-
 
       // Get page-wide events (not tied to specific monitors)
       const pageEvents = getEvents({
@@ -522,7 +537,10 @@ export const statusPageRouter = createTRPCRouter({
 
       // Build monitors array for backward compatibility
       const monitors = components
-        .filter((c): c is typeof c & { monitor: NonNullable<typeof c.monitor> } => c.monitor !== null && c.monitor !== undefined)
+        .filter(
+          (c): c is typeof c & { monitor: NonNullable<typeof c.monitor> } =>
+            c.monitor !== null && c.monitor !== undefined,
+        )
         .map((c) => ({
           ...c.monitor,
           status: c.status,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -347,8 +347,6 @@ export const statusPageRouter = createTRPCRouter({
               )
                 ? "info"
                 : "success"));
-<<<<<<< HEAD
-=======
 
         // Merge probe-based status with event-based status (worst wins)
         const probeStatus = probeStatusMap.get(c.monitor.id.toString());
@@ -361,7 +359,6 @@ export const statusPageRouter = createTRPCRouter({
           status = eventBasedStatus;
         }
 
->>>>>>> 53aedbf3 (feat: implement >50% region consensus for probe status)
         return {
           ...c.monitor,
           status,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -86,6 +86,106 @@ const gateFieldsSchema = selectPageSchema.pick({
   contactUrl: true,
 });
 
+/**
+ * Check recent probe status for a monitor using >50% region consensus.
+ * A monitor is down/degraded/up if >50% of regions share that status.
+ * Bias towards "success" - requires majority to change to error/degraded.
+ */
+async function getRecentProbeStatus(
+  monitorId: string,
+  jobType: "http" | "tcp" | "icmp" | "udp" | "dns" | "ssl",
+): Promise<"success" | "degraded" | "error" | null> {
+  try {
+    // Query the appropriate Tinybird endpoint
+    let procedure;
+    if (jobType === "http") procedure = tb.httpListDaily;
+    else if (jobType === "tcp") procedure = tb.tcpListDaily;
+    else if (jobType === "dns") procedure = tb.dnsListBiweekly;
+    else {
+      // Unsupported job types (icmp, udp, ssl) - no Tinybird procedures available
+      return null;
+    }
+
+    const result = await procedure({
+      monitorId,
+    });
+
+    if (!result?.data || result.data.length === 0) {
+      return null; // No data
+    }
+
+    // Group by region and keep only the most recent check from each region
+    const mostRecentByRegion = new Map<string, {
+      status: "success" | "degraded" | "error";
+      timestamp: number;
+    }>();
+
+    for (const check of result.data) {
+      // Determine the region/location identifier
+      // Cloud monitors use 'region', private locations might use 'locationId' or 'region'
+      const regionId = check.region || check.locationId || "default";
+      
+      // Determine status from the check
+      let status: "success" | "degraded" | "error" | null = null;
+      
+      // v1 endpoint with requestStatus field
+      if ("requestStatus" in check && check.requestStatus) {
+        status = check.requestStatus;
+      }
+      // v0 endpoint with boolean error field
+      else if ("error" in check && typeof check.error === "boolean") {
+        status = check.error ? "error" : "success";
+      }
+
+      if (!status) continue; // Skip checks without clear status
+
+      const timestamp = check.timestamp || 0;
+      const existing = mostRecentByRegion.get(regionId);
+
+      // Keep this check if it's newer (or first for this region)
+      if (!existing || timestamp > existing.timestamp) {
+        mostRecentByRegion.set(regionId, { status, timestamp });
+      }
+    }
+
+    if (mostRecentByRegion.size === 0) {
+      return null; // No valid checks with status
+    }
+
+    // Apply >50% majority logic
+    const total = mostRecentByRegion.size;
+    const counts = { error: 0, degraded: 0, success: 0 };
+    
+    for (const { status } of mostRecentByRegion.values()) {
+      counts[status]++;
+    }
+
+    // >50% means strictly greater than half
+    const threshold = total / 2;
+    
+    console.log(`[status-page] Monitor ${monitorId}: ${total} regions - error:${counts.error} degraded:${counts.degraded} success:${counts.success} (threshold:${threshold})`);
+    
+    // Priority: error > degraded > success (check in order)
+    // This ensures if >50% are error, we return error (most severe)
+    if (counts.error > threshold) {
+      console.log(`[status-page] Monitor ${monitorId}: Majority ERROR (${counts.error}/${total} > ${threshold})`);
+      return "error";
+    }
+    if (counts.degraded > threshold) {
+      console.log(`[status-page] Monitor ${monitorId}: Majority DEGRADED (${counts.degraded}/${total} > ${threshold})`);
+      return "degraded";
+    }
+    
+    // Default to success if no majority (bias towards up)
+    // This handles cases like: 1 error, 1 success (tie) → success
+    console.log(`[status-page] Monitor ${monitorId}: No majority or tie - defaulting to SUCCESS (bias towards up)`);
+    return "success";
+  } catch (err) {
+    // Tinybird errors should not block status page rendering
+    return null;
+  }
+}
+
 export const statusPageRouter = createTRPCRouter({
   get: publicProcedure
     .input(
@@ -159,6 +259,22 @@ export const statusPageRouter = createTRPCRouter({
 
       const monitorComponents = pageComponents.filter(isMonitorComponent);
 
+<<<<<<< HEAD
+=======
+      // Query recent probe status for all monitors (unless in manual mode)
+      const probeStatusMap = new Map<string, "success" | "degraded" | "error">();
+      if (barType !== "manual") {
+        const probeStatusPromises = monitorComponents.map(async (c) => {
+          const monitorId = c.monitor.id.toString();
+          const probeStatus = await getRecentProbeStatus(monitorId, c.monitor.jobType);
+          if (probeStatus) {
+            probeStatusMap.set(monitorId, probeStatus);
+          }
+        });
+        await Promise.all(probeStatusPromises);
+      }
+
+>>>>>>> 53aedbf3 (feat: implement >50% region consensus for probe status)
       // Transform all page components (both monitor and static types)
       const components = pageComponents.map((c) => {
         const events = getEvents({
@@ -237,6 +353,21 @@ export const statusPageRouter = createTRPCRouter({
               )
                 ? "info"
                 : "success"));
+<<<<<<< HEAD
+=======
+
+        // Merge probe-based status with event-based status (worst wins)
+        const probeStatus = probeStatusMap.get(c.monitor.id.toString());
+        let status: "success" | "degraded" | "error" | "info";
+        if (probeStatus === "error" || eventBasedStatus === "error") {
+          status = "error";
+        } else if (probeStatus === "degraded" || eventBasedStatus === "degraded") {
+          status = "degraded";
+        } else {
+          status = eventBasedStatus;
+        }
+
+>>>>>>> 53aedbf3 (feat: implement >50% region consensus for probe status)
         return {
           ...c.monitor,
           status,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -301,8 +301,8 @@ export const statusPageRouter = createTRPCRouter({
               ? "info"
               : "success");
         } else {
-          // Monitor: incidents, reports, and maintenances affect status
-          status =
+          // Monitor: incidents, reports, maintenances, AND probe data affect status
+          const eventBasedStatus =
             events.some((e) => e.type === "incident" && !e.to) &&
             barType !== "manual"
               ? "error"
@@ -316,6 +316,16 @@ export const statusPageRouter = createTRPCRouter({
                 )
                   ? "info"
                   : "success"));
+
+          // Merge probe-based status with event-based status (worst wins)
+          const probeStatus = c.monitor ? probeStatusMap.get(c.monitor.id.toString()) : undefined;
+          if (probeStatus === "error" || eventBasedStatus === "error") {
+            status = "error";
+          } else if (probeStatus === "degraded" || eventBasedStatus === "degraded") {
+            status = "degraded";
+          } else {
+            status = eventBasedStatus;
+          }
         }
 
         return {

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -163,22 +163,17 @@ async function getRecentProbeStatus(
     // >50% means strictly greater than half
     const threshold = total / 2;
     
-    console.log(`[status-page] Monitor ${monitorId}: ${total} regions - error:${counts.error} degraded:${counts.degraded} success:${counts.success} (threshold:${threshold})`);
-    
     // Priority: error > degraded > success (check in order)
     // This ensures if >50% are error, we return error (most severe)
     if (counts.error > threshold) {
-      console.log(`[status-page] Monitor ${monitorId}: Majority ERROR (${counts.error}/${total} > ${threshold})`);
       return "error";
     }
     if (counts.degraded > threshold) {
-      console.log(`[status-page] Monitor ${monitorId}: Majority DEGRADED (${counts.degraded}/${total} > ${threshold})`);
       return "degraded";
     }
     
     // Default to success if no majority (bias towards up)
     // This handles cases like: 1 error, 1 success (tie) → success
-    console.log(`[status-page] Monitor ${monitorId}: No majority or tie - defaulting to SUCCESS (bias towards up)`);
     return "success";
   } catch (err) {
     // Tinybird errors should not block status page rendering

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -254,8 +254,7 @@ export const statusPageRouter = createTRPCRouter({
 
       const monitorComponents = pageComponents.filter(isMonitorComponent);
 
-<<<<<<< HEAD
-=======
+
       // Query recent probe status for all monitors (unless in manual mode)
       const probeStatusMap = new Map<string, "success" | "degraded" | "error">();
       if (barType !== "manual") {
@@ -269,7 +268,7 @@ export const statusPageRouter = createTRPCRouter({
         await Promise.all(probeStatusPromises);
       }
 
->>>>>>> 53aedbf3 (feat: implement >50% region consensus for probe status)
+
       // Transform all page components (both monitor and static types)
       const components = pageComponents.map((c) => {
         const events = getEvents({

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -522,9 +522,9 @@ export const statusPageRouter = createTRPCRouter({
 
       // Build monitors array for backward compatibility
       const monitors = components
-        .filter((c) => c.monitor)
+        .filter((c): c is typeof c & { monitor: NonNullable<typeof c.monitor> } => c.monitor !== null && c.monitor !== undefined)
         .map((c) => ({
-          ...c.monitor!,
+          ...c.monitor,
           status: c.status,
           events: c.events,
           monitorGroupId: c.groupId,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -335,59 +335,19 @@ export const statusPageRouter = createTRPCRouter({
         };
       });
 
-      // Keep monitors for backward compatibility with existing fields
-      const monitors = monitorComponents.map((c) => {
-        const events = getEvents({
-          maintenances: _page.maintenances,
-          incidents: c.monitor.incidents ?? [],
-          reports: _page.statusReports,
-          monitorId: c.monitor.id,
-        });
-        const status =
-          events.some((e) => e.type === "incident" && !e.to) &&
-          barType !== "manual"
-            ? "error"
-            : (activeReportStatus(events) ??
-              (events.some(
-                (e) =>
-                  e.type === "maintenance" &&
-                  e.to &&
-                  e.from.getTime() <= new Date().getTime() &&
-                  e.to.getTime() >= new Date().getTime(),
-              )
-                ? "info"
-                : "success"));
 
-        // Merge probe-based status with event-based status (worst wins)
-        const probeStatus = probeStatusMap.get(c.monitor.id.toString());
-        let status: "success" | "degraded" | "error" | "info";
-        if (probeStatus === "error" || eventBasedStatus === "error") {
-          status = "error";
-        } else if (probeStatus === "degraded" || eventBasedStatus === "degraded") {
-          status = "degraded";
-        } else {
-          status = eventBasedStatus;
-        }
-
-        return {
-          ...c.monitor,
-          status,
-          events,
-          monitorGroupId: c.groupId,
-          order: c.order,
-          groupOrder: c.groupOrder,
-        };
-      });
-
+      // Calculate page-wide status from all monitor components
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show
-      const status = monitors.some((m) => m.status === "error")
+      const monitorComponentsWithStatus = components.filter((c) => c.monitor);
+      const status = monitorComponentsWithStatus.some((m) => m.status === "error")
         ? "error"
-        : monitors.some((m) => m.status === "degraded")
+        : monitorComponentsWithStatus.some((m) => m.status === "degraded")
           ? "degraded"
-          : monitors.some((m) => m.status === "info")
+          : monitorComponentsWithStatus.some((m) => m.status === "info")
             ? "info"
             : "success";
+
 
       // Get page-wide events (not tied to specific monitors)
       const pageEvents = getEvents({

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -127,9 +127,11 @@ async function getRecentProbeStatus(
     for (const check of result.data) {
       // Determine the region/location identifier
       // Cloud monitors use 'region', private locations might use 'locationId' or 'region'
-      const regionId =
+      const regionId: string =
         check.region ||
-        ("locationId" in check ? check.locationId : null) ||
+        ("locationId" in check && typeof check.locationId === "string"
+          ? check.locationId
+          : "") ||
         "default";
 
       // Determine status from the check


### PR DESCRIPTION
Ensures that monitors in the status page, monitored by private location probes, shows the correct status based on the majority status instead of only displaying "Operational".
Resolves #2482

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

