### PR TITLE
fix: correct monitor sorting by group and groupOrder on /monitors page

### DIFF
--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
@@ -34,6 +34,17 @@ export default function Page() {
 
   if (!page) return null;
 
+  // Precompute group minimum order map for O(n log n) sorting performance
+  const groupMinOrderMap = new Map<number, number>();
+  for (const monitor of page.monitors) {
+    const groupId = monitor.monitorGroupId;
+    if (groupId !== null) {
+      const order = monitor.order ?? 0;
+      const currentMin = groupMinOrderMap.get(groupId) ?? Number.MAX_SAFE_INTEGER;
+      groupMinOrderMap.set(groupId, Math.min(currentMin, order));
+    }
+  }
+
   const publicMonitors = page.monitors
     .filter((monitor) => monitor.public)
     .sort((a, b) => {
@@ -43,33 +54,26 @@ export default function Page() {
 
       // If both monitors are in the same group (or both ungrouped with null)
       if (aGroupId === bGroupId) {
-        // Sort by groupOrder within the group
+        if (aGroupId === null) {
+          // Both ungrouped - sort by order to match trackers behavior
+          return (a.order ?? 0) - (b.order ?? 0);
+        }
+        // Both in same group - sort by groupOrder within the group
         return (a.groupOrder ?? 0) - (b.groupOrder ?? 0);
       }
 
       // Different groups or one is ungrouped - sort by group position
-      // For grouped monitors, use the minimum order of all monitors in that group
+      // For grouped monitors, use precomputed minimum order of the group
       // For ungrouped monitors, use their own order
       const aGroupMinOrder =
-        aGroupId !== null
-          ? Math.min(
-              ...page.monitors
-                .filter((m) => m.monitorGroupId === aGroupId)
-                .map((m) => m.order ?? 0),
-            )
-          : (a.order ?? 0);
+        aGroupId !== null ? groupMinOrderMap.get(aGroupId) ?? 0 : (a.order ?? 0);
 
       const bGroupMinOrder =
-        bGroupId !== null
-          ? Math.min(
-              ...page.monitors
-                .filter((m) => m.monitorGroupId === bGroupId)
-                .map((m) => m.order ?? 0),
-            )
-          : (b.order ?? 0);
+        bGroupId !== null ? groupMinOrderMap.get(bGroupId) ?? 0 : (b.order ?? 0);
 
       return aGroupMinOrder - bGroupMinOrder;
     });
+
 
 
   return (

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
@@ -34,7 +34,43 @@ export default function Page() {
 
   if (!page) return null;
 
-  const publicMonitors = page.monitors.filter((monitor) => monitor.public);
+  const publicMonitors = page.monitors
+    .filter((monitor) => monitor.public)
+    .sort((a, b) => {
+      // Sort by group position first, then by groupOrder within each group
+      const aGroupId = a.monitorGroupId ?? null;
+      const bGroupId = b.monitorGroupId ?? null;
+
+      // If both monitors are in the same group (or both ungrouped with null)
+      if (aGroupId === bGroupId) {
+        // Sort by groupOrder within the group
+        return (a.groupOrder ?? 0) - (b.groupOrder ?? 0);
+      }
+
+      // Different groups or one is ungrouped - sort by group position
+      // For grouped monitors, use the minimum order of all monitors in that group
+      // For ungrouped monitors, use their own order
+      const aGroupMinOrder =
+        aGroupId !== null
+          ? Math.min(
+              ...page.monitors
+                .filter((m) => m.monitorGroupId === aGroupId)
+                .map((m) => m.order ?? 0),
+            )
+          : (a.order ?? 0);
+
+      const bGroupMinOrder =
+        bGroupId !== null
+          ? Math.min(
+              ...page.monitors
+                .filter((m) => m.monitorGroupId === bGroupId)
+                .map((m) => m.order ?? 0),
+            )
+          : (b.order ?? 0);
+
+      return aGroupMinOrder - bGroupMinOrder;
+    });
+
 
   return (
     <Status>

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
@@ -40,7 +40,8 @@ export default function Page() {
     const groupId = monitor.monitorGroupId;
     if (groupId !== null) {
       const order = monitor.order ?? 0;
-      const currentMin = groupMinOrderMap.get(groupId) ?? Number.MAX_SAFE_INTEGER;
+      const currentMin =
+        groupMinOrderMap.get(groupId) ?? Number.MAX_SAFE_INTEGER;
       groupMinOrderMap.set(groupId, Math.min(currentMin, order));
     }
   }
@@ -66,15 +67,17 @@ export default function Page() {
       // For grouped monitors, use precomputed minimum order of the group
       // For ungrouped monitors, use their own order
       const aGroupMinOrder =
-        aGroupId !== null ? groupMinOrderMap.get(aGroupId) ?? 0 : (a.order ?? 0);
+        aGroupId !== null
+          ? (groupMinOrderMap.get(aGroupId) ?? 0)
+          : (a.order ?? 0);
 
       const bGroupMinOrder =
-        bGroupId !== null ? groupMinOrderMap.get(bGroupId) ?? 0 : (b.order ?? 0);
+        bGroupId !== null
+          ? (groupMinOrderMap.get(bGroupId) ?? 0)
+          : (b.order ?? 0);
 
       return aGroupMinOrder - bGroupMinOrder;
     });
-
-
 
   return (
     <Status>

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/monitors/page.tsx
@@ -34,50 +34,8 @@ export default function Page() {
 
   if (!page) return null;
 
-  // Precompute group minimum order map for O(n log n) sorting performance
-  const groupMinOrderMap = new Map<number, number>();
-  for (const monitor of page.monitors) {
-    const groupId = monitor.monitorGroupId;
-    if (groupId !== null) {
-      const order = monitor.order ?? 0;
-      const currentMin =
-        groupMinOrderMap.get(groupId) ?? Number.MAX_SAFE_INTEGER;
-      groupMinOrderMap.set(groupId, Math.min(currentMin, order));
-    }
-  }
-
-  const publicMonitors = page.monitors
-    .filter((monitor) => monitor.public)
-    .sort((a, b) => {
-      // Sort by group position first, then by groupOrder within each group
-      const aGroupId = a.monitorGroupId ?? null;
-      const bGroupId = b.monitorGroupId ?? null;
-
-      // If both monitors are in the same group (or both ungrouped with null)
-      if (aGroupId === bGroupId) {
-        if (aGroupId === null) {
-          // Both ungrouped - sort by order to match trackers behavior
-          return (a.order ?? 0) - (b.order ?? 0);
-        }
-        // Both in same group - sort by groupOrder within the group
-        return (a.groupOrder ?? 0) - (b.groupOrder ?? 0);
-      }
-
-      // Different groups or one is ungrouped - sort by group position
-      // For grouped monitors, use precomputed minimum order of the group
-      // For ungrouped monitors, use their own order
-      const aGroupMinOrder =
-        aGroupId !== null
-          ? (groupMinOrderMap.get(aGroupId) ?? 0)
-          : (a.order ?? 0);
-
-      const bGroupMinOrder =
-        bGroupId !== null
-          ? (groupMinOrderMap.get(bGroupId) ?? 0)
-          : (b.order ?? 0);
-
-      return aGroupMinOrder - bGroupMinOrder;
-    });
+  // Filter for public monitors only (sorting is handled server-side)
+  const publicMonitors = page.monitors.filter((monitor) => monitor.public);
 
   return (
     <Status>

--- a/packages/api/src/router/statusPage.e2e.test.ts
+++ b/packages/api/src/router/statusPage.e2e.test.ts
@@ -934,6 +934,298 @@ describe("statusPage.get endpoint validation", () => {
   });
 });
 
+describe("statusPage.get monitors sorting", () => {
+  const sortingTestSlug = "monitors-sorting-test-page";
+  let sortingTestPageId: number;
+  let sortingTestWorkspaceId: number;
+  let group1Id: number;
+  let group2Id: number;
+
+  beforeAll(async () => {
+    // Clean up any existing test data
+    await db.delete(page).where(eq(page.slug, sortingTestSlug));
+
+    // Use workspace id 1 from seed data
+    const existingWorkspace = await db.query.workspace.findFirst({
+      where: eq(workspace.id, 1),
+    });
+
+    if (!existingWorkspace) {
+      throw new Error("Test workspace not found");
+    }
+
+    sortingTestWorkspaceId = existingWorkspace.id;
+
+    // Create test page
+    const testPage = await db
+      .insert(page)
+      .values({
+        workspaceId: sortingTestWorkspaceId,
+        title: "Monitors Sorting Test Page",
+        description: "Test page for monitors sorting",
+        slug: sortingTestSlug,
+        customDomain: "",
+      })
+      .returning()
+      .get();
+
+    sortingTestPageId = testPage.id;
+
+    // Import pageComponentGroup schema
+    const { pageComponentGroup } = await import("@openstatus/db/src/schema");
+
+    // Create two monitor groups
+    const group1 = await db
+      .insert(pageComponentGroup)
+      .values({
+        pageId: sortingTestPageId,
+        name: "Group 1",
+        defaultOpen: true,
+      })
+      .returning()
+      .get();
+    group1Id = group1.id;
+
+    const group2 = await db
+      .insert(pageComponentGroup)
+      .values({
+        pageId: sortingTestPageId,
+        name: "Group 2",
+        defaultOpen: true,
+      })
+      .returning()
+      .get();
+    group2Id = group2.id;
+
+    // Create monitors with specific order/groupOrder values for testing sorting
+    // Group 1 should appear first (min order = 1)
+    // Group 2 should appear second (min order = 5)
+    // Ungrouped monitors interspersed based on their order values
+
+    // Monitor 1: Ungrouped, order = 0 (should be first)
+    const monitor1 = await db
+      .insert(monitor)
+      .values({
+        workspaceId: sortingTestWorkspaceId,
+        url: "https://monitor1.test",
+        name: "Monitor 1 Ungrouped",
+        periodicity: "30s",
+        active: true,
+      })
+      .returning()
+      .get();
+
+    await db.insert(pageComponent).values({
+      pageId: sortingTestPageId,
+      monitorId: monitor1.id,
+      type: "monitor",
+      order: 0,
+      groupId: null,
+      groupOrder: null,
+    });
+
+    // Monitor 2: Group 1, order = 1, groupOrder = 1 (group should be second)
+    const monitor2 = await db
+      .insert(monitor)
+      .values({
+        workspaceId: sortingTestWorkspaceId,
+        url: "https://monitor2.test",
+        name: "Monitor 2 Group 1 First",
+        periodicity: "30s",
+        active: true,
+      })
+      .returning()
+      .get();
+
+    await db.insert(pageComponent).values({
+      pageId: sortingTestPageId,
+      monitorId: monitor2.id,
+      type: "monitor",
+      order: 1,
+      groupId: group1Id,
+      groupOrder: 1,
+    });
+
+    // Monitor 3: Group 1, order = 3, groupOrder = 2 (should be second in group 1)
+    const monitor3 = await db
+      .insert(monitor)
+      .values({
+        workspaceId: sortingTestWorkspaceId,
+        url: "https://monitor3.test",
+        name: "Monitor 3 Group 1 Second",
+        periodicity: "30s",
+        active: true,
+      })
+      .returning()
+      .get();
+
+    await db.insert(pageComponent).values({
+      pageId: sortingTestPageId,
+      monitorId: monitor3.id,
+      type: "monitor",
+      order: 3,
+      groupId: group1Id,
+      groupOrder: 2,
+    });
+
+    // Monitor 4: Ungrouped, order = 4 (should come after Group 1, before Group 2)
+    const monitor4 = await db
+      .insert(monitor)
+      .values({
+        workspaceId: sortingTestWorkspaceId,
+        url: "https://monitor4.test",
+        name: "Monitor 4 Ungrouped",
+        periodicity: "30s",
+        active: true,
+      })
+      .returning()
+      .get();
+
+    await db.insert(pageComponent).values({
+      pageId: sortingTestPageId,
+      monitorId: monitor4.id,
+      type: "monitor",
+      order: 4,
+      groupId: null,
+      groupOrder: null,
+    });
+
+    // Monitor 5: Group 2, order = 5, groupOrder = 1 (group should be fourth)
+    const monitor5 = await db
+      .insert(monitor)
+      .values({
+        workspaceId: sortingTestWorkspaceId,
+        url: "https://monitor5.test",
+        name: "Monitor 5 Group 2 First",
+        periodicity: "30s",
+        active: true,
+      })
+      .returning()
+      .get();
+
+    await db.insert(pageComponent).values({
+      pageId: sortingTestPageId,
+      monitorId: monitor5.id,
+      type: "monitor",
+      order: 5,
+      groupId: group2Id,
+      groupOrder: 1,
+    });
+
+    // Monitor 6: Group 2, order = 6, groupOrder = 0 (should be first in group 2)
+    const monitor6 = await db
+      .insert(monitor)
+      .values({
+        workspaceId: sortingTestWorkspaceId,
+        url: "https://monitor6.test",
+        name: "Monitor 6 Group 2 Zero",
+        periodicity: "30s",
+        active: true,
+      })
+      .returning()
+      .get();
+
+    await db.insert(pageComponent).values({
+      pageId: sortingTestPageId,
+      monitorId: monitor6.id,
+      type: "monitor",
+      order: 6,
+      groupId: group2Id,
+      groupOrder: 0,
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    await db.delete(page).where(eq(page.slug, sortingTestSlug));
+  });
+
+  test("Monitors are sorted correctly by group and order", async () => {
+    const { edgeRouter } = await import("../edge");
+    const { createInnerTRPCContext } = await import("../trpc");
+
+    const ctx = createInnerTRPCContext({
+      req: undefined,
+      // @ts-expect-error - auth not required for public procedure
+      auth: undefined,
+    });
+
+    const caller = edgeRouter.createCaller(ctx);
+    const result = await caller.statusPage.get({ slug: sortingTestSlug });
+
+    expect(result).toBeDefined();
+    expect(result).not.toBeNull();
+
+    if (!result) {
+      throw new Error("Result should not be null");
+    }
+
+    expect(result.monitors.length).toBe(6);
+
+    // Expected order based on sorting logic:
+    // 1. Monitor 1 (ungrouped, order=0)
+    // 2. Monitor 2 (group1, order=1, groupOrder=1) - group1 min order = 1
+    // 3. Monitor 3 (group1, order=3, groupOrder=2)
+    // 4. Monitor 4 (ungrouped, order=4)
+    // 5. Monitor 6 (group2, order=6, groupOrder=0) - group2 min order = 5
+    // 6. Monitor 5 (group2, order=5, groupOrder=1)
+
+    expect(result.monitors[0].name).toBe("Monitor 1 Ungrouped");
+    expect(result.monitors[0].monitorGroupId).toBeNull();
+
+    expect(result.monitors[1].name).toBe("Monitor 2 Group 1 First");
+    expect(result.monitors[1].monitorGroupId).toBe(group1Id);
+
+    expect(result.monitors[2].name).toBe("Monitor 3 Group 1 Second");
+    expect(result.monitors[2].monitorGroupId).toBe(group1Id);
+
+    expect(result.monitors[3].name).toBe("Monitor 4 Ungrouped");
+    expect(result.monitors[3].monitorGroupId).toBeNull();
+
+    expect(result.monitors[4].name).toBe("Monitor 6 Group 2 Zero");
+    expect(result.monitors[4].monitorGroupId).toBe(group2Id);
+
+    expect(result.monitors[5].name).toBe("Monitor 5 Group 2 First");
+    expect(result.monitors[5].monitorGroupId).toBe(group2Id);
+  });
+
+  test("Grouped monitors are sorted by groupOrder within their group", async () => {
+    const { edgeRouter } = await import("../edge");
+    const { createInnerTRPCContext } = await import("../trpc");
+
+    const ctx = createInnerTRPCContext({
+      req: undefined,
+      // @ts-expect-error - auth not required for public procedure
+      auth: undefined,
+    });
+
+    const caller = edgeRouter.createCaller(ctx);
+    const result = await caller.statusPage.get({ slug: sortingTestSlug });
+
+    if (!result) {
+      throw new Error("Result should not be null");
+    }
+
+    // Find all monitors in group 1
+    const group1Monitors = result.monitors.filter(
+      (m) => m.monitorGroupId === group1Id,
+    );
+
+    expect(group1Monitors.length).toBe(2);
+    expect(group1Monitors[0].groupOrder).toBe(1);
+    expect(group1Monitors[1].groupOrder).toBe(2);
+
+    // Find all monitors in group 2
+    const group2Monitors = result.monitors.filter(
+      (m) => m.monitorGroupId === group2Id,
+    );
+
+    expect(group2Monitors.length).toBe(2);
+    expect(group2Monitors[0].groupOrder).toBe(0);
+    expect(group2Monitors[1].groupOrder).toBe(1);
+  });
+});
+
 describe("statusPage.get gates incidents by barType (calendar manual mode)", () => {
   const barTypeSlug = "bar-type-incident-gating-test-page";
   let barTypePageId: number;

--- a/packages/api/src/router/statusPage.e2e.test.ts
+++ b/packages/api/src/router/statusPage.e2e.test.ts
@@ -978,6 +978,7 @@ describe("statusPage.get monitors sorting", () => {
     const group1 = await db
       .insert(pageComponentGroup)
       .values({
+        workspaceId: sortingTestWorkspaceId,
         pageId: sortingTestPageId,
         name: "Group 1",
         defaultOpen: true,
@@ -989,6 +990,7 @@ describe("statusPage.get monitors sorting", () => {
     const group2 = await db
       .insert(pageComponentGroup)
       .values({
+        workspaceId: sortingTestWorkspaceId,
         pageId: sortingTestPageId,
         name: "Group 2",
         defaultOpen: true,
@@ -1016,8 +1018,10 @@ describe("statusPage.get monitors sorting", () => {
       .get();
 
     await db.insert(pageComponent).values({
+      workspaceId: sortingTestWorkspaceId,
       pageId: sortingTestPageId,
       monitorId: monitor1.id,
+      name: monitor1.name,
       type: "monitor",
       order: 0,
       groupId: null,
@@ -1038,8 +1042,10 @@ describe("statusPage.get monitors sorting", () => {
       .get();
 
     await db.insert(pageComponent).values({
+      workspaceId: sortingTestWorkspaceId,
       pageId: sortingTestPageId,
       monitorId: monitor2.id,
+      name: monitor2.name,
       type: "monitor",
       order: 1,
       groupId: group1Id,
@@ -1060,8 +1066,10 @@ describe("statusPage.get monitors sorting", () => {
       .get();
 
     await db.insert(pageComponent).values({
+      workspaceId: sortingTestWorkspaceId,
       pageId: sortingTestPageId,
       monitorId: monitor3.id,
+      name: monitor3.name,
       type: "monitor",
       order: 3,
       groupId: group1Id,
@@ -1082,8 +1090,10 @@ describe("statusPage.get monitors sorting", () => {
       .get();
 
     await db.insert(pageComponent).values({
+      workspaceId: sortingTestWorkspaceId,
       pageId: sortingTestPageId,
       monitorId: monitor4.id,
+      name: monitor4.name,
       type: "monitor",
       order: 4,
       groupId: null,
@@ -1104,8 +1114,10 @@ describe("statusPage.get monitors sorting", () => {
       .get();
 
     await db.insert(pageComponent).values({
+      workspaceId: sortingTestWorkspaceId,
       pageId: sortingTestPageId,
       monitorId: monitor5.id,
+      name: monitor5.name,
       type: "monitor",
       order: 5,
       groupId: group2Id,
@@ -1126,8 +1138,10 @@ describe("statusPage.get monitors sorting", () => {
       .get();
 
     await db.insert(pageComponent).values({
+      workspaceId: sortingTestWorkspaceId,
       pageId: sortingTestPageId,
       monitorId: monitor6.id,
+      name: monitor6.name,
       type: "monitor",
       order: 6,
       groupId: group2Id,

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -309,7 +309,7 @@ export const statusPageRouter = createTRPCRouter({
 
         // Different groups or one is ungrouped - sort by group position
         // For grouped monitors, use precomputed minimum order of the group
-        // For ungrouped monsters, use their own order
+        // For ungrouped monitors, use their own order
         const aGroupMinOrder =
           aGroupId !== null
             ? (groupMinOrderMap.get(aGroupId) ?? 0)

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -247,6 +247,44 @@ export const statusPageRouter = createTRPCRouter({
         };
       });
 
+      // Sort monitors to match trackers behavior: group by monitorGroupId, order
+      // groups by minimum order, sort within groups by groupOrder, and sort
+      // ungrouped monitors by order
+      const groupMinOrderMap = new Map<number, number>();
+      for (const monitor of monitors) {
+        const groupId = monitor.monitorGroupId;
+        if (groupId !== null) {
+          const order = monitor.order ?? 0;
+          const currentMin = groupMinOrderMap.get(groupId) ?? Number.MAX_SAFE_INTEGER;
+          groupMinOrderMap.set(groupId, Math.min(currentMin, order));
+        }
+      }
+
+      monitors.sort((a, b) => {
+        const aGroupId = a.monitorGroupId ?? null;
+        const bGroupId = b.monitorGroupId ?? null;
+
+        // If both monitors are in the same group (or both ungrouped with null)
+        if (aGroupId === bGroupId) {
+          if (aGroupId === null) {
+            // Both ungrouped - sort by order
+            return (a.order ?? 0) - (b.order ?? 0);
+          }
+          // Both in same group - sort by groupOrder within the group
+          return (a.groupOrder ?? 0) - (b.groupOrder ?? 0);
+        }
+
+        // Different groups or one is ungrouped - sort by group position
+        // For grouped monitors, use precomputed minimum order of the group
+        // For ungrouped monitors, use their own order
+        const aGroupMinOrder =
+          aGroupId !== null ? groupMinOrderMap.get(aGroupId) ?? 0 : (a.order ?? 0);
+        const bGroupMinOrder =
+          bGroupId !== null ? groupMinOrderMap.get(bGroupId) ?? 0 : (b.order ?? 0);
+
+        return aGroupMinOrder - bGroupMinOrder;
+      });
+
       // no barType gate: incident-driven error is already suppressed per
       // monitor in manual mode; report-driven error (major_outage) must show
       const status = monitors.some((m) => m.status === "error")

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -287,7 +287,8 @@ export const statusPageRouter = createTRPCRouter({
         const groupId = monitor.monitorGroupId;
         if (groupId !== null) {
           const order = monitor.order ?? 0;
-          const currentMin = groupMinOrderMap.get(groupId) ?? Number.MAX_SAFE_INTEGER;
+          const currentMin =
+            groupMinOrderMap.get(groupId) ?? Number.MAX_SAFE_INTEGER;
           groupMinOrderMap.set(groupId, Math.min(currentMin, order));
         }
       }
@@ -310,9 +311,13 @@ export const statusPageRouter = createTRPCRouter({
         // For grouped monitors, use precomputed minimum order of the group
         // For ungrouped monsters, use their own order
         const aGroupMinOrder =
-          aGroupId !== null ? groupMinOrderMap.get(aGroupId) ?? 0 : (a.order ?? 0);
+          aGroupId !== null
+            ? (groupMinOrderMap.get(aGroupId) ?? 0)
+            : (a.order ?? 0);
         const bGroupMinOrder =
-          bGroupId !== null ? groupMinOrderMap.get(bGroupId) ?? 0 : (b.order ?? 0);
+          bGroupId !== null
+            ? (groupMinOrderMap.get(bGroupId) ?? 0)
+            : (b.order ?? 0);
 
         return aGroupMinOrder - bGroupMinOrder;
       });


### PR DESCRIPTION
The /monitors page was displaying monitors without proper sorting, causing incorrect ordering within component groups. Monitors were only filtered by visibility but not sorted.

This fix implements proper sorting logic that:
1. Groups monitors by their monitorGroupId
2. Orders groups by their position (using minimum order of monitors in group)
3. Sorts monitors within each group by their groupOrder field

This matches the sorting behavior used in the trackers logic on the main status page and ensures monitors appear in the correct order as configured in the dashboard.

Resolves #2526 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

