### PR TITLE
docs: remove outdated private location limitations from guide

### DIFF
--- a/apps/web/src/content/pages/docs/guides/how-to-create-private-location.mdx
+++ b/apps/web/src/content/pages/docs/guides/how-to-create-private-location.mdx
@@ -13,7 +13,7 @@ description: "Set up monitoring from your own infrastructure using Docker-based 
 
 In this guide, you'll set up a **private location** — a monitoring probe running on your own infrastructure. This lets you monitor internal applications, private APIs, and network resources behind your firewall without exposing them to the public internet.
 
-<Aside type="caution">Private locations are currently in **beta**. Some features like incident creation and public status page support are not yet available for private locations.</Aside>
+<Aside type="caution">Private locations are currently in **beta**.</Aside>
 
 For background on when to use a private location and how the connection works, see [Understanding private locations](/docs/concept/private-locations).
 
@@ -69,10 +69,6 @@ abc123         ghcr.io/openstatushq/private-location:latest   Up 2 minutes   ope
 - Deployed a monitoring probe on your own infrastructure
 - Assigned monitors to check from your private location
 
-## Current limitations
-
-- Incidents are **not yet created** for monitors running via private locations. Continue using openstatus public regions if you need alerting.
-- Public monitors on status pages **do not yet support** private locations.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Removed mentions of incident creation and status page support being unavailable, as these features are now supported for private locations.

Changes:
- Removed limitation text from intro caution aside
- Removed entire 'Current limitations' section

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

