### PR TITLE
chore: split workspace usage from get, tidy dashboard tRPC setup

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -50,9 +50,6 @@ async function HydrateSidebar({ children }: { children: React.ReactNode }) {
     queryClient.prefetchQuery(trpc.page.list.queryOptions()),
     queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
     queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
-    // The sidebar's getting-started banner reads these. Awaited only because
-    // nothing streams yet — it moves to `batchPrefetch` with step 2b.
-    queryClient.prefetchQuery(trpc.workspace.usage.queryOptions()),
     queryClient.prefetchQuery(trpc.workspace.list.queryOptions()),
     queryClient.prefetchQuery(trpc.user.get.queryOptions()),
   ]);

--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -50,6 +50,9 @@ async function HydrateSidebar({ children }: { children: React.ReactNode }) {
     queryClient.prefetchQuery(trpc.page.list.queryOptions()),
     queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
     queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
+    // The sidebar's getting-started banner reads these. Awaited only because
+    // nothing streams yet — it moves to `batchPrefetch` with step 2b.
+    queryClient.prefetchQuery(trpc.workspace.usage.queryOptions()),
     queryClient.prefetchQuery(trpc.workspace.list.queryOptions()),
     queryClient.prefetchQuery(trpc.user.get.queryOptions()),
   ]);

--- a/apps/dashboard/src/app/(dashboard)/settings/billing/client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/billing/client.tsx
@@ -81,6 +81,7 @@ export function Client() {
   const [isPending, startTransition] = useTransition();
   const [{ success }, setSearchParams] = useQueryStates(searchParamsParsers);
   const { data: workspace } = useQuery(trpc.workspace.get.queryOptions());
+  const { data: usage } = useQuery(trpc.workspace.usage.queryOptions());
   const customerPortalMutation = useMutation(
     trpc.stripeRouter.getUserCustomerPortal.mutationOptions({
       onSuccess: (url) => {
@@ -152,22 +153,22 @@ export function Client() {
               <div className="flex flex-col gap-2">
                 <BillingProgress
                   label="Monitors"
-                  value={workspace.usage?.monitors ?? 0}
+                  value={usage?.monitors ?? 0}
                   max={workspace.limits.monitors}
                 />
                 <BillingProgress
                   label="Status Pages"
-                  value={workspace.usage?.pages ?? 0}
+                  value={usage?.pages ?? 0}
                   max={workspace.limits["status-pages"]}
                 />
                 <BillingProgress
                   label="Page Components"
-                  value={workspace.usage?.pageComponents ?? 0}
+                  value={usage?.pageComponents ?? 0}
                   max={workspace.limits["page-components"]}
                 />
                 <BillingProgress
                   label="Notifications"
-                  value={workspace.usage?.notifications ?? 0}
+                  value={usage?.notifications ?? 0}
                   max={workspace.limits["notification-channels"]}
                 />
                 <BillingProgress

--- a/apps/dashboard/src/app/(dashboard)/status-pages/create/client.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/create/client.tsx
@@ -28,9 +28,8 @@ export function Client() {
     trpc.page.new.mutationOptions({
       onSuccess: (data) => {
         refetch();
-        // NOTE: invalidate workspace to update the usage
         queryClient.invalidateQueries({
-          queryKey: trpc.workspace.get.queryKey(),
+          queryKey: trpc.workspace.usage.queryKey(),
         });
         startTransition(() => {
           router.push(`/status-pages/${data.id}/edit`);

--- a/apps/dashboard/src/app/onboarding/client.tsx
+++ b/apps/dashboard/src/app/onboarding/client.tsx
@@ -83,14 +83,14 @@ export function Client() {
   const { data: monitors } = useQuery(trpc.monitor.list.queryOptions());
   const { data: pages } = useQuery(trpc.page.list.queryOptions());
 
-  // Invalidate so workspace counts (sidebar quota, plan gates) stay fresh.
+  // Invalidate so the getting-started counts stay fresh.
   const createMonitorMutation = useMutation(
     trpc.monitor.new.mutationOptions({
       onSuccess: async () => {
         await setSearchParams({ monitor: "completed" });
         await Promise.all([
           queryClient.invalidateQueries({
-            queryKey: trpc.workspace.get.queryKey(),
+            queryKey: trpc.workspace.usage.queryKey(),
           }),
           queryClient.invalidateQueries({
             queryKey: trpc.monitor.list.queryKey(),
@@ -105,7 +105,7 @@ export function Client() {
         await setSearchParams({ page: "completed" });
         await Promise.all([
           queryClient.invalidateQueries({
-            queryKey: trpc.workspace.get.queryKey(),
+            queryKey: trpc.workspace.usage.queryKey(),
           }),
           queryClient.invalidateQueries({
             queryKey: trpc.page.list.queryKey(),

--- a/apps/dashboard/src/components/data-table/monitors/data-table-action-bar.tsx
+++ b/apps/dashboard/src/components/data-table/monitors/data-table-action-bar.tsx
@@ -65,7 +65,7 @@ export function MonitorDataTableActionBar({
           queryKey: trpc.monitor.list.queryKey(),
         });
         queryClient.invalidateQueries({
-          queryKey: trpc.workspace.get.queryKey(),
+          queryKey: trpc.workspace.usage.queryKey(),
         });
         // Clear selection once deletion succeeds
         table.toggleAllRowsSelected(false);

--- a/apps/dashboard/src/components/forms/components/update.tsx
+++ b/apps/dashboard/src/components/forms/components/update.tsx
@@ -36,9 +36,9 @@ export function FormComponentsUpdate() {
   // "removed" (delete) and placeholders as "new" (create).
   const refetchAndRemount = async (...refetches: Promise<unknown>[]) => {
     await Promise.all(refetches);
-    // invalidate workspace to update the usage (getting-started checklist)
+    // the getting-started checklist reads these counts
     queryClient.invalidateQueries({
-      queryKey: trpc.workspace.get.queryKey(),
+      queryKey: trpc.workspace.usage.queryKey(),
     });
     setFormKey((k) => k + 1);
   };

--- a/apps/dashboard/src/components/forms/status-page/update.tsx
+++ b/apps/dashboard/src/components/forms/status-page/update.tsx
@@ -61,11 +61,9 @@ export function FormStatusPageUpdate() {
     trpc.page.delete.mutationOptions({
       onSuccess: () => {
         router.push("/status-pages");
-        // NOTE: invalidate workspace to update the usage
         queryClient.invalidateQueries({
-          queryKey: trpc.workspace.get.queryKey(),
+          queryKey: trpc.workspace.usage.queryKey(),
         });
-        // NOTE: invalidate status page list to update the usage
         queryClient.invalidateQueries({
           queryKey: trpc.page.list.queryKey(),
         });

--- a/apps/dashboard/src/components/nav/nav-banner-checklist.tsx
+++ b/apps/dashboard/src/components/nav/nav-banner-checklist.tsx
@@ -19,18 +19,20 @@ export function NavBannerChecklist({
   handleClose: () => void;
 }) {
   const trpc = useTRPC();
-  const { data: workspace } = useQuery(trpc.workspace.get.queryOptions());
+  const { data: usage } = useQuery(trpc.workspace.usage.queryOptions());
   const { data: pages } = useQuery(trpc.page.list.queryOptions());
 
-  if (!workspace) return null;
+  // Hide until the counts land — every item would read as unchecked and the
+  // banner would flash "0/5" before correcting itself.
+  if (!usage) return null;
 
   const onlyPage = pages?.length === 1 ? pages[0] : undefined;
 
-  const hasMonitors = (workspace.usage?.monitors ?? 0) > 0;
-  const hasStatusPages = (workspace.usage?.pages ?? 0) > 0;
-  const hasPageComponents = (workspace.usage?.pageComponents ?? 0) > 0;
-  const hasNotifications = (workspace.usage?.notifications ?? 0) > 0;
-  const hasStatusReports = (workspace.usage?.statusReports ?? 0) > 0;
+  const hasMonitors = usage.monitors > 0;
+  const hasStatusPages = usage.pages > 0;
+  const hasPageComponents = usage.pageComponents > 0;
+  const hasNotifications = usage.notifications > 0;
+  const hasStatusReports = usage.statusReports > 0;
 
   const items = [
     {

--- a/apps/dashboard/src/components/nav/nav-monitors.tsx
+++ b/apps/dashboard/src/components/nav/nav-monitors.tsx
@@ -58,7 +58,7 @@ export function NavMonitors() {
       onSuccess: () => {
         refetch();
         queryClient.invalidateQueries({
-          queryKey: trpc.workspace.get.queryKey(),
+          queryKey: trpc.workspace.usage.queryKey(),
         });
       },
     }),
@@ -68,7 +68,7 @@ export function NavMonitors() {
       onSuccess: (newMonitor) => {
         refetch();
         queryClient.invalidateQueries({
-          queryKey: trpc.workspace.get.queryKey(),
+          queryKey: trpc.workspace.usage.queryKey(),
         });
         router.push(`/monitors/${newMonitor.id}`);
       },

--- a/apps/dashboard/src/components/nav/nav-status-pages.tsx
+++ b/apps/dashboard/src/components/nav/nav-status-pages.tsx
@@ -54,7 +54,7 @@ export function NavStatusPages() {
       onSuccess: () => {
         refetch();
         queryClient.invalidateQueries({
-          queryKey: trpc.workspace.get.queryKey(),
+          queryKey: trpc.workspace.usage.queryKey(),
         });
       },
     }),

--- a/apps/dashboard/src/lib/trpc/client.tsx
+++ b/apps/dashboard/src/lib/trpc/client.tsx
@@ -1,27 +1,18 @@
 "use client";
 
 import type { AppRouter } from "@openstatus/api";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createTRPCClient } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
 import { useState } from "react";
 
+import { makeQueryClient } from "@/lib/trpc/query-client";
 import { endingLink, sentryLoggerLink } from "@/lib/trpc/shared";
 
 export const { TRPCProvider, useTRPC, useTRPCClient } =
   createTRPCContext<AppRouter>();
 
-function makeQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        // With SSR, we usually want to set some default staleTime
-        // above 0 to avoid refetching immediately on the client
-        staleTime: 60 * 1000,
-      },
-    },
-  });
-}
 let browserQueryClient: QueryClient | undefined = undefined;
 function getQueryClient() {
   if (typeof window === "undefined") {

--- a/apps/dashboard/src/lib/trpc/server.tsx
+++ b/apps/dashboard/src/lib/trpc/server.tsx
@@ -2,7 +2,7 @@ import "server-only";
 import type { AppRouter } from "@openstatus/api";
 import { HydrationBoundary } from "@tanstack/react-query";
 import { dehydrate } from "@tanstack/react-query";
-import { TRPCClientError, createTRPCClient } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 import {
   type ResolverDef,
   type TRPCQueryOptions,
@@ -91,6 +91,18 @@ export function batchPrefetch<T extends ReturnType<TRPCQueryOptions<any>>>(
   }
 }
 
+// Duck-typed rather than `instanceof TRPCClientError`: that check fails across
+// bundle boundaries, and an in-process caller throws `TRPCError` (bare `code`,
+// no `data`). tRPC matches on the same fields internally for this reason.
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const { code, data } = error as {
+    code?: unknown;
+    data?: { code?: unknown } | null;
+  };
+  return code === "NOT_FOUND" || data?.code === "NOT_FOUND";
+}
+
 /**
  * Fetches a query and calls `notFound()` if the server returns NOT_FOUND.
  * Use this for gating queries in layouts where the resource must exist.
@@ -104,9 +116,7 @@ export async function fetchQueryOrNotFound<
       ReturnType<Extract<T["queryFn"], (...args: never[]) => unknown>>
     >;
   } catch (error) {
-    if (error instanceof TRPCClientError && error.data?.code === "NOT_FOUND") {
-      notFound();
-    }
+    if (isNotFoundError(error)) notFound();
     throw error;
   }
 }

--- a/packages/api/src/router/workspace.ts
+++ b/packages/api/src/router/workspace.ts
@@ -1,6 +1,6 @@
 import { Events } from "@openstatus/analytics";
 import {
-  getWorkspaceWithUsage,
+  getWorkspaceUsage,
   updateWorkspaceName,
 } from "@openstatus/services/workspace";
 import { z } from "zod";
@@ -9,9 +9,14 @@ import { toServiceCtx, toTRPCError } from "../service-adapter";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const workspaceRouter = createTRPCRouter({
-  get: protectedProcedure.query(async ({ ctx }) => {
+  // The authed middleware already resolved and parsed this row; re-selecting
+  // it would be the same query. Counts live in `usage` — the shell reads
+  // `limits` on every route, the counts only on two surfaces.
+  get: protectedProcedure.query(({ ctx }) => ctx.workspace),
+
+  usage: protectedProcedure.query(async ({ ctx }) => {
     try {
-      return await getWorkspaceWithUsage({ ctx: toServiceCtx(ctx) });
+      return await getWorkspaceUsage({ ctx: toServiceCtx(ctx) });
     } catch (err) {
       toTRPCError(err);
     }

--- a/packages/services/src/workspace/__tests__/workspace.test.ts
+++ b/packages/services/src/workspace/__tests__/workspace.test.ts
@@ -26,7 +26,7 @@ import { ForbiddenError } from "../../errors";
 import {
   getWorkspace,
   getWorkspaceByStripeId,
-  getWorkspaceWithUsage,
+  getWorkspaceUsage,
   listWorkspaces,
   updateWorkspaceName,
   updateWorkspacePlan,
@@ -51,19 +51,18 @@ describe("getWorkspace", () => {
   });
 });
 
-describe("getWorkspaceWithUsage", () => {
-  test("attaches a zero-or-positive usage block", async () => {
+describe("getWorkspaceUsage", () => {
+  test("returns a zero-or-positive count for every key", async () => {
     await withTestTransaction(async (tx) => {
-      const result = await getWorkspaceWithUsage({
+      const result = await getWorkspaceUsage({
         ctx: { ...teamCtx, db: tx },
       });
-      expect(result.id).toBe(teamCtx.workspace.id);
 
       // Iterate the usage object *before* any `toMatchObject` call —
       // the `toMatchObject` implementation mutates the received
       // object in place, replacing number fields with the
       // `expect.any(Number)` asymmetric-matcher stub on the expected
-      // side. Subsequent reads of `result.usage.<key>` then return the
+      // side. Subsequent reads of `result.<key>` then return the
       // matcher object (typeof "object"), not the original count. Do
       // the value-shape + non-negative check first.
       for (const key of [
@@ -74,13 +73,13 @@ describe("getWorkspaceWithUsage", () => {
         "statusReports",
         "checks",
       ] as const) {
-        const value = result.usage[key];
+        const value = result[key];
         expect(typeof value).toBe("number");
         if (typeof value === "number") {
           expect(value).toBeGreaterThanOrEqual(0);
         }
       }
-      expect(result.usage.checks).toBe(0);
+      expect(result.checks).toBe(0);
     });
   });
 
@@ -91,10 +90,10 @@ describe("getWorkspaceWithUsage", () => {
         status: "investigating",
         title: "svc-ws-test-status-report",
       });
-      const result = await getWorkspaceWithUsage({
+      const result = await getWorkspaceUsage({
         ctx: { ...teamCtx, db: tx },
       });
-      expect(result.usage.statusReports).toBeGreaterThanOrEqual(1);
+      expect(result.statusReports).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -104,7 +103,7 @@ describe("getWorkspaceWithUsage", () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
       const workspaceId = teamCtx.workspace.id;
-      const before = (await getWorkspaceWithUsage({ ctx })).usage;
+      const before = await getWorkspaceUsage({ ctx });
 
       await tx.insert(monitor).values([
         { workspaceId, url: "https://a.example.dev", name: "svc-ws-usage-1" },
@@ -149,7 +148,7 @@ describe("getWorkspaceWithUsage", () => {
         title: "svc-ws-usage-report",
       });
 
-      const after = (await getWorkspaceWithUsage({ ctx })).usage;
+      const after = await getWorkspaceUsage({ ctx });
       expect(after.monitors).toBe(before.monitors + 2);
       expect(after.notifications).toBe(before.notifications + 1);
       expect(after.pages).toBe(before.pages + 1);
@@ -163,7 +162,7 @@ describe("getWorkspaceWithUsage", () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
       const workspaceId = teamCtx.workspace.id;
-      const before = (await getWorkspaceWithUsage({ ctx })).usage.monitors;
+      const before = (await getWorkspaceUsage({ ctx })).monitors;
 
       await tx.insert(monitor).values({
         workspaceId,
@@ -172,7 +171,7 @@ describe("getWorkspaceWithUsage", () => {
         deletedAt: new Date(),
       });
 
-      const after = (await getWorkspaceWithUsage({ ctx })).usage.monitors;
+      const after = (await getWorkspaceUsage({ ctx })).monitors;
       expect(after).toBe(before);
     });
   });
@@ -180,7 +179,7 @@ describe("getWorkspaceWithUsage", () => {
   test("does not count another workspace's rows", async () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
-      const before = (await getWorkspaceWithUsage({ ctx })).usage;
+      const before = await getWorkspaceUsage({ ctx });
 
       const [foreign] = await tx
         .insert(workspace)
@@ -203,7 +202,7 @@ describe("getWorkspaceWithUsage", () => {
         title: "svc-ws-usage-foreign-report",
       });
 
-      const after = (await getWorkspaceWithUsage({ ctx })).usage;
+      const after = await getWorkspaceUsage({ ctx });
       expect(after.monitors).toBe(before.monitors);
       expect(after.statusReports).toBe(before.statusReports);
     });

--- a/packages/services/src/workspace/index.ts
+++ b/packages/services/src/workspace/index.ts
@@ -1,17 +1,16 @@
 export {
   getWorkspace,
   getWorkspaceByStripeId,
-  getWorkspaceWithUsage,
+  getWorkspaceUsage,
   listWorkspaces,
   type WorkspaceUsage,
-  type WorkspaceWithUsage,
 } from "./list";
 export { downgradeWorkspaceToFree } from "./downgrade";
 export { updateWorkspaceName, updateWorkspacePlan } from "./update";
 export {
   GetWorkspaceByStripeIdInput,
   GetWorkspaceInput,
-  GetWorkspaceWithUsageInput,
+  GetWorkspaceUsageInput,
   ListWorkspacesInput,
   UpdateWorkspaceNameInput,
   UpdateWorkspacePlanInput,

--- a/packages/services/src/workspace/list.ts
+++ b/packages/services/src/workspace/list.ts
@@ -15,7 +15,7 @@ import { NotFoundError } from "../errors";
 import type { Workspace } from "../types";
 import {
   GetWorkspaceByStripeIdInput,
-  type GetWorkspaceWithUsageInput,
+  type GetWorkspaceUsageInput,
   ListWorkspacesInput,
 } from "./schemas";
 
@@ -32,8 +32,6 @@ export type WorkspaceUsage = {
   statusReports: number;
   checks: number;
 };
-
-export type WorkspaceWithUsage = Workspace & { usage: WorkspaceUsage };
 
 /** Load the workspace the caller is scoped to. */
 export async function getWorkspace(args: {
@@ -55,32 +53,12 @@ export async function getWorkspace(args: {
   return selectWorkspaceSchema.parse(result);
 }
 
-/**
- * Workspace plus the four usage counts the dashboard surfaces alongside plan
- * limits. Active monitors only (`deletedAt IS NULL`); notifications / pages /
- * page-components are unconditional counts scoped to the workspace.
- */
-export async function getWorkspaceWithUsage(args: {
-  ctx: ServiceContext;
-  input?: GetWorkspaceWithUsageInput;
-}): Promise<WorkspaceWithUsage> {
-  const { ctx } = args;
-  const db = ctx.db ?? defaultDb;
-  const workspaceId = ctx.workspace.id;
+// Counts, not rows: the previous relational read materialized every page,
+// component, monitor (with its config blobs) and notification just to call
+// `.length` on them. All five are single-table and index-covered.
+function usageCountQueries(db: DB, workspaceId: number) {
   const total = sql<number>`count(*)`;
-
-  // Counts, not rows: the previous relational read materialized every page,
-  // component, monitor (with its config blobs) and notification just to call
-  // `.length` on them.
-  const [
-    workspaceRows,
-    monitorRows,
-    notificationRows,
-    pageRows,
-    pageComponentRows,
-    statusReportRows,
-  ] = await batchReads(db, [
-    db.select().from(workspace).where(eq(workspace.id, workspaceId)),
+  return [
     db
       .select({ count: total })
       .from(monitor)
@@ -103,28 +81,36 @@ export async function getWorkspaceWithUsage(args: {
       .select({ count: total })
       .from(statusReport)
       .where(eq(statusReport.workspaceId, workspaceId)),
-  ]);
+  ] as const;
+}
 
-  const result = workspaceRows[0];
-
-  // Same guard as `getWorkspace` — unreachable in practice (workspace
-  // resolved upstream) but keeps the error shape consistent with every
-  // other service, rather than letting `parse(undefined)` surface as
-  // a `ZodError`.
-  if (!result) throw new NotFoundError("workspace", workspaceId);
-
-  const usage: WorkspaceUsage = {
-    monitors: monitorRows[0]?.count ?? 0,
-    notifications: notificationRows[0]?.count ?? 0,
-    pages: pageRows[0]?.count ?? 0,
-    pageComponents: pageComponentRows[0]?.count ?? 0,
-    statusReports: statusReportRows[0]?.count ?? 0,
+function toUsage(rows: { count: number }[][]): WorkspaceUsage {
+  const [monitors, notifications, pages, pageComponents, statusReports] = rows;
+  return {
+    monitors: monitors?.[0]?.count ?? 0,
+    notifications: notifications?.[0]?.count ?? 0,
+    pages: pages?.[0]?.count ?? 0,
+    pageComponents: pageComponents?.[0]?.count ?? 0,
+    statusReports: statusReports?.[0]?.count ?? 0,
     // Parity with the legacy router — checks usage was previously commented
     // out pending a real source and left as 0. Preserved here.
     checks: 0,
   };
+}
 
-  return { ...selectWorkspaceSchema.parse(result), usage };
+/**
+ * The usage counts the dashboard surfaces alongside plan limits. Active
+ * monitors only (`deletedAt IS NULL`); notifications / pages / page-components
+ * are unconditional counts scoped to the workspace.
+ */
+export async function getWorkspaceUsage(args: {
+  ctx: ServiceContext;
+  input?: GetWorkspaceUsageInput;
+}): Promise<WorkspaceUsage> {
+  const { ctx } = args;
+  const db = ctx.db ?? defaultDb;
+
+  return toUsage(await batchReads(db, usageCountQueries(db, ctx.workspace.id)));
 }
 
 /**

--- a/packages/services/src/workspace/schemas.ts
+++ b/packages/services/src/workspace/schemas.ts
@@ -5,10 +5,8 @@ import { z } from "zod";
 export const GetWorkspaceInput = z.object({}).strict();
 export type GetWorkspaceInput = z.infer<typeof GetWorkspaceInput>;
 
-export const GetWorkspaceWithUsageInput = z.object({}).strict();
-export type GetWorkspaceWithUsageInput = z.infer<
-  typeof GetWorkspaceWithUsageInput
->;
+export const GetWorkspaceUsageInput = z.object({}).strict();
+export type GetWorkspaceUsageInput = z.infer<typeof GetWorkspaceUsageInput>;
 
 export const ListWorkspacesInput = z.object({ userId: z.number().int() });
 export type ListWorkspacesInput = z.infer<typeof ListWorkspacesInput>;


### PR DESCRIPTION
Two small cleanups on top of the dashboard shell prefetch work.

### Split `usage` out of `workspace.get`

`workspace.get` was calling `getWorkspaceWithUsage`, so every route in the shell paid for five `count(*)` queries plus a redundant re-select of the workspace row — even though the authed middleware has already resolved and parsed that row, and only two surfaces (billing, onboarding checklist) actually read the counts.

- `workspace.get` now returns `ctx.workspace` directly — no query.
- New `workspace.usage` procedure backed by `getWorkspaceUsage`, which returns just the counts (`WorkspaceWithUsage` is gone; `WorkspaceUsage` stays).
- Consumers that only needed `limits` read them off `workspace.get`; billing and the nav checklist opt into `workspace.usage`.

The count queries themselves are unchanged (active monitors only, everything workspace-scoped), so the existing `getWorkspaceUsage` tests carry over with the result shape flattened from `result.usage.x` to `result.x`.

### tRPC client/server tidy-up

- `apps/dashboard/src/lib/trpc/client.tsx` had its own inline `makeQueryClient` that drifted from the shared `query-client.ts` one — it was missing the `dehydrate.shouldDehydrateQuery` option that keeps pending queries streamable. No behaviour change today (the browser instance is never dehydrated), but it means future global defaults land in one place instead of two.
- `fetchQueryOrNotFound` matched `error instanceof TRPCClientError`, which fails across bundle boundaries and never matches the bare `TRPCError` an in-process caller throws. Replaced with a duck-typed `isNotFoundError` check on `code` / `data.code`, the same fields tRPC matches on internally.

<sub>Both commits are dashboard-only apart from the `workspace` service and router.</sub>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

