### PR TITLE
fix(dashboard): change hard-coded badge url to show custom domains

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/sidebar.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/sidebar.tsx
@@ -26,7 +26,9 @@ export function Sidebar() {
 
   if (!statusPage) return null;
 
-  const BADGE_URL = `https://${statusPage.slug}.openstatus.dev/badge/v2`;
+  const BADGE_URL = `https://${
+    statusPage.customDomain || `${statusPage.slug}.openstatus.dev`
+  }/badge/v2`;
 
   return (
     <SidebarRight


### PR DESCRIPTION
Affects both self-hosted and SaaS. Updates the badge URL in the dashboard to point to custom domains if available.
Resolves #2516 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

