### PR TITLE
perf: stop blocking dashboard render on prefetches, bound /overview history

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/chat/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/chat/layout.tsx
@@ -11,7 +11,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
@@ -23,8 +23,7 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   // Prefetch the conversation list so the right sidebar paints immediately.
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.chatSession.list.queryOptions());
+  prefetch(trpc.chatSession.list.queryOptions());
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/invite/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/invite/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import type { SearchParams } from "nuqs";
 
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
@@ -15,8 +15,7 @@ export default async function InvitePage(props: {
     return redirect("/overview");
   }
 
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.invitation.get.queryOptions({ token }));
+  prefetch(trpc.invitation.get.queryOptions({ token }));
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -12,7 +12,7 @@ import {
   LEFT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 export default async function Layout({
   children,
@@ -44,14 +44,16 @@ export default async function Layout({
   );
 }
 
-async function HydrateSidebar({ children }: { children: React.ReactNode }) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
-    queryClient.prefetchQuery(trpc.workspace.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.user.get.queryOptions()),
+function HydrateSidebar({ children }: { children: React.ReactNode }) {
+  // Not awaited: the pending queries are dehydrated and streamed to the client
+  // (see `shouldDehydrateQuery` in lib/trpc/query-client). Awaiting here made
+  // the shell's slowest query the TTFB of every dashboard route.
+  batchPrefetch([
+    trpc.page.list.queryOptions(),
+    trpc.monitor.list.queryOptions(),
+    trpc.workspace.get.queryOptions(),
+    trpc.workspace.list.queryOptions(),
+    trpc.user.get.queryOptions(),
   ]);
 
   return <HydrateClient>{children}</HydrateClient>;

--- a/apps/dashboard/src/app/(dashboard)/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@openstatus/ui/components/ui/skeleton";
+
+/**
+ * Fallback for segment transitions. The shell (sidebar, header) is rendered by
+ * the surrounding layout and stays put — only the main area swaps.
+ */
+export default function Loading() {
+  return (
+    <div className="flex w-full flex-1 flex-col gap-4 p-4">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-4 w-72" />
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/monitors/(list)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/(list)/page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "nuqs";
 
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
@@ -10,13 +10,12 @@ export default async function Page({
 }: {
   searchParams: Promise<SearchParams>;
 }) {
-  const queryClient = getQueryClient();
-
-  await Promise.all([
-    searchParamsCache.parse(searchParams),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions()),
+  batchPrefetch([
+    trpc.monitor.list.queryOptions(),
+    trpc.monitorTag.list.queryOptions(),
   ]);
+  // NOTE: store in cache to avoid flicker on clients first render
+  await searchParamsCache.parse(searchParams);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/edit/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/edit/layout.tsx
@@ -1,14 +1,9 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.monitorTag.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.monitorTag.list.queryOptions(),
+    trpc.privateLocation.list.queryOptions(),
   ]);
 
   return <HydrateClient>{children}</HydrateClient>;

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/incidents/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/incidents/layout.tsx
@@ -16,9 +16,7 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  prefetch(
-    trpc.incident.list.queryOptions({ monitorId: Number.parseInt(id) }),
-  );
+  prefetch(trpc.incident.list.queryOptions({ monitorId: Number.parseInt(id) }));
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/incidents/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/incidents/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { getQueryClient, trpc } from "@/lib/trpc/server";
+import { prefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -15,9 +15,8 @@ export default async function Layout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const queryClient = getQueryClient();
   const { id } = await params;
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.incident.list.queryOptions({ monitorId: Number.parseInt(id) }),
   );
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);

--- a/apps/dashboard/src/app/(dashboard)/monitors/[id]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/monitors/[id]/layout.tsx
@@ -6,8 +6,8 @@ import {
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
 import {
   HydrateClient,
+  batchPrefetch,
   fetchQueryOrNotFound,
-  getQueryClient,
   trpc,
 } from "@/lib/trpc/server";
 
@@ -23,15 +23,16 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
+  // Started before the gate is awaited so the 404 check costs one round trip
+  // rather than serialising ahead of its siblings.
+  batchPrefetch([
+    trpc.notification.list.queryOptions(),
+    trpc.privateLocation.list.queryOptions(),
+  ]);
   await fetchQueryOrNotFound(
     trpc.monitor.get.queryOptions({ id: Number.parseInt(id) }),
   );
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.notification.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
-  ]);
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/notifications/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/notifications/layout.tsx
@@ -4,7 +4,7 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
@@ -14,8 +14,7 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.notification.list.queryOptions());
+  prefetch(trpc.notification.list.queryOptions());
   return (
     <HydrateClient>
       <AppHeader>

--- a/apps/dashboard/src/app/(dashboard)/overview/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/overview/layout.tsx
@@ -4,25 +4,22 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { overviewActiveOrClosedSince } from "@/data/overview-window";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
+export default function Layout({ children }: { children: React.ReactNode }) {
+  const activeOrClosedSince = overviewActiveOrClosedSince();
 
   // inputs must match page.tsx's queries exactly — a differing input misses the cache
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.incident.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.statusReport.list.queryOptions({})),
-    queryClient.prefetchQuery(trpc.maintenance.list.queryOptions()),
+  batchPrefetch([
+    trpc.monitor.list.queryOptions(),
+    trpc.page.list.queryOptions(),
+    trpc.incident.list.queryOptions({ activeOrClosedSince }),
+    trpc.statusReport.list.queryOptions({ activeOrClosedSince }),
+    trpc.maintenance.list.queryOptions({ activeOrClosedSince }),
   ]);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/overview/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/overview/page.tsx
@@ -29,24 +29,34 @@ import {
 } from "@/components/metric/metric-card";
 import { DataTable } from "@/components/ui/data-table/data-table";
 import { buildOverviewData } from "@/data/overview-events.client";
+import { overviewActiveOrClosedSince } from "@/data/overview-window";
 import { useTRPC } from "@/lib/trpc/client";
 
 import { CreateEventButtonGroup } from "./create-event-button-group";
+import { OverviewSkeleton } from "./skeleton";
 
 export default function Page() {
   const trpc = useTRPC();
 
+  // Not a period filter: everything still open is returned regardless of age,
+  // so an incident open for weeks still surfaces. Only *closed* rows are
+  // windowed, and those are all this page renders under "Recent Activity".
+  const activeOrClosedSince = overviewActiveOrClosedSince();
+
   const { data: monitors } = useQuery(trpc.monitor.list.queryOptions());
   const { data: pages } = useQuery(trpc.page.list.queryOptions());
-  // no period — an incident open for weeks must still surface here
-  const { data: incidents } = useQuery(trpc.incident.list.queryOptions());
-  const { data: statusReports } = useQuery(
-    trpc.statusReport.list.queryOptions({}),
+  const { data: incidents } = useQuery(
+    trpc.incident.list.queryOptions({ activeOrClosedSince }),
   );
-  const { data: maintenances } = useQuery(trpc.maintenance.list.queryOptions());
+  const { data: statusReports } = useQuery(
+    trpc.statusReport.list.queryOptions({ activeOrClosedSince }),
+  );
+  const { data: maintenances } = useQuery(
+    trpc.maintenance.list.queryOptions({ activeOrClosedSince }),
+  );
 
   if (!monitors || !pages || !incidents || !statusReports || !maintenances)
-    return null;
+    return <OverviewSkeleton />;
 
   const { needsAttention, upcomingMaintenances, recentlyResolved, metrics } =
     buildOverviewData({

--- a/apps/dashboard/src/app/(dashboard)/overview/skeleton.tsx
+++ b/apps/dashboard/src/app/(dashboard)/overview/skeleton.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@openstatus/ui/components/ui/skeleton";
+
+import {
+  SectionDescription,
+  SectionGroup,
+  SectionHeader,
+  SectionTitle,
+} from "@/components/content/section";
+import { Section } from "@/components/content/section";
+import {
+  MetricCard,
+  MetricCardGroup,
+  MetricCardHeader,
+  MetricCardTitle,
+} from "@/components/metric/metric-card";
+import { DataTableSkeleton } from "@/components/ui/data-table/data-table-skeleton";
+
+const METRIC_COUNT = 5;
+
+/**
+ * Mirrors the section/card structure of `page.tsx` so the streamed shell and
+ * the loaded page occupy the same space — a smaller placeholder would shift
+ * the layout on hydration.
+ */
+export function OverviewSkeleton() {
+  return (
+    <SectionGroup>
+      <Section>
+        <SectionHeader>
+          <SectionTitle>Overview</SectionTitle>
+          <SectionDescription>
+            Welcome to your OpenStatus dashboard.
+          </SectionDescription>
+        </SectionHeader>
+        <MetricCardGroup>
+          {Array.from({ length: METRIC_COUNT }).map((_, i) => (
+            <MetricCard key={i}>
+              <MetricCardHeader className="flex items-center justify-between gap-2">
+                <MetricCardTitle className="truncate">
+                  <Skeleton className="h-4 w-24" />
+                </MetricCardTitle>
+                <Skeleton className="size-4 shrink-0" />
+              </MetricCardHeader>
+              <Skeleton className="h-8 w-12" />
+            </MetricCard>
+          ))}
+        </MetricCardGroup>
+      </Section>
+      <Section>
+        <SectionHeader>
+          <SectionTitle>Needs Attention</SectionTitle>
+          <SectionDescription>
+            Everything currently unresolved, newest first.
+          </SectionDescription>
+        </SectionHeader>
+        <DataTableSkeleton />
+      </Section>
+      <Section>
+        <SectionHeader>
+          <SectionTitle>Recent Activity</SectionTitle>
+          <SectionDescription>
+            Resolved incidents and reports, and completed maintenances from the
+            last 7 days.
+          </SectionDescription>
+        </SectionHeader>
+        <DataTableSkeleton />
+      </Section>
+    </SectionGroup>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/settings/account/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/account/layout.tsx
@@ -4,7 +4,7 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
@@ -15,8 +15,7 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.member.list.queryOptions());
+  prefetch(trpc.member.list.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/settings/audit-logs/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/audit-logs/layout.tsx
@@ -4,7 +4,7 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
@@ -15,8 +15,7 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.auditLog.list.queryOptions({}));
+  prefetch(trpc.auditLog.list.queryOptions({}));
   return (
     <HydrateClient>
       <div>

--- a/apps/dashboard/src/app/(dashboard)/settings/general/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/general/layout.tsx
@@ -4,22 +4,17 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.member.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.invitation.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.apiKey.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.member.list.queryOptions(),
+    trpc.invitation.list.queryOptions(),
+    trpc.apiKey.list.queryOptions(),
   ]);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/settings/integrations/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/integrations/layout.tsx
@@ -4,21 +4,16 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.integrationRouter.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.integrationRouter.list.queryOptions(),
+    trpc.workspace.get.queryOptions(),
   ]);
 
   return (

--- a/apps/dashboard/src/app/(dashboard)/settings/private-locations/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/private-locations/layout.tsx
@@ -4,21 +4,16 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
 import { NavActions } from "./nav-actions";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.notification.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.privateLocation.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.notification.list.queryOptions(),
+    trpc.privateLocation.list.queryOptions(),
   ]);
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/settings/sso/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/sso/layout.tsx
@@ -4,7 +4,7 @@ import {
   AppHeaderContent,
 } from "@/components/nav/app-header";
 import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Tabs } from "../tabs";
 import { Breadcrumb } from "./breadcrumb";
@@ -15,8 +15,7 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(trpc.workspace.get.queryOptions());
+  prefetch(trpc.workspace.get.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/status-pages/(list)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/(list)/page.tsx
@@ -1,11 +1,9 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 
-export default async function Page() {
-  const queryClient = getQueryClient();
-
-  await queryClient.prefetchQuery(trpc.page.list.queryOptions());
+export default function Page() {
+  prefetch(trpc.page.list.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/components/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/components/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -16,16 +16,11 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
-  await Promise.all([
-    queryClient.prefetchQuery(
-      trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
-    ),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(
-      trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
-    ),
+  batchPrefetch([
+    trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
+    trpc.monitor.list.queryOptions(),
+    trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
   ]);
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -16,16 +16,11 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
-  await Promise.all([
-    queryClient.prefetchQuery(
-      trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
-    ),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(
-      trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
-    ),
+  batchPrefetch([
+    trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
+    trpc.monitor.list.queryOptions(),
+    trpc.pageComponent.list.queryOptions({ pageId: Number.parseInt(id) }),
   ]);
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);
 

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/history/page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "nuqs";
 
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Client } from "./client";
 import { searchParamsCache } from "./search-params";
@@ -13,11 +13,10 @@ export default async function Page({
   searchParams: Promise<SearchParams>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
   // NOTE: store in cache to avoid flicker on clients first render
   await searchParamsCache.parse(searchParams);
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.page.getUptimeHistory.queryOptions({ id: Number.parseInt(id) }),
   );
 

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/layout.tsx
@@ -7,7 +7,7 @@ import { AppSidebarTrigger } from "@/components/nav/app-sidebar";
 import {
   HydrateClient,
   fetchQueryOrNotFound,
-  getQueryClient,
+  prefetch,
   trpc,
 } from "@/lib/trpc/server";
 
@@ -23,12 +23,13 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
+  // Started before the gate is awaited so the 404 check costs one round trip
+  // rather than serialising ahead of it.
+  prefetch(trpc.monitor.list.queryOptions());
   await fetchQueryOrNotFound(
     trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
   );
-  await queryClient.prefetchQuery(trpc.monitor.list.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -16,9 +16,8 @@ export default async function Layout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const queryClient = getQueryClient();
 
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.maintenance.list.queryOptions({
       pageId: Number.parseInt(id),
     }),

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/status-reports/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/status-reports/layout.tsx
@@ -4,7 +4,7 @@ import {
   RIGHT_SIDEBAR_COOKIE,
   getSidebarDefaultOpen,
 } from "@/lib/sidebar-cookie";
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 import { Sidebar } from "../sidebar";
 
@@ -15,9 +15,8 @@ export default async function Layout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const queryClient = getQueryClient();
   const { id } = await params;
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.statusReport.list.queryOptions({ pageId: Number.parseInt(id) }),
   );
   const defaultOpen = await getSidebarDefaultOpen(RIGHT_SIDEBAR_COOKIE, false);

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/subscribers/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/subscribers/layout.tsx
@@ -1,4 +1,4 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, prefetch, trpc } from "@/lib/trpc/server";
 
 export default async function Layout({
   children,
@@ -7,10 +7,9 @@ export default async function Layout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const queryClient = getQueryClient();
   const { id } = await params;
 
-  await queryClient.prefetchQuery(
+  prefetch(
     trpc.pageSubscriber.list.queryOptions({ pageId: Number.parseInt(id) }),
   );
 

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -11,7 +11,6 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 import { TailwindIndicator } from "@/components/tailwind-indicator";
 import { ThemeProvider } from "@/components/theme-provider";
-import { auth } from "@/lib/auth";
 import { TRPCReactProvider } from "@/lib/trpc/client";
 
 import { ogMetadata, twitterMetadata } from "./metadata";
@@ -75,13 +74,11 @@ export const metadata: Metadata = {
 
 // export const dynamic = "error";
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const session = await auth();
-
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -94,7 +91,7 @@ export default async function RootLayout({
           "font-sans antialiased",
         )}
       >
-        <SessionProvider session={session}>
+        <SessionProvider>
           <TRPCReactProvider>
             <NuqsAdapter>
               <ThemeProvider

--- a/apps/dashboard/src/app/onboarding/layout.tsx
+++ b/apps/dashboard/src/app/onboarding/layout.tsx
@@ -1,16 +1,11 @@
-import { HydrateClient, getQueryClient, trpc } from "@/lib/trpc/server";
+import { HydrateClient, batchPrefetch, trpc } from "@/lib/trpc/server";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const queryClient = getQueryClient();
-  await Promise.all([
-    queryClient.prefetchQuery(trpc.workspace.get.queryOptions()),
-    queryClient.prefetchQuery(trpc.user.get.queryOptions()),
-    queryClient.prefetchQuery(trpc.monitor.list.queryOptions()),
-    queryClient.prefetchQuery(trpc.page.list.queryOptions()),
+export default function Layout({ children }: { children: React.ReactNode }) {
+  batchPrefetch([
+    trpc.workspace.get.queryOptions(),
+    trpc.user.get.queryOptions(),
+    trpc.monitor.list.queryOptions(),
+    trpc.page.list.queryOptions(),
   ]);
 
   return <HydrateClient>{children}</HydrateClient>;

--- a/apps/dashboard/src/data/overview-window.ts
+++ b/apps/dashboard/src/data/overview-window.ts
@@ -1,0 +1,18 @@
+export const OVERVIEW_WINDOW_DAYS = 7;
+
+/**
+ * Start of the window `/overview` renders: everything still open, plus what
+ * closed in the last {@link OVERVIEW_WINDOW_DAYS} days.
+ *
+ * Truncated to the hour so the server prefetch and the client query hash to the
+ * same tRPC query key — an exact `new Date()` on each side would differ by
+ * milliseconds and miss the hydrated cache. Flooring widens the window, so the
+ * result is always a superset of what the page filters down to.
+ */
+export function overviewActiveOrClosedSince(now = new Date()): Date {
+  const hour = new Date(now);
+  hour.setUTCMinutes(0, 0, 0);
+  return new Date(
+    hour.getTime() - OVERVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  );
+}

--- a/apps/dashboard/src/data/overview-window.ts
+++ b/apps/dashboard/src/data/overview-window.ts
@@ -12,7 +12,5 @@ export const OVERVIEW_WINDOW_DAYS = 7;
 export function overviewActiveOrClosedSince(now = new Date()): Date {
   const hour = new Date(now);
   hour.setUTCMinutes(0, 0, 0);
-  return new Date(
-    hour.getTime() - OVERVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000,
-  );
+  return new Date(hour.getTime() - OVERVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000);
 }

--- a/packages/api/src/router/incident.ts
+++ b/packages/api/src/router/incident.ts
@@ -37,6 +37,7 @@ export const incidentRouter = createTRPCRouter({
           period: z.enum(periods).optional(),
           monitorId: z.number().nullish(),
           order: z.enum(["asc", "desc"]).optional(),
+          activeOrClosedSince: z.coerce.date().optional(),
         })
         .optional(),
     )
@@ -48,6 +49,7 @@ export const incidentRouter = createTRPCRouter({
             monitorId: input?.monitorId ?? undefined,
             period: input?.period,
             order: input?.order ?? "desc",
+            activeOrClosedSince: input?.activeOrClosedSince,
             // Same sentinel as status-report / maintenance — dashboard has
             // no paging UI; Connect-equivalent would cap externally.
             limit: 10_000,

--- a/packages/api/src/router/maintenance.ts
+++ b/packages/api/src/router/maintenance.ts
@@ -42,6 +42,7 @@ export const maintenanceRouter = createTRPCRouter({
           period: z.enum(periods).optional(),
           pageId: z.number().optional(),
           order: z.enum(["asc", "desc"]).optional(),
+          activeOrClosedSince: z.coerce.date().optional(),
         })
         .optional(),
     )
@@ -53,6 +54,7 @@ export const maintenanceRouter = createTRPCRouter({
             pageId: input?.pageId,
             period: input?.period,
             order: input?.order ?? "desc",
+            activeOrClosedSince: input?.activeOrClosedSince,
             // tRPC callers (dashboard) want the full set — see
             // statusReport.list for the same reasoning.
             limit: 10_000,

--- a/packages/api/src/router/statusReport.ts
+++ b/packages/api/src/router/statusReport.ts
@@ -203,6 +203,7 @@ export const statusReportRouter = createTRPCRouter({
         period: z.enum(periods).optional(),
         order: z.enum(["asc", "desc"]).optional(),
         pageId: z.number().optional(),
+        activeOrClosedSince: z.coerce.date().optional(),
       }),
     )
     .query(async ({ ctx, input }) => {
@@ -213,6 +214,7 @@ export const statusReportRouter = createTRPCRouter({
             pageId: input.pageId,
             period: input.period,
             order: input.order ?? "desc",
+            activeOrClosedSince: input.activeOrClosedSince,
             // tRPC consumers (dashboard) want the full set — no paging UI
             // today. Pass a sentinel ceiling rather than silently truncating;
             // Connect's separate handler imposes its own max=100.

--- a/packages/services/src/incident/__tests__/incident.test.ts
+++ b/packages/services/src/incident/__tests__/incident.test.ts
@@ -315,4 +315,44 @@ describe("list / get", () => {
       expect(ours[1]?.monitor?.id).toBe(testMonitorId);
     });
   });
+
+  test("activeOrClosedSince keeps every open incident regardless of age", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const day = 24 * 60 * 60 * 1000;
+
+      const open = await insertIncident(tx, {
+        workspaceId: teamCtx.workspace.id,
+        monitorId: testMonitorId,
+      });
+      const recentlyResolved = await insertIncident(tx, {
+        workspaceId: teamCtx.workspace.id,
+        monitorId: testMonitorId,
+        resolvedAt: new Date(Date.now() - 2 * day),
+      });
+      const longResolved = await insertIncident(tx, {
+        workspaceId: teamCtx.workspace.id,
+        monitorId: testMonitorId,
+        resolvedAt: new Date(Date.now() - 30 * day),
+      });
+
+      const { items } = await listIncidents({
+        ctx,
+        input: {
+          limit: 100,
+          offset: 0,
+          order: "desc",
+          monitorId: testMonitorId,
+          activeOrClosedSince: new Date(Date.now() - 7 * day),
+        },
+      });
+
+      const ids = items.map((i) => i.id);
+      // Open incidents are never windowed out — an incident open for weeks
+      // must still surface on /overview.
+      expect(ids).toContain(open.id);
+      expect(ids).toContain(recentlyResolved.id);
+      expect(ids).not.toContain(longResolved.id);
+    });
+  });
 });

--- a/packages/services/src/incident/list.ts
+++ b/packages/services/src/incident/list.ts
@@ -7,6 +7,8 @@ import {
   eq,
   gte,
   inArray,
+  isNull,
+  or,
   sql,
 } from "@openstatus/db";
 import {
@@ -97,12 +99,23 @@ export async function listIncidents(args: {
   const input = ListIncidentsInput.parse(args.input);
   const db = ctx.db ?? defaultDb;
 
-  const conditions: SQL[] = [eq(incidentTable.workspaceId, ctx.workspace.id)];
+  // `or(...)` is typed `SQL | undefined`, and `and()` drops undefined entries.
+  const conditions: (SQL | undefined)[] = [
+    eq(incidentTable.workspaceId, ctx.workspace.id),
+  ];
   if (input.monitorId !== undefined) {
     conditions.push(eq(incidentTable.monitorId, input.monitorId));
   }
   if (input.period !== undefined) {
     conditions.push(gte(incidentTable.startedAt, periodToSince(input.period)));
+  }
+  if (input.activeOrClosedSince !== undefined) {
+    conditions.push(
+      or(
+        isNull(incidentTable.resolvedAt),
+        gte(incidentTable.resolvedAt, input.activeOrClosedSince),
+      ),
+    );
   }
   const whereClause = and(...conditions);
 

--- a/packages/services/src/incident/schemas.ts
+++ b/packages/services/src/incident/schemas.ts
@@ -26,5 +26,10 @@ export const ListIncidentsInput = z.object({
   period: incidentListPeriodSchema.optional(),
   monitorId: z.number().int().optional(),
   order: z.enum(["asc", "desc"]).default("desc"),
+  /**
+   * Keep every unresolved incident, plus those resolved at or after this date.
+   * Lets a caller that only renders current state skip the full history.
+   */
+  activeOrClosedSince: z.coerce.date().optional(),
 });
 export type ListIncidentsInput = z.infer<typeof ListIncidentsInput>;

--- a/packages/services/src/maintenance/list.ts
+++ b/packages/services/src/maintenance/list.ts
@@ -110,6 +110,11 @@ export async function listMaintenances(args: {
   if (input.period !== undefined) {
     conditions.push(gte(maintenance.createdAt, periodToSince(input.period)));
   }
+  if (input.activeOrClosedSince !== undefined) {
+    // A window is in-progress or upcoming exactly while `to >= now`, so this
+    // one predicate covers both "still active" and "ended recently".
+    conditions.push(gte(maintenance.to, input.activeOrClosedSince));
+  }
   const whereClause = and(...conditions);
 
   // Count and page queries run in parallel outside a transaction — a

--- a/packages/services/src/maintenance/schemas.ts
+++ b/packages/services/src/maintenance/schemas.ts
@@ -50,6 +50,12 @@ export const ListMaintenancesInput = z.object({
   pageId: z.number().int().optional(),
   period: maintenanceListPeriodSchema.optional(),
   order: z.enum(["asc", "desc"]).default("desc"),
+  /**
+   * Keep every in-progress or upcoming window, plus those that ended at or
+   * after this date. Lets a caller that only renders current state skip the
+   * full history.
+   */
+  activeOrClosedSince: z.coerce.date().optional(),
 });
 export type ListMaintenancesInput = z.infer<typeof ListMaintenancesInput>;
 

--- a/packages/services/src/monitor/__tests__/reads.test.ts
+++ b/packages/services/src/monitor/__tests__/reads.test.ts
@@ -17,11 +17,11 @@ import {
 import type { DrizzleTx, ServiceContext } from "../../context";
 import { ForbiddenError, NotFoundError, ValidationError } from "../../errors";
 import { createMonitor } from "../create";
-import { listMonitors } from "../list";
 import { fetchMonitorDailyStats } from "../get-daily-summary";
 import { getMonitorStatus } from "../get-monitor-status";
 import { getMonitorSummary } from "../get-monitor-summary";
 import { getResponseLog } from "../get-response-log";
+import { listMonitors } from "../list";
 import { listResponseLogs } from "../list-response-logs";
 import { getPrivateLocationIdsByMonitor } from "../private-locations";
 

--- a/packages/services/src/monitor/__tests__/reads.test.ts
+++ b/packages/services/src/monitor/__tests__/reads.test.ts
@@ -1,5 +1,6 @@
 import { eq } from "@openstatus/db";
 import {
+  incidentTable,
   monitor,
   monitorStatusTable,
   privateLocation,
@@ -13,9 +14,10 @@ import {
   makeUserCtx,
   withTestTransaction,
 } from "../../../test/helpers";
-import type { ServiceContext } from "../../context";
+import type { DrizzleTx, ServiceContext } from "../../context";
 import { ForbiddenError, NotFoundError, ValidationError } from "../../errors";
 import { createMonitor } from "../create";
+import { listMonitors } from "../list";
 import { fetchMonitorDailyStats } from "../get-daily-summary";
 import { getMonitorStatus } from "../get-monitor-status";
 import { getMonitorSummary } from "../get-monitor-summary";
@@ -33,6 +35,88 @@ beforeAll(async () => {
   const free = (await createWorkspaceFixture("free")).workspace;
   teamCtx = makeUserCtx(team, { userId: 1 });
   freeCtx = makeUserCtx(free, { userId: 2 });
+});
+
+function insertIncidentRow(
+  tx: DrizzleTx,
+  opts: {
+    monitorId: number;
+    workspaceId: number;
+    startedAt: Date;
+    resolvedAt: Date | null;
+  },
+) {
+  return tx
+    .insert(incidentTable)
+    .values({
+      monitorId: opts.monitorId,
+      workspaceId: opts.workspaceId,
+      startedAt: opts.startedAt,
+      resolvedAt: opts.resolvedAt,
+    })
+    .returning()
+    .get();
+}
+
+describe("listMonitors incident enrichment", () => {
+  test("returns open incidents plus the latest, newest first", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const row = await createMonitor({
+        ctx,
+        input: {
+          name: `${TEST_PREFIX}-incident-window`,
+          jobType: "http",
+          url: "https://example.com",
+          method: "GET",
+          headers: [],
+          assertions: [],
+          active: false,
+          regions: ["ams"],
+        },
+      });
+
+      const minute = 60 * 1000;
+      const at = (agoMinutes: number) =>
+        new Date(Date.now() - agoMinutes * minute);
+      // Unique (monitor_id, started_at) — each row needs a distinct start.
+      // The newest row is resolved and the open one is older, so the two
+      // branches of the filter are exercised independently.
+      const oldResolved = await insertIncidentRow(tx, {
+        monitorId: row.id,
+        workspaceId: teamCtx.workspace.id,
+        startedAt: at(50),
+        resolvedAt: at(45),
+      });
+      const open = await insertIncidentRow(tx, {
+        monitorId: row.id,
+        workspaceId: teamCtx.workspace.id,
+        startedAt: at(40),
+        resolvedAt: null,
+      });
+      const newestResolved = await insertIncidentRow(tx, {
+        monitorId: row.id,
+        workspaceId: teamCtx.workspace.id,
+        startedAt: at(20),
+        resolvedAt: at(15),
+      });
+
+      const { items } = await listMonitors({
+        ctx,
+        input: { limit: 100, offset: 0, order: "desc" },
+      });
+      const mine = items.find((m) => m.id === row.id);
+      const ids = (mine?.incidents ?? []).map((i) => i.id);
+
+      // Latest by startedAt, plus everything unresolved. The older resolved
+      // row is dropped rather than pulling the monitor's whole history.
+      expect(ids).toContain(newestResolved.id);
+      expect(ids).toContain(open.id);
+      expect(ids).not.toContain(oldResolved.id);
+      // `incidents[0]` drives the "Last Incident" column, so ordering matters.
+      expect(ids[0]).toBe(newestResolved.id);
+    });
+  });
 });
 
 describe("getMonitorStatus", () => {

--- a/packages/services/src/monitor/list.ts
+++ b/packages/services/src/monitor/list.ts
@@ -5,8 +5,10 @@ import {
   db as defaultDb,
   desc,
   eq,
+  getTableColumns,
   inArray,
   isNull,
+  or,
   sql,
 } from "@openstatus/db";
 import {
@@ -54,6 +56,42 @@ export type ListMonitorsResult = {
 };
 
 /**
+ * Every open incident for these monitors, plus each monitor's most recent one.
+ * Consumers read only the open count and the latest incident's date, so
+ * selecting the full history made `monitor.list` — prefetched by the sidebar on
+ * every dashboard route — scale with the workspace's lifetime incident count.
+ */
+function recentIncidents(db: DB, monitorIds: number[], workspaceId: number) {
+  const ranked = db
+    .select({
+      ...getTableColumns(incidentTable),
+      // Alias avoids `rank` / `row_number`, which name SQLite window functions.
+      recencyRank: sql<number>`row_number() over (partition by ${incidentTable.monitorId} order by ${incidentTable.startedAt} desc)`.as(
+        "recency_rank",
+      ),
+    })
+    .from(incidentTable)
+    .where(
+      and(
+        inArray(incidentTable.monitorId, monitorIds),
+        // Scope to caller's workspace — defence-in-depth in case an
+        // incident.monitorId somehow points cross-workspace. The
+        // `incident.monitorId` FK doesn't enforce workspace ownership.
+        eq(incidentTable.workspaceId, workspaceId),
+      ),
+    )
+    .as("ranked");
+
+  // Newest first so consumers reading `incidents[0]` get the latest incident;
+  // the unordered select this replaced left that row arbitrary.
+  return db
+    .select()
+    .from(ranked)
+    .where(or(eq(ranked.recencyRank, 1), isNull(ranked.resolvedAt)))
+    .orderBy(desc(ranked.startedAt));
+}
+
+/**
  * Batched enrichment for a list of monitors — loads tags + incidents in
  * two IN queries (three if notifications / privateLocations are also
  * requested). Avoids the per-row pattern that pairs badly with dashboards
@@ -90,19 +128,7 @@ async function enrichMonitorsBatch(
         ),
       )
       .all(),
-    db
-      .select()
-      .from(incidentTable)
-      .where(
-        and(
-          inArray(incidentTable.monitorId, ids),
-          // Scope to caller's workspace — defence-in-depth in case an
-          // incident.monitorId somehow points cross-workspace. The
-          // `incident.monitorId` FK doesn't enforce workspace ownership.
-          eq(incidentTable.workspaceId, workspaceId),
-        ),
-      )
-      .all(),
+    recentIncidents(db, ids, workspaceId).all(),
     include.notifications
       ? db
           .select({

--- a/packages/services/src/monitor/list.ts
+++ b/packages/services/src/monitor/list.ts
@@ -66,9 +66,10 @@ function recentIncidents(db: DB, monitorIds: number[], workspaceId: number) {
     .select({
       ...getTableColumns(incidentTable),
       // Alias avoids `rank` / `row_number`, which name SQLite window functions.
-      recencyRank: sql<number>`row_number() over (partition by ${incidentTable.monitorId} order by ${incidentTable.startedAt} desc)`.as(
-        "recency_rank",
-      ),
+      recencyRank:
+        sql<number>`row_number() over (partition by ${incidentTable.monitorId} order by ${incidentTable.startedAt} desc)`.as(
+          "recency_rank",
+        ),
     })
     .from(incidentTable)
     .where(

--- a/packages/services/src/status-report/list.ts
+++ b/packages/services/src/status-report/list.ts
@@ -7,6 +7,8 @@ import {
   eq,
   gte,
   inArray,
+  ne,
+  or,
   sql,
 } from "@openstatus/db";
 import {
@@ -211,7 +213,10 @@ export async function listStatusReports(args: {
   const input = ListStatusReportsInput.parse(args.input);
   const db = ctx.db ?? defaultDb;
 
-  const conditions: SQL[] = [eq(statusReport.workspaceId, ctx.workspace.id)];
+  // `or(...)` is typed `SQL | undefined`, and `and()` drops undefined entries.
+  const conditions: (SQL | undefined)[] = [
+    eq(statusReport.workspaceId, ctx.workspace.id),
+  ];
   if (input.statuses.length > 0) {
     conditions.push(inArray(statusReport.status, input.statuses));
   }
@@ -220,6 +225,14 @@ export async function listStatusReports(args: {
   }
   if (input.period !== undefined) {
     conditions.push(gte(statusReport.createdAt, periodToSince(input.period)));
+  }
+  if (input.activeOrClosedSince !== undefined) {
+    conditions.push(
+      or(
+        ne(statusReport.status, "resolved"),
+        gte(statusReport.updatedAt, input.activeOrClosedSince),
+      ),
+    );
   }
   const whereClause = and(...conditions);
 

--- a/packages/services/src/status-report/schemas.ts
+++ b/packages/services/src/status-report/schemas.ts
@@ -109,6 +109,13 @@ export const ListStatusReportsInput = z.object({
   pageId: z.number().int().optional(),
   period: statusReportListPeriodSchema.optional(),
   order: z.enum(["asc", "desc"]).default("desc"),
+  /**
+   * Keep every unresolved report, plus those touched at or after this date.
+   * `updatedAt` is a safe proxy for the resolution time here: resolving writes
+   * the row, so it is always >= the resolving update's date. Lets a caller
+   * that only renders current state skip the full history.
+   */
+  activeOrClosedSince: z.coerce.date().optional(),
 });
 export type ListStatusReportsInput = z.infer<typeof ListStatusReportsInput>;
 


### PR DESCRIPTION
`/overview` could exceed 2s TTFB. Three independent causes stacked, all of
which get worse as a workspace ages — hence "some users".

Nothing streamed. Every layout `await`ed its prefetches before returning JSX,
and there was no loading.tsx or Suspense boundary anywhere in the app, so TTFB
was the full depth of the query chain: proxy session lookup -> root layout
session lookup -> resolveActiveWorkspace -> shell's 5 prefetches -> (barrier)
-> overview's 5 prefetches. Roughly 16-19 libsql statements, ~7 of them
strictly serial, since the http driver sends one request per statement.

- Layouts now use the existing non-awaiting `prefetch` / `batchPrefetch`
  helpers. `shouldDehydrateQuery` was already configured to ship pending
  queries, so the promises stream to the client instead of gating the shell.
- The two detail routes started their sibling prefetches before awaiting the
  `notFound()` gate, so the gate costs one round trip rather than two serial.
- Added loading.tsx plus an overview skeleton; the client guards returned
  `null`, which would have streamed a blank screen.

The root layout awaited `auth()` purely to seed a SessionProvider nothing
reads — `useSession` appears nowhere, only `signOut`, which doesn't need the
context. That was a database session lookup at the head of every render, and
`cache()` could not dedupe it with the proxy's own lookup.

Unbounded history fed scalars. Every list procedure passes a 10k sentinel with
no period, so `/overview` loaded the workspace's entire incident, report and
maintenance history to render five counts and two short tables:

- New `activeOrClosedSince` filter on the incident / status-report /
  maintenance list verbs: keep everything still open regardless of age, plus
  what closed since the given date. An incident open for weeks still surfaces.
  Preferred over a dedicated overview verb because every count the page shows
  is derivable from that set, so it needs no extra queries and no duplicated
  enrichment.
- `monitor.list` fetched every incident ever for every monitor, on every
  dashboard route via the sidebar, to render one date per row. It now selects
  open incidents plus each monitor's latest via a window function, and orders
  them so `incidents[0]` is the newest — that row was previously arbitrary.

Not addressed here: Auth.js still uses database sessions (switching to JWT
would drop the remaining lookups but gives up server-side revocation),
Tinybird's `revalidate: 0`, and the status-page history query.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WLRLD6gwfDJsCrFcWAxDPp

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

