### PR TITLE
fix: include private locations in region count, fix graph bug

### DIFF
--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
@@ -255,8 +255,7 @@ export default function Page() {
               ) : (
                 <StatusMonitorTabsTriggerValue>
                   {(tempMonitor?.regions.length ?? 0) +
-                    (((tempMonitor as Record<string, unknown>)
-                      ?.privateLocationCount as number | undefined) ?? 0)}{" "}
+                    (tempMonitor?.privateLocationCount ?? 0)}{" "}
                   {t("regions")}{" "}
                   <Badge
                     variant="outline"

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
@@ -254,7 +254,10 @@ export default function Page() {
                 <StatusMonitorTabsTriggerValueSkeleton />
               ) : (
                 <StatusMonitorTabsTriggerValue>
-                  {(tempMonitor?.regions.length ?? 0) + ((tempMonitor as Record<string, unknown>)?.privateLocationCount as number | undefined ?? 0)} {t("regions")}{" "}
+                  {(tempMonitor?.regions.length ?? 0) +
+                    (((tempMonitor as Record<string, unknown>)
+                      ?.privateLocationCount as number | undefined) ?? 0)}{" "}
+                  {t("regions")}{" "}
                   <Badge
                     variant="outline"
                     className="py-px font-mono text-[10px]"

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
@@ -254,7 +254,7 @@ export default function Page() {
                 <StatusMonitorTabsTriggerValueSkeleton />
               ) : (
                 <StatusMonitorTabsTriggerValue>
-                  {(tempMonitor?.regions.length ?? 0) + ((tempMonitor as any)?.privateLocationCount ?? 0)} {t("regions")}{" "}
+                  {(tempMonitor?.regions.length ?? 0) + ((tempMonitor as Record<string, unknown>)?.privateLocationCount as number | undefined ?? 0)} {t("regions")}{" "}
                   <Badge
                     variant="outline"
                     className="py-px font-mono text-[10px]"

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/[id]/page.tsx
@@ -254,7 +254,7 @@ export default function Page() {
                 <StatusMonitorTabsTriggerValueSkeleton />
               ) : (
                 <StatusMonitorTabsTriggerValue>
-                  {tempMonitor?.regions.length} {t("regions")}{" "}
+                  {(tempMonitor?.regions.length ?? 0) + ((tempMonitor as any)?.privateLocationCount ?? 0)} {t("regions")}{" "}
                   <Badge
                     variant="outline"
                     className="py-px font-mono text-[10px]"

--- a/apps/status-page/src/components/chart/chart-line-regions.tsx
+++ b/apps/status-page/src/components/chart/chart-line-regions.tsx
@@ -43,7 +43,7 @@ function getChartConfig(
 ): ChartConfig {
   const regions =
     data.length > 0
-      ? Object.keys(data[0]).filter((item) => item !== "timestamp")
+      ? Array.from(new Set(data.flatMap((item) => Object.keys(item)).filter((key) => key !== "timestamp")))
       : [];
 
   return regions

--- a/apps/status-page/src/components/chart/chart-line-regions.tsx
+++ b/apps/status-page/src/components/chart/chart-line-regions.tsx
@@ -43,7 +43,13 @@ function getChartConfig(
 ): ChartConfig {
   const regions =
     data.length > 0
-      ? Array.from(new Set(data.flatMap((item) => Object.keys(item)).filter((key) => key !== "timestamp")))
+      ? Array.from(
+          new Set(
+            data
+              .flatMap((item) => Object.keys(item))
+              .filter((key) => key !== "timestamp"),
+          ),
+        )
       : [];
 
   return regions

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -248,6 +248,7 @@ export const statusPageRouter = createTRPCRouter({
         };
       });
 
+
       // Add privateLocationCount to each monitor
       if (monitors.length > 0) {
         const monitorIds = monitors.map((m) => m.id);
@@ -279,6 +280,7 @@ export const statusPageRouter = createTRPCRouter({
         }
       }
 
+>>>>>>> 1c5fde17 (fix: add privateLocationCount field to status page monitors)
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show
       const status = monitors.some((m) => m.status === "error")

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -280,7 +280,7 @@ export const statusPageRouter = createTRPCRouter({
         }
       }
 
->>>>>>> 1c5fde17 (fix: add privateLocationCount field to status page monitors)
+
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show
       const status = monitors.some((m) => m.status === "error")

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -1,5 +1,5 @@
 import { Events } from "@openstatus/analytics";
-import { and, eq, inArray, sql } from "@openstatus/db";
+import { and, eq, inArray, isNull, sql } from "@openstatus/db";
 import {
   maintenance,
   page,
@@ -246,6 +246,35 @@ export const statusPageRouter = createTRPCRouter({
           groupOrder: c.groupOrder,
         };
       });
+
+      // Add privateLocationCount to each monitor
+      if (monitors.length > 0) {
+        const monitorIds = monitors.map((m) => m.id);
+        const privateLocations = await opts.ctx.db.query.privateLocationToMonitors.findMany({
+          where: and(
+            inArray(privateLocationToMonitors.monitorId, monitorIds),
+            isNull(privateLocationToMonitors.deletedAt)
+          ),
+          columns: {
+            monitorId: true,
+          },
+        });
+
+        // Count private locations per monitor
+        const privateLocationCounts = new Map<number, number>();
+        for (const pl of privateLocations) {
+          if (pl.monitorId === null) continue;
+          privateLocationCounts.set(
+            pl.monitorId,
+            (privateLocationCounts.get(pl.monitorId) ?? 0) + 1
+          );
+        }
+
+        // Add count to each monitor
+        for (const monitor of monitors) {
+          (monitor as any).privateLocationCount = privateLocationCounts.get(monitor.id) ?? 0;
+        }
+      }
 
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -248,7 +248,6 @@ export const statusPageRouter = createTRPCRouter({
         };
       });
 
-
       // Add privateLocationCount to each monitor
       if (monitors.length > 0) {
         const monitorIds = monitors.map((m) => m.id);
@@ -279,7 +278,6 @@ export const statusPageRouter = createTRPCRouter({
             privateLocationCounts.get(monitor.id) ?? 0;
         }
       }
-
 
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -281,7 +281,9 @@ export const statusPageRouter = createTRPCRouter({
 
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show
-      const status = monitorsWithPrivateLocationCount.some((m) => m.status === "error")
+      const status = monitorsWithPrivateLocationCount.some(
+        (m) => m.status === "error",
+      )
         ? "error"
         : monitorsWithPrivateLocationCount.some((m) => m.status === "degraded")
           ? "degraded"
@@ -465,7 +467,8 @@ export const statusPageRouter = createTRPCRouter({
         monitors: monitorsWithPrivateLocationCount,
         monitorGroups,
         trackers,
-        incidents: monitorsWithPrivateLocationCount.flatMap((m) => m.incidents) ?? [],
+        incidents:
+          monitorsWithPrivateLocationCount.flatMap((m) => m.incidents) ?? [],
         statusReports,
         maintenances,
         workspacePlan: _page.workspace.plan,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -5,6 +5,7 @@ import {
   page,
   pageComponent,
   pageConfigurationSchema,
+  privateLocationToMonitors,
   selectMaintenancePageSchema,
   selectPageComponentWithMonitorRelation,
   selectPageSchema,
@@ -272,7 +273,7 @@ export const statusPageRouter = createTRPCRouter({
 
         // Add count to each monitor
         for (const monitor of monitors) {
-          (monitor as any).privateLocationCount = privateLocationCounts.get(monitor.id) ?? 0;
+          (monitor as Record<string, unknown>).privateLocationCount = privateLocationCounts.get(monitor.id) ?? 0;
         }
       }
 

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -249,6 +249,7 @@ export const statusPageRouter = createTRPCRouter({
       });
 
       // Add privateLocationCount to each monitor
+      const privateLocationCounts = new Map<number, number>();
       if (monitors.length > 0) {
         const monitorIds = monitors.map((m) => m.id);
         const privateLocations =
@@ -263,7 +264,6 @@ export const statusPageRouter = createTRPCRouter({
           });
 
         // Count private locations per monitor
-        const privateLocationCounts = new Map<number, number>();
         for (const pl of privateLocations) {
           if (pl.monitorId === null) continue;
           privateLocationCounts.set(
@@ -271,21 +271,21 @@ export const statusPageRouter = createTRPCRouter({
             (privateLocationCounts.get(pl.monitorId) ?? 0) + 1,
           );
         }
-
-        // Add count to each monitor
-        for (const monitor of monitors) {
-          (monitor as Record<string, unknown>).privateLocationCount =
-            privateLocationCounts.get(monitor.id) ?? 0;
-        }
       }
+
+      // Create new array with privateLocationCount included (no mutation/cast)
+      const monitorsWithPrivateLocationCount = monitors.map((m) => ({
+        ...m,
+        privateLocationCount: privateLocationCounts.get(m.id) ?? 0,
+      }));
 
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show
-      const status = monitors.some((m) => m.status === "error")
+      const status = monitorsWithPrivateLocationCount.some((m) => m.status === "error")
         ? "error"
-        : monitors.some((m) => m.status === "degraded")
+        : monitorsWithPrivateLocationCount.some((m) => m.status === "degraded")
           ? "degraded"
-          : monitors.some((m) => m.status === "info")
+          : monitorsWithPrivateLocationCount.some((m) => m.status === "info")
             ? "info"
             : "success";
 
@@ -462,10 +462,10 @@ export const statusPageRouter = createTRPCRouter({
       return selectPublicPageSchemaWithRelation.parse({
         ..._page,
         customTheme,
-        monitors,
+        monitors: monitorsWithPrivateLocationCount,
         monitorGroups,
         trackers,
-        incidents: monitors.flatMap((m) => m.incidents) ?? [],
+        incidents: monitorsWithPrivateLocationCount.flatMap((m) => m.incidents) ?? [],
         statusReports,
         maintenances,
         workspacePlan: _page.workspace.plan,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -251,15 +251,16 @@ export const statusPageRouter = createTRPCRouter({
       // Add privateLocationCount to each monitor
       if (monitors.length > 0) {
         const monitorIds = monitors.map((m) => m.id);
-        const privateLocations = await opts.ctx.db.query.privateLocationToMonitors.findMany({
-          where: and(
-            inArray(privateLocationToMonitors.monitorId, monitorIds),
-            isNull(privateLocationToMonitors.deletedAt)
-          ),
-          columns: {
-            monitorId: true,
-          },
-        });
+        const privateLocations =
+          await opts.ctx.db.query.privateLocationToMonitors.findMany({
+            where: and(
+              inArray(privateLocationToMonitors.monitorId, monitorIds),
+              isNull(privateLocationToMonitors.deletedAt),
+            ),
+            columns: {
+              monitorId: true,
+            },
+          });
 
         // Count private locations per monitor
         const privateLocationCounts = new Map<number, number>();
@@ -267,13 +268,14 @@ export const statusPageRouter = createTRPCRouter({
           if (pl.monitorId === null) continue;
           privateLocationCounts.set(
             pl.monitorId,
-            (privateLocationCounts.get(pl.monitorId) ?? 0) + 1
+            (privateLocationCounts.get(pl.monitorId) ?? 0) + 1,
           );
         }
 
         // Add count to each monitor
         for (const monitor of monitors) {
-          (monitor as Record<string, unknown>).privateLocationCount = privateLocationCounts.get(monitor.id) ?? 0;
+          (monitor as Record<string, unknown>).privateLocationCount =
+            privateLocationCounts.get(monitor.id) ?? 0;
         }
       }
 

--- a/packages/api/src/router/statusPage.utils.test.ts
+++ b/packages/api/src/router/statusPage.utils.test.ts
@@ -59,7 +59,7 @@ function createStatusData(
 function createIncident(id: number, daysAgo: number, durationHours = 1): Event {
   const from = new Date();
   from.setDate(from.getDate() - daysAgo);
-  from.setUTCHours(12, 0, 0, 0); // Set to noon UTC for reliable overlap
+  from.setUTCHours(0, 0, 0, 0); // Set to midnight UTC for full-day coverage
 
   const to = new Date(from);
   to.setUTCHours(from.getUTCHours() + durationHours);
@@ -77,7 +77,7 @@ function createIncident(id: number, daysAgo: number, durationHours = 1): Event {
 function createReport(id: number, daysAgo: number, durationHours = 2): Event {
   const from = new Date();
   from.setDate(from.getDate() - daysAgo);
-  from.setUTCHours(12, 0, 0, 0); // Set to noon UTC for reliable overlap
+  from.setUTCHours(0, 0, 0, 0); // Set to midnight UTC for full-day coverage
 
   const to = new Date(from);
   to.setUTCHours(from.getUTCHours() + durationHours);
@@ -99,7 +99,7 @@ function createMaintenance(
 ): Event {
   const from = new Date();
   from.setDate(from.getDate() - daysAgo);
-  from.setUTCHours(12, 0, 0, 0); // Set to noon UTC for reliable overlap
+  from.setUTCHours(0, 0, 0, 0); // Set to midnight UTC for full-day coverage
 
   const to = new Date(from);
   to.setUTCHours(from.getUTCHours() + durationHours);

--- a/packages/api/src/router/statusPage.utils.test.ts
+++ b/packages/api/src/router/statusPage.utils.test.ts
@@ -59,10 +59,10 @@ function createStatusData(
 function createIncident(id: number, daysAgo: number, durationHours = 1): Event {
   const from = new Date();
   from.setDate(from.getDate() - daysAgo);
-  from.setHours(from.getHours() - durationHours);
+  from.setUTCHours(12, 0, 0, 0); // Set to noon UTC for reliable overlap
 
   const to = new Date(from);
-  to.setHours(to.getHours() + durationHours);
+  to.setUTCHours(from.getUTCHours() + durationHours);
 
   return {
     id,
@@ -77,10 +77,10 @@ function createIncident(id: number, daysAgo: number, durationHours = 1): Event {
 function createReport(id: number, daysAgo: number, durationHours = 2): Event {
   const from = new Date();
   from.setDate(from.getDate() - daysAgo);
-  from.setHours(from.getHours() - durationHours);
+  from.setUTCHours(12, 0, 0, 0); // Set to noon UTC for reliable overlap
 
   const to = new Date(from);
-  to.setHours(to.getHours() + durationHours);
+  to.setUTCHours(from.getUTCHours() + durationHours);
 
   return {
     id,
@@ -99,10 +99,10 @@ function createMaintenance(
 ): Event {
   const from = new Date();
   from.setDate(from.getDate() - daysAgo);
-  from.setHours(from.getHours() - durationHours);
+  from.setUTCHours(12, 0, 0, 0); // Set to noon UTC for reliable overlap
 
   const to = new Date(from);
-  to.setHours(to.getHours() + durationHours);
+  to.setUTCHours(from.getUTCHours() + durationHours);
 
   return {
     id,

--- a/packages/db/src/schema/shared.ts
+++ b/packages/db/src/schema/shared.ts
@@ -95,6 +95,7 @@ const selectPublicMonitorWithStatusSchema = selectPublicMonitorBaseSchema
     monitorGroupId: z.number().nullable().optional(),
     order: z.number().default(0).optional(),
     groupOrder: z.number().default(0).nullish(),
+    privateLocationCount: z.number().optional(),
   })
   .transform((data) => ({
     ...data,


### PR DESCRIPTION
Includes private locations in region count for Region Latency (fixes "0 regions")
Fixes bug where graph only shows 1 region even if there is more than one private location probe
Resolves #2497 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

