### PR TITLE
fix(dashboard): include private locations in monitor sidebar regions

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
@@ -58,10 +58,17 @@ export function Sidebar() {
             },
             {
               label: "Regions",
-              value:
-                monitor.regions.length > 6
-                  ? `${monitor.regions.length} regions`
-                  : monitor.regions.join(", "),
+              value: (() => {
+                const allRegions = [
+                  ...monitor.regions,
+                  ...(monitor.privateLocations?.map((location) =>
+                    location.id.toString(),
+                  ) ?? []),
+                ];
+                return allRegions.length > 6
+                  ? `${allRegions.length} regions`
+                  : allRegions.join(", ");
+              })(),
             },
             {
               label: "Tags",


### PR DESCRIPTION
Fixes issue where sidebar Regions section only showed cloud regions, appearing empty for private-only monitors.

Changes: Combined monitor.regions with monitor.privateLocations mapped to string IDs, matching the pattern used in the overview page.

The sidebar now shows all regions (cloud + private) with the same display logic (show count if more than 6, otherwise show comma-separated list).

Partially resolves #2506 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

