### PR TITLE
fix: sort regions consistently in dashboard monitor sidebar

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/sidebar.tsx
@@ -77,9 +77,20 @@ export function Sidebar() {
                     location.id.toString(),
                   ) ?? []),
                 ];
-                return allRegions.length > 6
-                  ? `${allRegions.length} regions`
-                  : allRegions.join(", ");
+                // Sort regions: numeric sort for private location IDs, alphabetic for region codes
+                const sortedRegions = allRegions.sort((a, b) => {
+                  const aNum = Number(a);
+                  const bNum = Number(b);
+                  // If both are numeric, sort numerically
+                  if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return aNum - bNum;
+                  }
+                  // Otherwise, sort alphabetically
+                  return a.localeCompare(b);
+                });
+                return sortedRegions.length > 6
+                  ? `${sortedRegions.length} regions`
+                  : sortedRegions.join(", ");
               })(),
             },
             {


### PR DESCRIPTION
Sort regions alphabetically/numerically for consistent display order:
- Private location IDs (1, 2, 3, 10) sorted numerically
- Region codes (ams, fra, gru) sorted alphabetically

Fixes inconsistent region display order where dashboard showed unsorted regions (3, 2, 1 or 2, 1, 3) while status page (region latency's legend) showed them sorted.

<img width="256" height="45" alt="image" src="https://github.com/user-attachments/assets/5d110960-b7cf-4fdd-b096-8aae7e206262" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

