### PR TITLE
fix: use mv__http_1d__v1 in global metrics endpoint

### DIFF
--- a/packages/tinybird/endpoints/endpoint__http_metrics_global_1d__v0.pipe
+++ b/packages/tinybird/endpoints/endpoint__http_metrics_global_1d__v0.pipe
@@ -17,7 +17,7 @@ SQL >
         max(cronTimestamp) as lastTimestamp,
         count() as count,
         monitorId
-    FROM mv__http_1d__v0
+    FROM mv__http_1d__v1
     WHERE monitorId IN {{ Array(monitorIds, 'String', '1') }}
     GROUP BY monitorId
 


### PR DESCRIPTION
The HTTP global metrics endpoint was reading from mv__http_1d__v0, but the aggregate pipe writes to mv__http_1d__v1. This caused HTTP monitors checked by private locations to show empty metrics (p50/p90/p95, last checked) on the dashboard.

Changed endpoint__http_metrics_global_1d__v0.pipe to read from v1 MV to match the active data source.

Fixes issue where HTTP private location monitors don't show metrics while TCP monitors do.

<img width="549" height="814" alt="image" src="https://github.com/user-attachments/assets/4d43a3ba-5502-4390-84f9-76bf92aa7e1c" />

Resolves #2490 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

