### PR TITLE
fix(server): include region in raw check timings

### DIFF
--- a/apps/server/src/routes/v1/check/http/post.test.ts
+++ b/apps/server/src/routes/v1/check/http/post.test.ts
@@ -52,6 +52,7 @@ test("Create a single check  ", async () => {
         tlsHandshakeStart: 5,
         transferDone: 10,
         transferStart: 9,
+        region: "ams",
       },
     ],
     response: {
@@ -169,6 +170,7 @@ test("Create a multiple check", async () => {
         tlsHandshakeStart: 5,
         transferDone: 10,
         transferStart: 9,
+        region: "ams",
       },
       {
         connectDone: 14,
@@ -181,6 +183,7 @@ test("Create a multiple check", async () => {
         tlsHandshakeStart: 15,
         transferDone: 20,
         transferStart: 19,
+        region: "gru",
       },
     ],
     response: {

--- a/apps/server/src/routes/v1/check/http/post.ts
+++ b/apps/server/src/routes/v1/check/http/post.ts
@@ -139,12 +139,15 @@ export function registerHTTPPostCheck(api: typeof checkApi) {
       });
     }
 
-    const allTimings = fulfilledRequest.map((r) => r.timing);
+    const allTimings = fulfilledRequest.map((r) => ({
+      ...r.timing,
+      region: r.region,
+    }));
 
     const lastResponse = fulfilledRequest[fulfilledRequest.length - 1];
     const responseResult = CheckPostResponseSchema.parse({
       id: newCheck.id,
-      raw: allTimings, // TODO: we should return the region here as well!
+      raw: allTimings,
       response: lastResponse,
       aggregated: aggregatedResponse ? aggregatedResponse : undefined,
     });

--- a/apps/server/src/routes/v1/check/http/schema.ts
+++ b/apps/server/src/routes/v1/check/http/schema.ts
@@ -75,6 +75,10 @@ export const AggregatedResponseSchema = z
     description: "The aggregated data of the check",
   });
 
+const RegionSchema = z
+  .string()
+  .openapi({ description: "The region where the check ran" });
+
 export const ResponseSchema = z.object({
   timestamp: z
     .number()
@@ -119,7 +123,7 @@ export const ResponseSchema = z.object({
     .openapi({
       description: "The aggregated data dns timing of the check",
     }),
-  region: z.string().openapi({ description: "The region where the check ran" }),
+  region: RegionSchema,
 });
 
 export const AggregatedResult = z.object({
@@ -131,9 +135,13 @@ export const AggregatedResult = z.object({
   latency: AggregatedResponseSchema,
 });
 
+export const RawTimingSchema = TimingSchema.extend({
+  region: RegionSchema,
+});
+
 export const CheckPostResponseSchema = z.object({
   id: z.int().openapi({ description: "The id of the check" }),
-  raw: z.array(TimingSchema).openapi({
+  raw: z.array(RawTimingSchema).openapi({
     description: "The raw data of the check",
   }),
   response: ResponseSchema.openapi({


### PR DESCRIPTION
## Summary
The POST /v1/check/http response now includes region in each entry of the raw timings array, so consumers can tell which region each timing belongs to.

Previously only timing was returned, dropping the region the checker had already reported (ResponseSchema.region).

## Notes
Additive, backward-compatible API change. No DB migration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

