### PR TITLE
fix: display actual monitor status in dashboard sidebar

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
@@ -38,8 +38,19 @@ export function Sidebar() {
             },
             {
               label: "Status",
-              // FIXME: dynamic
-              value: <span className="text-success">Normal</span>,
+              value: (
+                <span
+                  className={
+                    monitor.status === "error"
+                      ? "text-destructive"
+                      : monitor.status === "degraded"
+                        ? "text-warning"
+                        : "text-success"
+                  }
+                >
+                  {monitor.status.charAt(0).toUpperCase() + monitor.status.slice(1)}
+                </span>
+              ),
             },
             {
               label: "Type",

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
@@ -48,7 +48,8 @@ export function Sidebar() {
                         : "text-success"
                   }
                 >
-                  {monitor.status.charAt(0).toUpperCase() + monitor.status.slice(1)}
+                  {monitor.status.charAt(0).toUpperCase() +
+                    monitor.status.slice(1)}
                 </span>
               ),
             },


### PR DESCRIPTION
- Replaced hardcoded status with dynamic monitor.status
- Added color styling: error (red), degraded (yellow), active (green)
- Fixes issue where private location monitor status wasn't reflected in UI

Resolves #2504 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

