### PR TITLE
feat: add memory limits to docker-compose files for self-hosted

### DIFF
--- a/docker-compose-lightweight.yaml
+++ b/docker-compose-lightweight.yaml
@@ -32,6 +32,7 @@ services:
             retries: 5
             start_period: 10s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -89,6 +90,7 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -125,6 +127,7 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:

--- a/docker-compose-lightweight.yaml
+++ b/docker-compose-lightweight.yaml
@@ -32,6 +32,12 @@ services:
             retries: 5
             start_period: 10s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     # Idempotent: drizzle skips already-applied migrations on every up
     db-migrate:
@@ -83,6 +89,12 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     status-page:
         container_name: openstatus-status-page
@@ -113,3 +125,9 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -59,13 +59,6 @@ services:
             retries: 5
             start_period: 20s
         restart: unless-stopped
-        memswap_limit: 1G
-        deploy:
-            resources:
-                limits:
-                    memory: 1G
-                reservations:
-                    memory: 512M
 
     # Internal Services - Using GitHub Packages
     # Idempotent: drizzle skips already-applied migrations on every up.

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -34,6 +34,12 @@ services:
             retries: 5
             start_period: 10s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     tinybird-local:
         container_name: openstatus-tinybird
@@ -52,6 +58,12 @@ services:
             retries: 5
             start_period: 20s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 1G
+                reservations:
+                    memory: 512M
 
     # Internal Services - Using GitHub Packages
     # Idempotent: drizzle skips already-applied migrations on every up.
@@ -104,6 +116,12 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     server:
         container_name: openstatus-server
@@ -131,6 +149,12 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     private-location:
         container_name: openstatus-private-location
@@ -164,6 +188,12 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 256M
+                reservations:
+                    memory: 128M
 
     checker:
         container_name: openstatus-checker
@@ -187,6 +217,12 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 256M
+                reservations:
+                    memory: 128M
 
     dashboard:
         container_name: openstatus-dashboard
@@ -218,6 +254,12 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     status-page:
         container_name: openstatus-status-page
@@ -249,3 +291,9 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -23,6 +23,9 @@ services:
             - libsql-data:/var/lib/sqld
         environment:
             - SQLD_NODE=primary
+            # Increase limits to handle multiple services without connection pooling
+            - SQLD_MAX_CONCURRENT_CONNECTIONS=512
+            - SQLD_MAX_CONCURRENT_REQUESTS=1024
         healthcheck:
             test:
                 [

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -34,6 +34,7 @@ services:
             retries: 5
             start_period: 10s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -58,6 +59,7 @@ services:
             retries: 5
             start_period: 20s
         restart: unless-stopped
+        memswap_limit: 1G
         deploy:
             resources:
                 limits:
@@ -116,6 +118,7 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -149,6 +152,7 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -188,6 +192,7 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        memswap_limit: 256M
         deploy:
             resources:
                 limits:
@@ -217,6 +222,7 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        memswap_limit: 256M
         deploy:
             resources:
                 limits:
@@ -254,6 +260,7 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -291,6 +298,7 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,12 @@ services:
             retries: 5
             start_period: 10s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     tinybird-local:
         container_name: openstatus-tinybird
@@ -52,6 +58,12 @@ services:
             retries: 5
             start_period: 20s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 1G
+                reservations:
+                    memory: 512M
 
     # Internal Services
     # Idempotent: drizzle skips already-applied migrations on every up
@@ -104,6 +116,12 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     server:
         container_name: openstatus-server
@@ -134,6 +152,12 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     private-location:
         container_name: openstatus-private-location
@@ -170,6 +194,12 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 256M
+                reservations:
+                    memory: 128M
 
     dashboard:
         container_name: openstatus-dashboard
@@ -204,6 +234,12 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M
 
     status-page:
         container_name: openstatus-status-page
@@ -238,3 +274,9 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        deploy:
+            resources:
+                limits:
+                    memory: 512M
+                reservations:
+                    memory: 256M

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,12 +23,9 @@ services:
             - libsql-data:/var/lib/sqld
         environment:
             - SQLD_NODE=primary
-            # Limit concurrent connections to prevent exhaustion
-            - SQLD_MAX_CONCURRENT_CONNECTIONS=100
-            # Limit concurrent requests per connection
-            - SQLD_MAX_CONCURRENT_REQUESTS=10
-            # Close idle connections after 5 minutes
-            - SQLD_IDLE_SHUTDOWN_TIMEOUT=300
+            # Increase limits to handle multiple services without connection pooling
+            - SQLD_MAX_CONCURRENT_CONNECTIONS=512
+            - SQLD_MAX_CONCURRENT_REQUESTS=1024
         healthcheck:
             test:
                 [
@@ -45,10 +42,10 @@ services:
             resources:
                 limits:
                     memory: 512M
-                    cpus: '2.0'
+                    cpus: '4.0'
                 reservations:
                     memory: 256M
-                    cpus: '1.0'
+                    cpus: '2.0'
 
     tinybird-local:
         container_name: openstatus-tinybird

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,10 +42,8 @@ services:
             resources:
                 limits:
                     memory: 512M
-                    cpus: '4.0'
                 reservations:
                     memory: 256M
-                    cpus: '2.0'
 
     tinybird-local:
         container_name: openstatus-tinybird

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,13 +59,6 @@ services:
             retries: 5
             start_period: 20s
         restart: unless-stopped
-        memswap_limit: 1G
-        deploy:
-            resources:
-                limits:
-                    memory: 1G
-                reservations:
-                    memory: 512M
 
     # Internal Services
     # Idempotent: drizzle skips already-applied migrations on every up

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,12 @@ services:
             - libsql-data:/var/lib/sqld
         environment:
             - SQLD_NODE=primary
+            # Limit concurrent connections to prevent exhaustion
+            - SQLD_MAX_CONCURRENT_CONNECTIONS=100
+            # Limit concurrent requests per connection
+            - SQLD_MAX_CONCURRENT_REQUESTS=10
+            # Close idle connections after 5 minutes
+            - SQLD_IDLE_SHUTDOWN_TIMEOUT=300
         healthcheck:
             test:
                 [
@@ -39,8 +45,10 @@ services:
             resources:
                 limits:
                     memory: 512M
+                    cpus: '2.0'
                 reservations:
                     memory: 256M
+                    cpus: '1.0'
 
     tinybird-local:
         container_name: openstatus-tinybird

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
             retries: 5
             start_period: 10s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -58,6 +59,7 @@ services:
             retries: 5
             start_period: 20s
         restart: unless-stopped
+        memswap_limit: 1G
         deploy:
             resources:
                 limits:
@@ -116,6 +118,7 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -152,6 +155,7 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -194,6 +198,7 @@ services:
             retries: 3
             start_period: 30s
         restart: unless-stopped
+        memswap_limit: 256M
         deploy:
             resources:
                 limits:
@@ -234,6 +239,7 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:
@@ -274,6 +280,7 @@ services:
             retries: 3
             start_period: 45s
         restart: unless-stopped
+        memswap_limit: 512M
         deploy:
             resources:
                 limits:

--- a/packages/tinybird/scripts/backfill_external_status_v0_to_v1.ts
+++ b/packages/tinybird/scripts/backfill_external_status_v0_to_v1.ts
@@ -115,7 +115,7 @@ async function loadNameToSlugMap(): Promise<Map<string, string>> {
     authToken: env.DATABASE_AUTH_TOKEN,
   });
   const db = drizzle(client);
-  
+
   try {
     const rows = await db
       .select({ name: externalService.name, slug: externalService.slug })

--- a/packages/tinybird/scripts/backfill_external_status_v0_to_v1.ts
+++ b/packages/tinybird/scripts/backfill_external_status_v0_to_v1.ts
@@ -115,17 +115,22 @@ async function loadNameToSlugMap(): Promise<Map<string, string>> {
     authToken: env.DATABASE_AUTH_TOKEN,
   });
   const db = drizzle(client);
-  const rows = await db
-    .select({ name: externalService.name, slug: externalService.slug })
-    .from(externalService)
-    .where(isNotNull(externalService.slug))
-    .all();
-  const map = new Map<string, string>();
-  for (const r of rows) {
-    map.set(r.name, r.slug);
+  
+  try {
+    const rows = await db
+      .select({ name: externalService.name, slug: externalService.slug })
+      .from(externalService)
+      .where(isNotNull(externalService.slug))
+      .all();
+    const map = new Map<string, string>();
+    for (const r of rows) {
+      map.set(r.name, r.slug);
+    }
+    console.log(`[backfill] loaded ${map.size} name→slug mappings from libSQL`);
+    return map;
+  } finally {
+    client.close();
   }
-  console.log(`[backfill] loaded ${map.size} name→slug mappings from libSQL`);
-  return map;
 }
 
 function rowsToSnapshots(args: {


### PR DESCRIPTION
Add resource limits to all docker-compose configurations to prevent unbounded memory growth and improve stability on resource-constrained self-hosted deployments.

Memory limits are based on the existing Coolify deployment configuration:
- libsql: 512M limit / 256M reservation
- tinybird-local: 1G limit / 512M reservation
- workflows: 512M limit / 256M reservation
- server: 512M limit / 256M reservation
- private-location: 256M limit / 128M reservation
- checker: 256M limit / 128M reservation
- dashboard: 512M limit / 256M reservation
- status-page: 512M limit / 256M reservation

This prevents swap thrashing and improves OOM handling on systems with limited memory, addressing issues where LibSQL connection timeouts occur due to severe memory pressure.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

