### PR TITLE
test(notifications): cover the formatTimestamp helper

### DIFF
--- a/packages/notifications/base/src/utils/timestamp.test.ts
+++ b/packages/notifications/base/src/utils/timestamp.test.ts
@@ -1,0 +1,32 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { formatTimestamp } from "./timestamp";
+
+describe("formatTimestamp", () => {
+  it("formats a valid epoch timestamp as an ISO string", () => {
+    expect(formatTimestamp(1700000000000)).toBe("2023-11-14T22:13:20.000Z");
+  });
+
+  it("formats timestamps before the unix epoch", () => {
+    expect(formatTimestamp(-1000)).toBe("1969-12-31T23:59:59.000Z");
+  });
+
+  it("returns Unknown for 0, since it is falsy", () => {
+    expect(formatTimestamp(0)).toBe("Unknown");
+  });
+
+  it("returns Unknown for NaN", () => {
+    expect(formatTimestamp(Number.NaN)).toBe("Unknown");
+  });
+
+  it("returns Unknown for non finite values", () => {
+    expect(formatTimestamp(Number.POSITIVE_INFINITY)).toBe("Unknown");
+    expect(formatTimestamp(Number.NEGATIVE_INFINITY)).toBe("Unknown");
+  });
+
+  it("returns Unknown when the timestamp is beyond the maximum valid date", () => {
+    // The largest date JS can represent is 8.64e15 ms; one past it is invalid.
+    expect(formatTimestamp(8.64e15 + 1)).toBe("Unknown");
+  });
+});


### PR DESCRIPTION
Adds unit tests for formatTimestamp in packages/notifications/base, which was previously untested.

Covers all three branches:
- valid epoch timestamps, including dates before the unix epoch
- the falsy and non finite guard (0, NaN, Infinity, -Infinity all return "Unknown")
- timestamps beyond the maximum date JS can represent, where the constructed Date is invalid and the helper returns "Unknown"

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

