### PR TITLE
Configure Next.js staleTime for dynamic dashboard routes

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -9,6 +9,11 @@ const nextConfig: NextConfig = {
   experimental: {
     // barrel-optimize only when unaliased — the rewrite would bypass the nucleo alias
     optimizePackageImports: useNucleoIcons ? [] : ["@openstatus/icons"],
+    // dashboard routes are dynamic (auth/cookies); default dynamic staleTime of 0
+    // discards prefetched entries on navigation, so keep them 30s to make prefetch pay off
+    staleTimes: {
+      dynamic: 30,
+    },
   },
   turbopack: useNucleoIcons
     ? { resolveAlias: { "@openstatus/icons": "@openstatus/icons/nucleo" } }


### PR DESCRIPTION
## Summary
Configures Next.js experimental `staleTimes` to keep prefetched entries for dynamic dashboard routes for 30 seconds instead of the default 0 seconds.

## Changes
- Added `staleTimes` configuration to Next.js experimental settings in `apps/dashboard/next.config.ts`
- Set `dynamic` staleTime to 30 seconds to allow prefetched entries to remain cached during navigation
- Added explanatory comments noting that dashboard routes are dynamic (auth/cookies) and that the default staleTime of 0 discards prefetched entries, making prefetch optimization ineffective

## Details
The dashboard's routes are inherently dynamic due to authentication and cookie-based state. With the default staleTime of 0, prefetched page entries are immediately discarded on navigation, negating the performance benefit of prefetching. By setting staleTime to 30 seconds, prefetched entries remain valid long enough to provide meaningful performance improvements during typical user navigation patterns.

https://claude.ai/code/session_01CMNKJWjy6Jd5tFU97AH1KR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

