### PR TITLE
fix: add status labels for card value - duration (private locations)

### DIFF
--- a/packages/api/src/router/statusPage.utils.ts
+++ b/packages/api/src/router/statusPage.utils.ts
@@ -84,9 +84,9 @@ function formatNumber(num: number): string {
 function isToday(date: Date): boolean {
   const today = new Date();
   return (
-    date.getDate() === today.getDate() &&
-    date.getMonth() === today.getMonth() &&
-    date.getFullYear() === today.getFullYear()
+    date.getUTCDate() === today.getUTCDate() &&
+    date.getUTCMonth() === today.getUTCMonth() &&
+    date.getUTCFullYear() === today.getUTCFullYear()
   );
 }
 

--- a/packages/api/src/router/statusPage.utils.ts
+++ b/packages/api/src/router/statusPage.utils.ts
@@ -532,10 +532,7 @@ export function setDataByType({
           cardData = entries
             .map((entry) => {
               // Map each entry status to its corresponding events
-              const eventByStatus: Record<
-                string,
-                Event[]
-              > = {
+              const eventByStatus: Record<string, Event[]> = {
                 error: incidents,
                 degraded: reports,
                 info: maintenances,
@@ -574,9 +571,7 @@ export function setDataByType({
                 maintenances,
               );
             })
-            .filter(
-              (item): item is NonNullable<typeof item> => item !== null,
-            );
+            .filter((item): item is NonNullable<typeof item> => item !== null);
         }
         break;
 

--- a/packages/api/src/router/statusPage.utils.ts
+++ b/packages/api/src/router/statusPage.utils.ts
@@ -532,14 +532,40 @@ export function setDataByType({
           cardData = entries
             .map((entry) => {
               // Map each entry status to its corresponding events
-              const eventMap = {
+              const eventByStatus: Record<
+                string,
+                Event[]
+              > = {
                 error: incidents,
                 degraded: reports,
                 info: maintenances,
                 success: [], // Success is calculated differently
               };
+              const events = eventByStatus[entry.status];
 
-              const events = eventMap[entry.status as keyof typeof eventMap];
+              // When there are no events for this status but the data shows a
+              // non-zero count, calculate a proportional duration from the data
+              // so the card reflects actual probe-based status, not just events.
+              if (
+                events.length === 0 &&
+                (entry.status === "error" || entry.status === "degraded") &&
+                entry.count > 0
+              ) {
+                const totalMinutes = getAdjustedTotalMinutesInDay(
+                  date,
+                  maintenances,
+                );
+                const statusMinutes = Math.round(
+                  (entry.count / total) * totalMinutes,
+                );
+                if (statusMinutes === 0) return null;
+                durationMap.set(entry.status, statusMinutes);
+                return {
+                  status: entry.status,
+                  value: formatDuration(statusMinutes),
+                };
+              }
+
               return createDurationCardEntry(
                 entry.status,
                 events,
@@ -548,7 +574,9 @@ export function setDataByType({
                 maintenances,
               );
             })
-            .filter((item): item is NonNullable<typeof item> => item !== null);
+            .filter(
+              (item): item is NonNullable<typeof item> => item !== null,
+            );
         }
         break;
 


### PR DESCRIPTION
Adds the missing status labels when "Card Value" is set to "Duration".
<img width="180" height="184" alt="image" src="https://github.com/user-attachments/assets/e484eb0d-ae0f-444f-a4d7-ccbdce30201f" />
Partially resolves #2455

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

