### PR TITLE
fix: private location DNS monitoring

### DIFF
--- a/apps/checker/handlers/dns.go
+++ b/apps/checker/handlers/dns.go
@@ -25,7 +25,7 @@ type DNSResponse struct {
 	Trigger       string `json:"trigger"`
 	URI           string `json:"uri"`
 	RequestStatus string `json:"requestStatus,omitempty"`
-	Assertions    string `json:"assertions"`
+	Assertions    string `json:"timing"`
 
 	Records map[string][]string `json:"records"`
 

--- a/apps/checker/handlers/dns.go
+++ b/apps/checker/handlers/dns.go
@@ -25,7 +25,7 @@ type DNSResponse struct {
 	Trigger       string `json:"trigger"`
 	URI           string `json:"uri"`
 	RequestStatus string `json:"requestStatus,omitempty"`
-	Assertions    string `json:"timing"`
+	Timing        string `json:"timing"`
 
 	Records map[string][]string `json:"records"`
 

--- a/apps/checker/handlers/dns.go
+++ b/apps/checker/handlers/dns.go
@@ -25,6 +25,7 @@ type DNSResponse struct {
 	Trigger       string `json:"trigger"`
 	URI           string `json:"uri"`
 	RequestStatus string `json:"requestStatus,omitempty"`
+	Assertions    string `json:"assertions"`
 	Timing        string `json:"timing"`
 
 	Records map[string][]string `json:"records"`

--- a/apps/private-location/internal/server/ingest_dns.go
+++ b/apps/private-location/internal/server/ingest_dns.go
@@ -12,7 +12,7 @@ import (
 
 type DNSResponse struct {
 	ID            string `json:"id"`
-	Timing        string `json:"timing"`
+	Timing        string `json:"assertions"`
 	ErrorMessage  string `json:"errorMessage"`
 	Region        string `json:"region"`
 	Trigger       string `json:"trigger"`

--- a/apps/private-location/internal/server/ingest_dns.go
+++ b/apps/private-location/internal/server/ingest_dns.go
@@ -12,7 +12,7 @@ import (
 
 type DNSResponse struct {
 	ID            string `json:"id"`
-	Timing        string `json:"assertions"`
+	Timing        string `json:"timing"`
 	ErrorMessage  string `json:"errorMessage"`
 	Region        string `json:"region"`
 	Trigger       string `json:"trigger"`

--- a/apps/private-location/internal/tinybird/client.go
+++ b/apps/private-location/internal/tinybird/client.go
@@ -14,7 +14,7 @@ import (
 const (
 	DatasourceHTTP = "ping_response__v8"
 	DatasourceTCP  = "tcp_response__v0"
-	DatasourceDNS  = "tcp_dns__v0"
+	DatasourceDNS  = "dns_response__v0"
 )
 
 func getBaseURL() string {

--- a/packages/tinybird/datasources/dns_response__v0.datasource
+++ b/packages/tinybird/datasources/dns_response__v0.datasource
@@ -1,6 +1,6 @@
 
 SCHEMA >
-    `assertions` String `json:$.assertions`,
+    `timing` String `json:$.timing`,
     `cronTimestamp` Int64 `json:$.cronTimestamp`,
     `error` Int16 `json:$.error`,
     `errorMessage` String `json:$.errorMessage`,

--- a/packages/tinybird/datasources/dns_response__v0.datasource
+++ b/packages/tinybird/datasources/dns_response__v0.datasource
@@ -1,5 +1,6 @@
 
 SCHEMA >
+    `assertions` String `json:$.assertions`,
     `timing` String `json:$.timing`,
     `cronTimestamp` Int64 `json:$.cronTimestamp`,
     `error` Int16 `json:$.error`,


### PR DESCRIPTION
Fixes DNS monitors from private locations ingesting data to a non-existent datasource, and changed the DNS field name from `timing` to `assertions`

Resolves #2509 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

