### PR TITLE
perf: stream the dashboard tRPC batch response

### DIFF
--- a/apps/dashboard/src/lib/trpc/shared.ts
+++ b/apps/dashboard/src/lib/trpc/shared.ts
@@ -1,7 +1,7 @@
 import type { AppRouter } from "@openstatus/api";
 import * as Sentry from "@sentry/nextjs";
-import type { HTTPBatchLinkOptions, HTTPHeaders, TRPCLink } from "@trpc/client";
-import { httpBatchLink, loggerLink } from "@trpc/client";
+import type { HTTPHeaders, TRPCLink } from "@trpc/client";
+import { httpBatchStreamLink, loggerLink } from "@trpc/client";
 import superjson from "superjson";
 
 /**
@@ -56,16 +56,19 @@ const getBaseUrl = () => {
 
 // The whole tRPC surface is served from a single Node.js endpoint — there is
 // no longer an Edge/Node split, so all calls go to one link.
+// Streaming rather than plain batching: a batch mixing cheap queries with a
+// slow Tinybird pipe would otherwise deliver none of them until the slowest
+// one settles. Note this makes per-procedure errors arrive in-band on a 200 —
+// `sentryLoggerLink` above is what still reports them.
 export const endingLink =
   (opts?: {
     fetch?: typeof fetch;
     headers?: HTTPHeaders | (() => HTTPHeaders | Promise<HTTPHeaders>);
   }): TRPCLink<AppRouter> =>
   (runtime) =>
-    httpBatchLink({
+    httpBatchStreamLink<AppRouter>({
       headers: opts?.headers,
       fetch: opts?.fetch,
       transformer: superjson,
       url: `${getBaseUrl()}/api/trpc/lambda`,
-      // oxlint-disable-next-line typescript/no-explicit-any -- FIXME: remove any
-    } satisfies Partial<HTTPBatchLinkOptions<any>>)(runtime);
+    })(runtime);


### PR DESCRIPTION
## ⚠️ Do not merge before capturing a baseline

Merging is gated on snapshotting **TTFB P75 for `/api/trpc/lambda`** (currently
**1.41s**) plus a `trpc.timing` export from Vercel Observability. Log retention
will not let the before-picture be reconstructed afterwards.

---

## What

`apps/dashboard/src/lib/trpc/shared.ts`, `httpBatchLink` → `httpBatchStreamLink`.
Nothing else. `status-page` and `web` keep their own links.

## Why

`httpBatchLink` holds every result in a batch until the slowest procedure
settles. From production over 12h:

| batch | P75 |
| --- | --- |
| `tinybird.metrics,uptime,metricsTimingPhases,auditLog,metricsRegions` | 2.63s |
| `page.list,monitor.list,workspace.get,workspace.list,user.get,statusReport.list,tinybird…` | 4.01s |
| `page.list,workspace.get,workspace.list,user.get` (no tinybird) | **16ms** |

The same shell procedures cost 16ms alone and 2.26–4.01s batched with a Tinybird
call. Sidebar and table data sit behind chart data for seconds.

## Three things to be clear about

**1. Duration will not drop — TTFB will.** The request still ends when the
slowest op settles, so Vercel `Duration` P75 (1.44s) should stay ~flat. That is
the expected outcome, not a failure. Judge this on TTFB.

**2. This does not fix the navigation freeze.** That is the RSC round trip —
every layout `await`s its prefetches and there is no `loading.tsx` in the app.
This PR only affects queries the browser fires after the shell is up. On
chart-heavy pages, where Tinybird *is* the content, the felt change may be small.

**3. Route-level 4XX visibility is lost.** Headers flush before any procedure
resolves, so errors arrive in-band on a 200 and this route's Error Rate flattens
to ~0. Accepted because the coverage that matters survives: `createTRPCOnError`
and `sentryLoggerLink` still report to Sentry, and `timingMiddleware` already
logs per-procedure `ok`, which is finer-grained than the batch-level status.
Known gap: that log carries no error *code*, so `ok: false` will not distinguish
an expired session from a free-plan `assertPaidPeriod` `FORBIDDEN`. One-line
follow-up if needed.

## Type change

`httpBatchStreamLink<AppRouter>({…})` types the options directly, removing the
`satisfies Partial<HTTPBatchLinkOptions<any>>` workaround and its `FIXME` rather
than relocating them. No `any` remains.

## Verification

Source reading:

- `@trpc/server` `resolveResponse:1924` — `isStreamCall = getAcceptHeader(...) === "application/jsonl"`, reads `trpc-accept` with an `accept` fallback.
- `@sentry/nextjs` `wrapRouteHandlerWithSentry` — awaits the handler, reads `response.status`, returns the `Response` untouched. No `.text()`/`.json()`/`.clone()`, so nothing buffers the stream.

Same unauthenticated batch against `next dev`:

| Request | Status | Body |
| --- | --- | --- |
| no `trpc-accept` | `401` | `application/json`, single buffered array |
| `trpc-accept: application/jsonl` | `200` | `transfer-encoding: chunked`, header line then one line per op |

Both carry `vary: trpc-accept, accept`. `app.openstatus.dev` resolves to Vercel
anycast (`216.150.16.1/129`) with no proxy in front to buffer the response.

`pnpm tsc` clean and identical to the pre-change baseline; `oxfmt --check` and
`oxlint` clean on the touched file.

## After merge

Wait 12h, compare TTFB P75, then pull a per-procedure breakdown from
`trpc.timing`. At ~400 invocations/12h a move under a few hundred ms is inside
the noise band — that means extend the window, not that this failed.

**No commitment beyond this PR.** The `loading.tsx` work, the non-blocking
prefetch refactor and Tinybird's `revalidate: 0` are analysed but explicitly not
agreed; the breakdown chooses what comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

