### PR TITLE
ci: gate proto PRs on buf breaking check

### DIFF
--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -7,6 +7,7 @@ on:
       - "packages/proto/**"
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "packages/proto/**"
 
@@ -21,6 +22,9 @@ jobs:
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
+        with:
+          # breaking check resolves --against against the PR base commit
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -50,6 +54,11 @@ jobs:
       - name: 🧹 Lint api protos
         working-directory: ./packages/proto
         run: pnpm buf:lint:api
+
+      - name: 🔍 Breaking change check
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'buf skip breaking')
+        working-directory: ./packages/proto
+        run: pnpm exec buf breaking api --against "../../.git#ref=${{ github.event.pull_request.base.sha }},subdir=packages/proto/api"
 
       - name: 🔄 Regenerate proto files
         working-directory: ./packages/proto


### PR DESCRIPTION
## Problem

`packages/proto/buf.yaml` has declared a breaking-change ruleset since it was created:

```yaml
breaking:
  use:
    - FILE
```

Nothing ever invokes it. `proto-check.yml` runs `buf lint api`, regenerates, and checks for uncommitted output — but never `buf breaking`. So the policy exists on paper only.

## What this adds

One step in `proto-check.yml`:

```yaml
- name: 🔍 Breaking change check
  if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'buf skip breaking')
  working-directory: ./packages/proto
  run: pnpm exec buf breaking api --against "../../.git#ref=${{ github.event.pull_request.base.sha }},subdir=packages/proto/api"
```

Plus two supporting changes:
- `fetch-depth: 0` on checkout — the default shallow clone does not contain the PR base commit, so `--against` cannot resolve. `buf-push.yml` already sets this for the same reason.
- `types: [opened, synchronize, reopened, labeled, unlabeled]` on `pull_request` — without `labeled`/`unlabeled`, applying the skip label does not re-trigger the check and the PR stays red.

## Where it sits in the flow

```
proto PR touches packages/proto/**
  └─ proto-check.yml
       ├─ 🧹 pnpm buf:lint:api          (unchanged)
       ├─ 🔍 buf breaking                NEW — blocks the merge
       └─ 🔄 regenerate, fail if dirty  (unchanged)

merge to main
  └─ buf-push.yml  (unchanged)  →  BSR commit
                                    └─ SDK repos regenerate from it
```

The gate is the only thing between a breaking schema change and every downstream SDK. The BSR assigns each push a commit id, not a semantic version — nothing downstream can tell a breaking change from an additive one.

## Verification

Run against #2448, both sides pinned to that PR:

```
$ buf breaking api --against '.git#ref=514f9074^,subdir=packages/proto/api'
dns_monitor.proto:66:3: Field "10" with name "active" on message "DNSMonitor" changed cardinality
  from "optional with implicit presence" to "optional with explicit presence".
... 9 violations
EXIT=100
```

Nine violations across `dns_monitor`, `http_monitor`, `tcp_monitor` — the `bool active = 10` → `optional bool active = 10` change. Under this gate that PR would have needed an explicit `buf skip breaking` label to land, leaving a record on the PR.

## Notes for review

- **Scoped to the `api` module deliberately.** `buf lint` over the whole workspace exits 100 with 10+ violations in `internal/private_location` (`monitorId` should be `lower_snake_case`, etc.). That is pre-existing and out of scope here; scoping to `api` matches what `buf:lint:api` already does.
- **No `bufbuild/*` action added.** buf is already a pinned `@bufbuild/buf` catalog devDependency invoked as `pnpm exec buf` throughout. Adding the action would introduce a second buf version that can drift from the pinned one.
- **No BSR token needed.** `--against` compares against the PR base commit in git, not the registry, so this also works on forks.
- **This changes the merge workflow for proto PRs.** Intentionally strict — `FILE` is the ruleset already configured. If the team wants to mutate `v1` in place during 0.x, `buf skip breaking` makes that a deliberate, recorded choice rather than a silent one.
