### PR TITLE
fix: dashboard missing Regions info for private location http monitors

### DIFF
--- a/apps/workflows/src/checker/private-location.ts
+++ b/apps/workflows/src/checker/private-location.ts
@@ -47,7 +47,9 @@ export async function updateStatusPrivate(c: Context<Env>) {
   const monitorIdNumber = Number(monitorId);
   const privateLocationIdNumber = Number(privateLocationId);
 
-  // Set event data for Tinybird ingestion (matches cloud checker pattern)
+  // Set event data for OTel/Axiom structured logging (matches cloud checker pattern)
+  // Note: Private location pings are ingested to Tinybird separately via Go code in
+  // apps/private-location/internal/tinybird/client.go, not through this event object
   if (event) {
     event.status_update = {
       status: status,

--- a/apps/workflows/src/checker/private-location.ts
+++ b/apps/workflows/src/checker/private-location.ts
@@ -166,6 +166,9 @@ export async function updateStatusPrivate(c: Context<Env>) {
 
     const regions = [attachment.name];
 
+    let triggeredNotifications: { notificationId: number; provider: string }[] =
+      [];
+
     switch (status) {
       case "error":
         await checkerAudit.publishAuditLog({
@@ -180,7 +183,7 @@ export async function updateStatusPrivate(c: Context<Env>) {
             latency,
           },
         });
-        await triggerNotifications({
+        triggeredNotifications = await triggerNotifications({
           monitorId,
           statusCode,
           message,
@@ -202,7 +205,7 @@ export async function updateStatusPrivate(c: Context<Env>) {
             latency,
           },
         });
-        await triggerNotifications({
+        triggeredNotifications = await triggerNotifications({
           monitorId,
           statusCode,
           message,
@@ -224,7 +227,7 @@ export async function updateStatusPrivate(c: Context<Env>) {
             latency,
           },
         });
-        await triggerNotifications({
+        triggeredNotifications = await triggerNotifications({
           monitorId,
           statusCode,
           message,
@@ -235,6 +238,12 @@ export async function updateStatusPrivate(c: Context<Env>) {
         });
         break;
     }
+
+    // Add notification outcome to event for OTel logging
+    (event.status_update as Record<string, unknown>).notificationTriggered =
+      triggeredNotifications.length > 0;
+    (event.status_update as Record<string, unknown>).notifications =
+      triggeredNotifications;
 
     return c.json({ success: true }, 200);
   } catch (error) {

--- a/apps/workflows/src/checker/private-location.ts
+++ b/apps/workflows/src/checker/private-location.ts
@@ -48,15 +48,17 @@ export async function updateStatusPrivate(c: Context<Env>) {
   const privateLocationIdNumber = Number(privateLocationId);
 
   // Set event data for Tinybird ingestion (matches cloud checker pattern)
-  event.status_update = {
-    status: status,
-    message: message,
-    region: privateLocationId, // Private location ID as region string
-    status_code: statusCode,
-    cron_timestamp: cronTimestamp,
-    latency_ms: latency,
-    monitorId: monitorIdNumber,
-  };
+  if (event) {
+    event.status_update = {
+      status: status,
+      message: message,
+      region: privateLocationId, // Private location ID as region string
+      status_code: statusCode,
+      cron_timestamp: cronTimestamp,
+      latency_ms: latency,
+      monitorId: monitorIdNumber,
+    };
+  }
 
   try {
     const monitor = await db
@@ -240,10 +242,12 @@ export async function updateStatusPrivate(c: Context<Env>) {
     }
 
     // Add notification outcome to event for OTel logging
-    (event.status_update as Record<string, unknown>).notificationTriggered =
-      triggeredNotifications.length > 0;
-    (event.status_update as Record<string, unknown>).notifications =
-      triggeredNotifications;
+    if (event?.status_update) {
+      (event.status_update as Record<string, unknown>).notificationTriggered =
+        triggeredNotifications.length > 0;
+      (event.status_update as Record<string, unknown>).notifications =
+        triggeredNotifications;
+    }
 
     return c.json({ success: true }, 200);
   } catch (error) {

--- a/apps/workflows/src/checker/private-location.ts
+++ b/apps/workflows/src/checker/private-location.ts
@@ -43,8 +43,20 @@ export async function updateStatusPrivate(c: Context<Env>) {
     latency,
   } = result.data;
 
+  const event = c.get("event");
   const monitorIdNumber = Number(monitorId);
   const privateLocationIdNumber = Number(privateLocationId);
+
+  // Set event data for Tinybird ingestion (matches cloud checker pattern)
+  event.status_update = {
+    status: status,
+    message: message,
+    region: privateLocationId, // Private location ID as region string
+    status_code: statusCode,
+    cron_timestamp: cronTimestamp,
+    latency_ms: latency,
+    monitorId: monitorIdNumber,
+  };
 
   try {
     const monitor = await db

--- a/packages/tinybird/endpoints/endpoint__http_metrics_regions_14d__v0.pipe
+++ b/packages/tinybird/endpoints/endpoint__http_metrics_regions_14d__v0.pipe
@@ -13,7 +13,7 @@ SQL >
         round(quantile(0.90)(latency)) as p90Latency,
         round(quantile(0.95)(latency)) as p95Latency,
         round(quantile(0.99)(latency)) as p99Latency
-    FROM mv__http_14d__v0
+    FROM mv__http_14d__v1
     WHERE
         monitorId = {{ String(monitorId, '1', required=True) }}
         {% if regions %} AND region IN {{ Array(regions, 'String', 'ams,fra') }} {% end %}

--- a/packages/tinybird/endpoints/endpoint__http_metrics_regions_1d__v0.pipe
+++ b/packages/tinybird/endpoints/endpoint__http_metrics_regions_1d__v0.pipe
@@ -13,7 +13,7 @@ SQL >
         round(quantile(0.90)(latency)) as p90Latency,
         round(quantile(0.95)(latency)) as p95Latency,
         round(quantile(0.99)(latency)) as p99Latency
-    FROM mv__http_1d__v0
+    FROM mv__http_1d__v1
     WHERE
         monitorId = {{ String(monitorId, '1', required=True) }}
         {% if regions %} AND region IN {{ Array(regions, 'String', 'ams,fra') }} {% end %}


### PR DESCRIPTION
Partially resolves #2506 
<img width="480" height="404" alt="image" src="https://github.com/user-attachments/assets/3026ad71-df66-48f4-88ad-fd8f475157de" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

