### PR TITLE
ci: run Go tests on pushes to main

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -3,7 +3,7 @@ name: Go Tests
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - '*.*.*'
   pull_request:


### PR DESCRIPTION
The Go Tests workflow has `push.branches: [master]`, but the default branch is `main` and no `master` ref exists (`git ls-remote` shows only `main`; the other workflows all trigger on `main`). So the Go suites for `apps/checker` and `apps/private-location` only ever run on pull requests, never after a merge — recent runs of this workflow are all `pull_request` events.

One-line change so post-merge pushes run the tests too. No way to exercise this locally; it only shows up in Actions after merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

