### PR TITLE
fix: hide telegram qr code when self-hosting with no redis

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -61,8 +61,10 @@ AUTH_SECRET=your-random-secret-here-min-32-chars
 
 # [REQUIRED] Self-hosted mode - enables magic link authentication
 # Set to "true" to allow email login without OAuth
-# Note: NEXT_PUBLIC_SELF_HOST is baked into the Docker image at build time (see apps/dashboard/Dockerfile)
-# and cannot be changed via this runtime config file
+# Note: NEXT_PUBLIC_SELF_HOST is the client-side build-time version of this flag,
+# baked into the Docker image at build time (see apps/dashboard/Dockerfile).
+# It controls UI behavior like the Telegram connection flow (QR vs manual input),
+# and cannot be changed via this runtime config file.
 SELF_HOST="true"
 
 # GitHub OAuth (optional)

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -63,6 +63,10 @@ AUTH_SECRET=your-random-secret-here-min-32-chars
 # Set to "true" to allow email login without OAuth
 SELF_HOST="true"
 
+# [REQUIRED] Client-side self-hosted flag (embedded at build time)
+# Must match SELF_HOST value. Used by frontend to optimize UX for self-hosted environments
+NEXT_PUBLIC_SELF_HOST="true"
+
 # GitHub OAuth (optional)
 # Get from: https://github.com/settings/developers
 AUTH_GITHUB_ID=

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -65,7 +65,6 @@ AUTH_SECRET=your-random-secret-here-min-32-chars
 # and cannot be changed via this runtime config file
 SELF_HOST="true"
 
-
 # GitHub OAuth (optional)
 # Get from: https://github.com/settings/developers
 AUTH_GITHUB_ID=

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -20,11 +20,6 @@ DATABASE_AUTH_TOKEN=
 UPSTASH_REDIS_REST_URL=http://localhost:6379
 UPSTASH_REDIS_REST_TOKEN=placeholder
 
-# Self-hosted flag (optional) - set to "true" for self-hosted deployments
-# When true, Telegram QR code tab is hidden by default (assumes no Redis)
-# When false/unset, QR code tab shows immediately (optimistic for cloud deployments)
-NEXT_PUBLIC_SELF_HOSTED=true
-
 # QStash (optional - for background jobs)
 QSTASH_CURRENT_SIGNING_KEY=
 QSTASH_NEXT_SIGNING_KEY=
@@ -67,6 +62,10 @@ AUTH_SECRET=your-random-secret-here-min-32-chars
 # [REQUIRED] Self-hosted mode - enables magic link authentication
 # Set to "true" to allow email login without OAuth
 SELF_HOST="true"
+
+# Client-accessible self-hosted flag (for UI behavior like hiding Telegram QR tab during loading)
+NEXT_PUBLIC_SELF_HOST="true"
+
 
 # GitHub OAuth (optional)
 # Get from: https://github.com/settings/developers

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -20,6 +20,11 @@ DATABASE_AUTH_TOKEN=
 UPSTASH_REDIS_REST_URL=http://localhost:6379
 UPSTASH_REDIS_REST_TOKEN=placeholder
 
+# Self-hosted flag (optional) - set to "true" for self-hosted deployments
+# When true, Telegram QR code tab is hidden by default (assumes no Redis)
+# When false/unset, QR code tab shows immediately (optimistic for cloud deployments)
+NEXT_PUBLIC_SELF_HOSTED=true
+
 # QStash (optional - for background jobs)
 QSTASH_CURRENT_SIGNING_KEY=
 QSTASH_NEXT_SIGNING_KEY=

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -63,10 +63,6 @@ AUTH_SECRET=your-random-secret-here-min-32-chars
 # Set to "true" to allow email login without OAuth
 SELF_HOST="true"
 
-# Client-accessible self-hosted flag (for UI behavior like hiding Telegram QR tab during loading)
-NEXT_PUBLIC_SELF_HOST="true"
-
-
 # GitHub OAuth (optional)
 # Get from: https://github.com/settings/developers
 AUTH_GITHUB_ID=

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -61,11 +61,10 @@ AUTH_SECRET=your-random-secret-here-min-32-chars
 
 # [REQUIRED] Self-hosted mode - enables magic link authentication
 # Set to "true" to allow email login without OAuth
+# Note: NEXT_PUBLIC_SELF_HOST is baked into the Docker image at build time (see apps/dashboard/Dockerfile)
+# and cannot be changed via this runtime config file
 SELF_HOST="true"
 
-# [REQUIRED] Client-side self-hosted flag (embedded at build time)
-# Must match SELF_HOST value. Used by frontend to optimize UX for self-hosted environments
-NEXT_PUBLIC_SELF_HOST="true"
 
 # GitHub OAuth (optional)
 # Get from: https://github.com/settings/developers

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -22,6 +22,7 @@ ENV \
     UPSTASH_REDIS_REST_URL="https://test.upstash.io" \
     UNKEY_TOKEN="test" \
     SELF_HOST="true" \
+    NEXT_PUBLIC_SELF_HOST="true" \
     UNKEY_API_ID="test" \
     STRIPE_SECRET_KEY="test" \
     NEXT_PUBLIC_OPENPANEL_CLIENT_ID="test" \

--- a/apps/dashboard/dofigen.lock
+++ b/apps/dashboard/dofigen.lock
@@ -23,6 +23,7 @@ effective: |
         UPSTASH_REDIS_REST_URL: https://test.upstash.io
         UNKEY_TOKEN: test
         SELF_HOST: 'true'
+        NEXT_PUBLIC_SELF_HOST: 'true'
         UNKEY_API_ID: test
         STRIPE_SECRET_KEY: test
         NEXT_PUBLIC_OPENPANEL_CLIENT_ID: test
@@ -123,6 +124,7 @@ resources:
             STRIPE_SECRET_KEY: test
             AUTH_SECRET: build-time-placeholder-min-32-chars-long
             SELF_HOST: "true"
+            NEXT_PUBLIC_SELF_HOST: "true"
           run:
             - corepack enable
             - pnpm install --frozen-lockfile

--- a/apps/dashboard/dofigen.yml
+++ b/apps/dashboard/dofigen.yml
@@ -28,6 +28,7 @@ builders:
       STRIPE_SECRET_KEY: test
       AUTH_SECRET: build-time-placeholder-min-32-chars-long
       SELF_HOST: "true"
+      NEXT_PUBLIC_SELF_HOST: "true"
     run:
       - corepack enable
       - pnpm install --frozen-lockfile

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -38,7 +38,9 @@ export function TelegramConnectionFlow({
   } = useTelegramConnection({ form, mode });
 
   // Check build-time env var for deployment type, with backend fallback
-  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOST === "true" || tokenData?.isSelfHosted === true;
+  const isSelfHosted =
+    process.env.NEXT_PUBLIC_SELF_HOST === "true" ||
+    tokenData?.isSelfHosted === true;
   const redisAvailable = tokenData?.redisAvailable === true;
 
   // Biased loading behavior:

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,6 +37,13 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
+  const redisAvailable = tokenData?.redisAvailable ?? true;
+
+  // If Redis is not available, only show manual input without tabs
+  if (!isTokenLoading && !redisAvailable) {
+    return <TelegramManualInput form={form} />;
+  }
+
   return (
     <Tabs
       value={mode ?? "qr"}

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,17 +37,11 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
-  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOST === "true";
   const redisAvailable = tokenData?.redisAvailable === true;
 
-
-  // If self-hosted, hide QR tab during loading to prevent flash
-  // If Redis is confirmed unavailable, always hide QR tab
-  if (isSelfHosted && isTokenLoading) {
-    return <TelegramManualInput form={form} />;
-  }
-
-  if (!isTokenLoading && !redisAvailable) {
+  // Always hide QR tab during loading to prevent flash on self-hosted instances
+  // Show QR tab only after confirming Redis is actually available
+  if (isTokenLoading || !redisAvailable) {
     return <TelegramManualInput form={form} />;
   }
 

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -51,10 +51,6 @@ export function TelegramConnectionFlow({
     return <TelegramManualInput form={form} />;
   }
 
-
-
-
-
   return (
     <Tabs
       value={mode ?? "qr"}

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -18,12 +18,14 @@ interface TelegramConnectionFlowProps {
   form: UseFormReturn<FormValues>;
   mode: "qr" | "manual" | null;
   onModeChange: (mode: "qr" | "manual" | null) => void;
+  isSelfHosted?: boolean; // Optional: if not provided, assumes cloud (optimistic)
 }
 
 export function TelegramConnectionFlow({
   form,
   mode,
   onModeChange,
+  isSelfHosted: isSelfHostedProp,
 }: TelegramConnectionFlowProps) {
   const {
     tokenData,
@@ -37,13 +39,18 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
+  // Use prop if provided, otherwise use value from backend, default to false (cloud)
+  const isSelfHosted = isSelfHostedProp ?? tokenData?.isSelfHosted ?? false;
   const redisAvailable = tokenData?.redisAvailable === true;
 
-  // Hide QR tab during loading (prevents flash on self-hosted)
-  // Show QR tab only after confirming Redis is available
-  if (isTokenLoading || !redisAvailable) {
+  // Biased loading behavior:
+  // - Self-hosted: Hide QR during loading (conservative, prevents flash)
+  // - Cloud: Show QR during loading (optimistic, better UX)
+  // After loading: always check actual redisAvailable value
+  if ((isSelfHosted && isTokenLoading) || (!isTokenLoading && !redisAvailable)) {
     return <TelegramManualInput form={form} />;
   }
+
 
 
 

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,12 +37,14 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
-  const redisAvailable = tokenData?.redisAvailable ?? true;
+
+  const redisAvailable = tokenData?.redisAvailable === true;
 
   // If Redis is not available, only show manual input without tabs
   if (!isTokenLoading && !redisAvailable) {
     return <TelegramManualInput form={form} />;
   }
+
 
   return (
     <Tabs

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,10 +37,15 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
-
+  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOSTED === "true";
   const redisAvailable = tokenData?.redisAvailable === true;
 
-  // If Redis is not available, only show manual input without tabs
+  // If self-hosted, hide QR tab during loading to prevent flash
+  // If Redis is confirmed unavailable, always hide QR tab
+  if (isSelfHosted && isTokenLoading) {
+    return <TelegramManualInput form={form} />;
+  }
+
   if (!isTokenLoading && !redisAvailable) {
     return <TelegramManualInput form={form} />;
   }

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,10 +37,8 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
-  // Check build-time env var for deployment type, with backend fallback
-  const isSelfHosted =
-    process.env.NEXT_PUBLIC_SELF_HOST === "true" ||
-    tokenData?.isSelfHosted === true;
+  // Check build-time env var for deployment type
+  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOST === "true";
   const redisAvailable = tokenData?.redisAvailable === true;
 
   // Biased loading behavior:

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -47,7 +47,10 @@ export function TelegramConnectionFlow({
   // - Self-hosted: Hide QR during loading (conservative, prevents flash)
   // - Cloud: Show QR during loading (optimistic, better UX)
   // After loading: always check actual redisAvailable value
-  if ((isSelfHosted && isTokenLoading) || (!isTokenLoading && !redisAvailable)) {
+  if (
+    (isSelfHosted && isTokenLoading) ||
+    (!isTokenLoading && !redisAvailable)
+  ) {
     return <TelegramManualInput form={form} />;
   }
 

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -60,7 +60,7 @@ export function TelegramConnectionFlow({
       <TabsContent value="qr">
         <TelegramQRConnection
           form={form}
-          token={tokenData?.token}
+          token={tokenData?.token ?? undefined}
           isLoading={isTokenLoading}
           isPolling={isPolling}
           flowStep={flowStep}

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -18,14 +18,12 @@ interface TelegramConnectionFlowProps {
   form: UseFormReturn<FormValues>;
   mode: "qr" | "manual" | null;
   onModeChange: (mode: "qr" | "manual" | null) => void;
-  isSelfHosted?: boolean; // Optional: if not provided, assumes cloud (optimistic)
 }
 
 export function TelegramConnectionFlow({
   form,
   mode,
   onModeChange,
-  isSelfHosted: isSelfHostedProp,
 }: TelegramConnectionFlowProps) {
   const {
     tokenData,
@@ -39,8 +37,8 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
-  // Use prop if provided, otherwise use value from backend, default to false (cloud)
-  const isSelfHosted = isSelfHostedProp ?? tokenData?.isSelfHosted ?? false;
+  // Check build-time env var for deployment type, with backend fallback
+  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOST === "true" || tokenData?.isSelfHosted === true;
   const redisAvailable = tokenData?.redisAvailable === true;
 
   // Biased loading behavior:

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,15 +37,14 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
-  const isSelfHosted = tokenData?.isSelfHosted === true;
   const redisAvailable = tokenData?.redisAvailable === true;
 
-  // Self-hosted: hide QR tab during loading to prevent flash (conservative)
-  // Cloud: show QR tab during loading (optimistic)
-  // Always hide QR tab if Redis is confirmed unavailable
-  if ((isSelfHosted && isTokenLoading) || (!isTokenLoading && !redisAvailable)) {
+  // Hide QR tab during loading (prevents flash on self-hosted)
+  // Show QR tab only after confirming Redis is available
+  if (isTokenLoading || !redisAvailable) {
     return <TelegramManualInput form={form} />;
   }
+
 
 
 

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,13 +37,16 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
+  const isSelfHosted = tokenData?.isSelfHosted === true;
   const redisAvailable = tokenData?.redisAvailable === true;
 
-  // Always hide QR tab during loading to prevent flash on self-hosted instances
-  // Show QR tab only after confirming Redis is actually available
-  if (isTokenLoading || !redisAvailable) {
+  // Self-hosted: hide QR tab during loading to prevent flash (conservative)
+  // Cloud: show QR tab during loading (optimistic)
+  // Always hide QR tab if Redis is confirmed unavailable
+  if ((isSelfHosted && isTokenLoading) || (!isTokenLoading && !redisAvailable)) {
     return <TelegramManualInput form={form} />;
   }
+
 
 
   return (

--- a/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
+++ b/apps/dashboard/src/components/forms/components/telegram-connection-flow.tsx
@@ -37,8 +37,9 @@ export function TelegramConnectionFlow({
     confirmPrivateChat,
   } = useTelegramConnection({ form, mode });
 
-  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOSTED === "true";
+  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOST === "true";
   const redisAvailable = tokenData?.redisAvailable === true;
+
 
   // If self-hosted, hide QR tab during loading to prevent flash
   // If Redis is confirmed unavailable, always hide QR tab

--- a/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
+++ b/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
@@ -13,6 +13,7 @@ import { Form } from "@openstatus/ui/components/ui/form";
 import { Input } from "@openstatus/ui/components/ui/input";
 import { cn } from "@openstatus/ui/lib/utils";
 import { isTRPCClientError } from "@trpc/client";
+import { useQuery } from "@tanstack/react-query";
 import React, { useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -82,7 +83,9 @@ export function FormTelegram({
 
   // Fetch server config to determine deployment type for biased loading
   const trpc = useTRPC();
-  const { data: serverConfig } = trpc.notification.getServerConfig.useQuery();
+  const { data: serverConfig } = useQuery({
+    ...trpc.notification.getServerConfig.queryOptions(),
+  });
 
   function submitAction(values: FormValues) {
     if (isPending) return;

--- a/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
+++ b/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
@@ -79,8 +79,6 @@ export function FormTelegram({
     isEditMode ? null : "qr",
   );
 
-
-
   function submitAction(values: FormValues) {
     if (isPending) return;
 

--- a/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
+++ b/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
@@ -79,8 +79,7 @@ export function FormTelegram({
     isEditMode ? null : "qr",
   );
 
-  // Check build-time env var for deployment type (immediate, no loading delay)
-  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOST === "true";
+
 
   function submitAction(values: FormValues) {
     if (isPending) return;
@@ -144,7 +143,6 @@ export function FormTelegram({
                 form={form}
                 mode={mode}
                 onModeChange={setMode}
-                isSelfHosted={isSelfHosted}
               />
             )}
           </div>

--- a/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
+++ b/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/components/forms/form-card";
 import { useFormSheetDirty } from "@/components/forms/form-sheet";
 import { CheckboxTree } from "@/components/ui/checkbox-tree";
-import { trpc } from "@/lib/trpc";
+import { useTRPC } from "@/lib/trpc/client";
 
 import { TelegramConnectionFlow } from "../components/telegram-connection-flow";
 import { TelegramFormActions } from "../components/telegram-form-actions";
@@ -81,6 +81,7 @@ export function FormTelegram({
   );
 
   // Fetch server config to determine deployment type for biased loading
+  const trpc = useTRPC();
   const { data: serverConfig } = trpc.notification.getServerConfig.useQuery();
 
   function submitAction(values: FormValues) {

--- a/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
+++ b/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
@@ -13,7 +13,6 @@ import { Form } from "@openstatus/ui/components/ui/form";
 import { Input } from "@openstatus/ui/components/ui/input";
 import { cn } from "@openstatus/ui/lib/utils";
 import { isTRPCClientError } from "@trpc/client";
-import { useQuery } from "@tanstack/react-query";
 import React, { useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -25,7 +24,6 @@ import {
 } from "@/components/forms/form-card";
 import { useFormSheetDirty } from "@/components/forms/form-sheet";
 import { CheckboxTree } from "@/components/ui/checkbox-tree";
-import { useTRPC } from "@/lib/trpc/client";
 
 import { TelegramConnectionFlow } from "../components/telegram-connection-flow";
 import { TelegramFormActions } from "../components/telegram-form-actions";
@@ -81,11 +79,8 @@ export function FormTelegram({
     isEditMode ? null : "qr",
   );
 
-  // Fetch server config to determine deployment type for biased loading
-  const trpc = useTRPC();
-  const { data: serverConfig } = useQuery({
-    ...trpc.notification.getServerConfig.queryOptions(),
-  });
+  // Check build-time env var for deployment type (immediate, no loading delay)
+  const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOST === "true";
 
   function submitAction(values: FormValues) {
     if (isPending) return;
@@ -149,7 +144,7 @@ export function FormTelegram({
                 form={form}
                 mode={mode}
                 onModeChange={setMode}
-                isSelfHosted={serverConfig?.isSelfHosted}
+                isSelfHosted={isSelfHosted}
               />
             )}
           </div>

--- a/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
+++ b/apps/dashboard/src/components/forms/notifications/form-telegram.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/forms/form-card";
 import { useFormSheetDirty } from "@/components/forms/form-sheet";
 import { CheckboxTree } from "@/components/ui/checkbox-tree";
+import { trpc } from "@/lib/trpc";
 
 import { TelegramConnectionFlow } from "../components/telegram-connection-flow";
 import { TelegramFormActions } from "../components/telegram-form-actions";
@@ -78,6 +79,9 @@ export function FormTelegram({
   const [mode, setMode] = React.useState<"qr" | "manual" | null>(
     isEditMode ? null : "qr",
   );
+
+  // Fetch server config to determine deployment type for biased loading
+  const { data: serverConfig } = trpc.notification.getServerConfig.useQuery();
 
   function submitAction(values: FormValues) {
     if (isPending) return;
@@ -141,6 +145,7 @@ export function FormTelegram({
                 form={form}
                 mode={mode}
                 onModeChange={setMode}
+                isSelfHosted={serverConfig?.isSelfHosted}
               />
             )}
           </div>

--- a/packages/api/src/router/notification.ts
+++ b/packages/api/src/router/notification.ts
@@ -322,19 +322,21 @@ export const notificationRouter = createTRPCRouter({
     const workspaceId = opts.ctx.workspace.id;
     const randomId = nanoid(12);
     const EXPIRY = 1800; // 30 minutes
+    const isSelfHosted = process.env.SELF_HOST === "true";
 
     try {
       await redis.set(`telegram:workspace_token:${workspaceId}`, randomId, {
         ex: EXPIRY,
       });
-      return { token: randomId, redisAvailable: true };
+      return { token: randomId, redisAvailable: true, isSelfHosted };
     } catch (error) {
       // Redis unavailable (e.g., self-hosted without Redis)
       // Return null token to signal frontend to use manual setup only
       console.warn("Redis unavailable for Telegram token storage:", error);
-      return { token: null, redisAvailable: false };
+      return { token: null, redisAvailable: false, isSelfHosted };
     }
   }),
+
 
   getTelegramUpdates: protectedProcedure
     .input(

--- a/packages/api/src/router/notification.ts
+++ b/packages/api/src/router/notification.ts
@@ -323,11 +323,17 @@ export const notificationRouter = createTRPCRouter({
     const randomId = nanoid(12);
     const EXPIRY = 1800; // 30 minutes
 
-    await redis.set(`telegram:workspace_token:${workspaceId}`, randomId, {
-      ex: EXPIRY,
-    });
-
-    return { token: randomId };
+    try {
+      await redis.set(`telegram:workspace_token:${workspaceId}`, randomId, {
+        ex: EXPIRY,
+      });
+      return { token: randomId, redisAvailable: true };
+    } catch (error) {
+      // Redis unavailable (e.g., self-hosted without Redis)
+      // Return null token to signal frontend to use manual setup only
+      console.warn("Redis unavailable for Telegram token storage:", error);
+      return { token: null, redisAvailable: false };
+    }
   }),
 
   getTelegramUpdates: protectedProcedure

--- a/packages/api/src/router/notification.ts
+++ b/packages/api/src/router/notification.ts
@@ -49,13 +49,6 @@ import {
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const notificationRouter = createTRPCRouter({
-  // Fast endpoint to get server configuration (e.g., deployment type)
-  getServerConfig: protectedProcedure.query(() => {
-    return {
-      isSelfHosted: process.env.SELF_HOST === "true",
-    };
-  }),
-
   list: protectedProcedure.query(async ({ ctx }) => {
     try {
       const { items } = await listNotifications({
@@ -329,18 +322,17 @@ export const notificationRouter = createTRPCRouter({
     const workspaceId = opts.ctx.workspace.id;
     const randomId = nanoid(12);
     const EXPIRY = 1800; // 30 minutes
-    const isSelfHosted = process.env.SELF_HOST === "true";
 
     try {
       await redis.set(`telegram:workspace_token:${workspaceId}`, randomId, {
         ex: EXPIRY,
       });
-      return { token: randomId, redisAvailable: true, isSelfHosted };
+      return { token: randomId, redisAvailable: true };
     } catch (error) {
       // Redis unavailable (e.g., self-hosted without Redis)
       // Return null token to signal frontend to use manual setup only
       console.warn("Redis unavailable for Telegram token storage:", error);
-      return { token: null, redisAvailable: false, isSelfHosted };
+      return { token: null, redisAvailable: false };
     }
   }),
 

--- a/packages/api/src/router/notification.ts
+++ b/packages/api/src/router/notification.ts
@@ -49,6 +49,13 @@ import {
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const notificationRouter = createTRPCRouter({
+  // Fast endpoint to get server configuration (e.g., deployment type)
+  getServerConfig: protectedProcedure.query(() => {
+    return {
+      isSelfHosted: process.env.SELF_HOST === "true",
+    };
+  }),
+
   list: protectedProcedure.query(async ({ ctx }) => {
     try {
       const { items } = await listNotifications({

--- a/packages/api/src/router/notification.ts
+++ b/packages/api/src/router/notification.ts
@@ -344,7 +344,6 @@ export const notificationRouter = createTRPCRouter({
     }
   }),
 
-
   getTelegramUpdates: protectedProcedure
     .input(
       z


### PR DESCRIPTION
In self-hosted environments without Redis available, the Telegram notification setup is unable to connect to any Redis instance.
This PR changes the behaviour and now checks for a self-host env var to determine whether to show the loading skeleton.
For self-hosted deployments, the loading skeleton will not be displayed - however, if a Redis connection can be made, the QR code will be shown.
For cloud deployments, the loading skeleton *will* be displayed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

