### PR TITLE
docs: update importers README paths to packages/services/src/import

### DIFF
--- a/packages/importers/README.md
+++ b/packages/importers/README.md
@@ -51,7 +51,7 @@ type ImportProvider<TConfig extends ImportConfig> = {
 
 A `run()` call returns an `ImportSummary` containing sequential `PhaseResult` entries. Each phase (e.g. `"monitors"`, `"page"`, `"components"`, `"incidents"`) contains an array of `ResourceResult` items with a `status` of `"created"`, `"skipped"`, or `"failed"` and an opaque `data` payload that the service layer writes to the database.
 
-The importers package is **read-only** -- it fetches data from external APIs and maps it into OpenStatus shapes. The actual database writes happen in `packages/api/src/service/import.ts`.
+The importers package is **read-only** -- it fetches data from external APIs and maps it into OpenStatus shapes. The actual database writes happen in `packages/services/src/import/phase-writers.ts`.
 
 ## How the Import Pipeline Works
 
@@ -64,7 +64,7 @@ API Router (packages/api/src/router/import.ts)
   |
   | Calls previewImport() or runImport()
   v
-Service Layer (packages/api/src/service/import.ts)
+Service Layer (packages/services/src/import/)
   |
   | 1. Creates provider via createProvider(name)
   | 2. Validates API key via provider.validate()
@@ -170,15 +170,15 @@ Implement `ImportProvider<TConfig>`:
 
 Each phase produces `ResourceResult[]` with the mapped data in `data`. The service layer reads `data` to write to the database.
 
-The `data` shape must match what the corresponding phase writer in `packages/api/src/service/import.ts` casts it to. For incidents, this means the mapper must return `{ report, updates, sourceComponentIds }` -- even if `sourceComponentIds` is empty.
+The `data` shape must match what the corresponding phase writer in `packages/services/src/import/phase-writers.ts` casts it to. For incidents, this means the mapper must return `{ report, updates, sourceComponentIds }` -- even if `sourceComponentIds` is empty.
 
 ### 6. Register the provider
 
 1. Create `index.ts` with barrel exports
 2. Add to `IMPORT_PROVIDERS` in `src/index.ts`
 3. Add export paths in `package.json`
-4. Add a case in `createProvider()` in `packages/api/src/service/import.ts`
-5. Add the provider name to the `z.enum` in `packages/api/src/router/import.ts`
+4. Add a case in `createProvider()` in `packages/services/src/import/provider.ts`
+5. Add the provider name to `importProviders` in `packages/services/src/import/schemas.ts`
 6. Add a radio button in `apps/dashboard/src/components/forms/components/form-import.tsx`
 
 ### 7. Write tests


### PR DESCRIPTION
`packages/importers/README.md` points at `packages/api/src/service/import.ts` in five places, but that file doesn't exist — `packages/api/src/service/` only contains `telegram-updates.ts`. The import service now lives in `packages/services/src/import/`, and `packages/api/src/router/import.ts` is a 31-line wrapper that re-exports `previewImport`/`runImport` from `@openstatus/services/import`.

Repointed each reference at the file that actually holds the thing being described:

| README said | now points at |
|---|---|
| database writes | `packages/services/src/import/phase-writers.ts` |
| "Service Layer" in the flow diagram | `packages/services/src/import/` |
| phase writer casting the `data` shape | `packages/services/src/import/phase-writers.ts` |
| `createProvider()` | `packages/services/src/import/provider.ts` |
| provider `z.enum` (said router) | `importProviders` in `packages/services/src/import/schemas.ts` |

The last row is a small correction beyond the move: the enum is built from the `importProviders` list in `schemas.ts`, so that's the list a new provider needs adding to.

Docs only, no code changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

