### PR TITLE
feat: add volume mounts to persist Tinybird data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,6 @@ apps/alerting-engine/tmp/
 
 .env.docker
 
-# Docker volume data (Tinybird ClickHouse, Redis, etc.)
-data/
-
 # UI Registry build output
 apps/web/public/r
 packages/ui/public/r

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ apps/alerting-engine/tmp/
 
 .env.docker
 
+# Docker volume data (Tinybird ClickHouse, Redis, etc.)
+data/
+
 # UI Registry build output
 apps/web/public/r
 packages/ui/public/r

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -8,6 +8,10 @@ volumes:
         name: openstatus-libsql-data
     workflows-data:
         name: openstatus-workflows-data
+    tinybird-clickhouse-data:
+        name: openstatus-tinybird-clickhouse-data
+    tinybird-redis-data:
+        name: openstatus-tinybird-redis-data
 
 services:
     # External services
@@ -46,8 +50,8 @@ services:
         environment:
             - COMPATIBILITY_MODE=1
         volumes:
-            - ./data/tinybird/clickhouse:/var/lib/clickhouse
-            - ./data/tinybird/redis:/redis-data
+            - tinybird-clickhouse-data:/var/lib/clickhouse
+            - tinybird-redis-data:/redis-data
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:7181/"]
             interval: 15s

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -45,6 +45,9 @@ services:
             - "7181:7181"
         environment:
             - COMPATIBILITY_MODE=1
+        volumes:
+            - ./data/tinybird/clickhouse:/var/lib/clickhouse
+            - ./data/tinybird/redis:/redis-data
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:7181/"]
             interval: 15s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,10 @@ volumes:
         name: openstatus-libsql-data
     workflows-data:
         name: openstatus-workflows-data
+    tinybird-clickhouse-data:
+        name: openstatus-tinybird-clickhouse-data
+    tinybird-redis-data:
+        name: openstatus-tinybird-redis-data
 
 services:
     # External services
@@ -46,8 +50,8 @@ services:
         environment:
             - COMPATIBILITY_MODE=1
         volumes:
-            - ./data/tinybird/clickhouse:/var/lib/clickhouse
-            - ./data/tinybird/redis:/redis-data
+            - tinybird-clickhouse-data:/var/lib/clickhouse
+            - tinybird-redis-data:/redis-data
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:7181/"]
             interval: 15s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,9 @@ services:
             - "7181:7181"
         environment:
             - COMPATIBILITY_MODE=1
+        volumes:
+            - ./data/tinybird/clickhouse:/var/lib/clickhouse
+            - ./data/tinybird/redis:/redis-data
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:7181/"]
             interval: 15s


### PR DESCRIPTION
Added volume mounts for Tinybird Local to persist data across container restarts and recreations:

- ./data/tinybird/clickhouse:/var/lib/clickhouse (ClickHouse database)
- ./data/tinybird/redis:/redis-data (Redis metadata)

Without these volumes, all Tinybird data (datasources, pipes, materialized views, and ingested data) is lost when the container is removed or updated.

This change is essential for production self-hosted deployments where Tinybird data needs to survive container lifecycle events.

Implemented in both docker-compose.yaml and docker-compose.github-packages.yaml.

Based on docs: https://www.tinybird.co/docs/forward/core-concepts/tinybird-local#persist-local-data

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

