### PR TITLE
fix: prevent spurious recovery notifications for private locations

### DIFF
--- a/apps/workflows/src/checker/private-location.ts
+++ b/apps/workflows/src/checker/private-location.ts
@@ -326,8 +326,8 @@ export async function updateStatusPrivate(c: Context<Env>) {
             latency,
           },
         });
-        // Trigger notifications for cloud monitors always, private-only when threshold met
-        if (hasCloudRegions || shouldTriggerIncident) {
+        // Trigger notifications for cloud monitors always, private-only when threshold met AND status changed
+        if (hasCloudRegions || (shouldTriggerIncident && monitor.status !== "error")) {
           triggeredNotifications = await triggerNotifications({
             monitorId,
             statusCode,
@@ -389,8 +389,8 @@ export async function updateStatusPrivate(c: Context<Env>) {
             latency,
           },
         });
-        // Trigger notifications for cloud monitors always, private-only when threshold met
-        if (hasCloudRegions || shouldTriggerIncident) {
+        // Trigger notifications for cloud monitors always, private-only when threshold met AND status changed
+        if (hasCloudRegions || (shouldTriggerIncident && monitor.status !== "degraded")) {
           triggeredNotifications = await triggerNotifications({
             monitorId,
             statusCode,
@@ -449,8 +449,8 @@ export async function updateStatusPrivate(c: Context<Env>) {
             latency,
           },
         });
-        // Trigger notifications for cloud monitors always, private-only when threshold met
-        if (hasCloudRegions || shouldTriggerIncident) {
+        // Trigger notifications for cloud monitors always, private-only when threshold met AND status changed
+        if (hasCloudRegions || (shouldTriggerIncident && monitor.status !== "active")) {
           triggeredNotifications = await triggerNotifications({
             monitorId,
             statusCode,

--- a/apps/workflows/src/checker/private-location.ts
+++ b/apps/workflows/src/checker/private-location.ts
@@ -327,7 +327,10 @@ export async function updateStatusPrivate(c: Context<Env>) {
           },
         });
         // Trigger notifications for cloud monitors always, private-only when threshold met AND status changed
-        if (hasCloudRegions || (shouldTriggerIncident && monitor.status !== "error")) {
+        if (
+          hasCloudRegions ||
+          (shouldTriggerIncident && monitor.status !== "error")
+        ) {
           triggeredNotifications = await triggerNotifications({
             monitorId,
             statusCode,
@@ -390,7 +393,10 @@ export async function updateStatusPrivate(c: Context<Env>) {
           },
         });
         // Trigger notifications for cloud monitors always, private-only when threshold met AND status changed
-        if (hasCloudRegions || (shouldTriggerIncident && monitor.status !== "degraded")) {
+        if (
+          hasCloudRegions ||
+          (shouldTriggerIncident && monitor.status !== "degraded")
+        ) {
           triggeredNotifications = await triggerNotifications({
             monitorId,
             statusCode,
@@ -450,7 +456,10 @@ export async function updateStatusPrivate(c: Context<Env>) {
           },
         });
         // Trigger notifications for cloud monitors always, private-only when threshold met AND status changed
-        if (hasCloudRegions || (shouldTriggerIncident && monitor.status !== "active")) {
+        if (
+          hasCloudRegions ||
+          (shouldTriggerIncident && monitor.status !== "active")
+        ) {
           triggeredNotifications = await triggerNotifications({
             monitorId,
             statusCode,


### PR DESCRIPTION
Fixed bug where private location monitors would send recovery notifications without prior degraded/error notifications.

Private location notification logic was triggering notifications whenever the threshold was met (≥50% of locations in a status), regardless of whether the monitor's overall status had actually changed.

Example Bug Scenario (3 locations):
1. All locations start active, monitor.status = 'active'
2. Location 1 becomes degraded (1/3 = 33% < 50%)
   - shouldTriggerIncident = false
   - No notification sent
3. Location 1 recovers to active (3/3 = 100% ≥ 50%)
   - shouldTriggerIncident = true
   - Recovery notification sent even though monitor.status was always 'active'

For private-only monitors, notifications now require BOTH:
1. Threshold met (shouldTriggerIncident = true)
2. Monitor status actually changing (monitor.status !== targetStatus)

This matches the cloud monitor pattern in index.ts which checks monitor status before sending notifications (lines 168, 201, 237).
Cloud monitors continue to work as before (threshold-based notifications) since they aggregate regions differently.
Fixes notification asymmetry where users would see 'recovered' without seeing the initial 'degraded' or 'error' notification.

Resolves #2530 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

