### PR TITLE
fix: set private location status to active when reporting

### DIFF
--- a/apps/private-location/internal/server/ingest_common.go
+++ b/apps/private-location/internal/server/ingest_common.go
@@ -68,7 +68,7 @@ func (h *privateLocationHandler) sendEventAndUpdateLastSeen(ctx context.Context,
 		}
 	}
 
-	_, dbErr := h.db.NamedExec("UPDATE private_location SET last_seen_at = :last_seen_at WHERE id = :id", map[string]any{
+	_, dbErr := h.db.NamedExec("UPDATE private_location SET last_seen_at = :last_seen_at, status = 'active' WHERE id = :id", map[string]any{
 		"last_seen_at": time.Now().Unix(),
 		"id":           regionID,
 	})


### PR DESCRIPTION
Private locations were permanently showing 'error' status even when actively reporting. The database schema defaults status to 'error', but the status was never updated to 'active' when private locations sent check results.

Changed the UPDATE statement in sendEventAndUpdateLastSeen to also set status = 'active' alongside last_seen_at when private locations report in.

Fixes issue where working private locations show error status in the UI.

Resolves #2492 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

