### PR TITLE
fix: dns assertions nullable

### DIFF
--- a/apps/private-location/internal/server/ingest_dns.go
+++ b/apps/private-location/internal/server/ingest_dns.go
@@ -26,13 +26,8 @@ type DNSResponse struct {
 	WorkspaceID   int64 `json:"workspaceId"`
 	MonitorID     int64 `json:"monitorId"`
 	Timestamp     int64 `json:"timestamp"`
-<<<<<<< Updated upstream
 	Latency       int64 `json:"latency"`
 	CronTimestamp int64 `json:"cronTimestamp"`
-=======
-	Latency       int64  `json:"latency"`
-	CronTimestamp int64  `json:"cronTimestamp"`
->>>>>>> Stashed changes
 
 	Error uint8 `json:"error"`
 }
@@ -81,10 +76,6 @@ func (h *privateLocationHandler) IngestDNS(ctx context.Context, req *connect.Req
 		Error:         uint8(req.Msg.Error),
 		Region:        strconv.Itoa(ic.Region.ID),
 		MonitorID:     int64(ic.Monitor.ID),
-<<<<<<< Updated upstream
-=======
-		Assertions:    ic.Monitor.Assertions.String,
->>>>>>> Stashed changes
 		Timing:        req.Msg.Timing,
 		Latency:       req.Msg.Latency,
 		CronTimestamp: req.Msg.CronTimestamp,

--- a/apps/private-location/internal/server/ingest_dns.go
+++ b/apps/private-location/internal/server/ingest_dns.go
@@ -26,8 +26,13 @@ type DNSResponse struct {
 	WorkspaceID   int64 `json:"workspaceId"`
 	MonitorID     int64 `json:"monitorId"`
 	Timestamp     int64 `json:"timestamp"`
+<<<<<<< Updated upstream
 	Latency       int64 `json:"latency"`
 	CronTimestamp int64 `json:"cronTimestamp"`
+=======
+	Latency       int64  `json:"latency"`
+	CronTimestamp int64  `json:"cronTimestamp"`
+>>>>>>> Stashed changes
 
 	Error uint8 `json:"error"`
 }
@@ -76,6 +81,10 @@ func (h *privateLocationHandler) IngestDNS(ctx context.Context, req *connect.Req
 		Error:         uint8(req.Msg.Error),
 		Region:        strconv.Itoa(ic.Region.ID),
 		MonitorID:     int64(ic.Monitor.ID),
+<<<<<<< Updated upstream
+=======
+		Assertions:    ic.Monitor.Assertions.String,
+>>>>>>> Stashed changes
 		Timing:        req.Msg.Timing,
 		Latency:       req.Msg.Latency,
 		CronTimestamp: req.Msg.CronTimestamp,

--- a/packages/tinybird/datasources/dns_response__v0.datasource
+++ b/packages/tinybird/datasources/dns_response__v0.datasource
@@ -1,6 +1,6 @@
 
 SCHEMA >
-    `assertions` String `json:$.assertions`,
+    `assertions` Nullable(String) `json:$.assertions`,
     `timing` String `json:$.timing`,
     `cronTimestamp` Int64 `json:$.cronTimestamp`,
     `error` Int16 `json:$.error`,


### PR DESCRIPTION
DNS data was being quarantined because assertions was required but not sent

Resolves #2513 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

