### PR TITLE
fix: reset delete confirmation input when dialog closes

### DIFF
--- a/apps/dashboard/src/components/dropdowns/quick-actions.tsx
+++ b/apps/dashboard/src/components/dropdowns/quick-actions.tsx
@@ -89,8 +89,14 @@ export function QuickActions({
     });
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    setOpen(newOpen);
+    // Reset the input value when dialog state changes
+    setValue("");
+  };
+
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           {children ?? (


### PR DESCRIPTION
The delete confirmation dialog was retaining the previous input value when opened again for a different item. Users would see the old value pre-filled in the confirmation input field.
The 'value' state was updated when typing but never reset when the dialog closed, causing it to persist across multiple uses.
Added handleOpenChange handler that resets the input value to an empty string whenever the dialog state changes (opens or closes).

Resolves #2528 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

