### PR TITLE
feat(server): rate-limit public status route per-IP

### DIFF
--- a/apps/server/src/libs/test/preload.ts
+++ b/apps/server/src/libs/test/preload.ts
@@ -145,6 +145,18 @@ mock.module("@/libs/clients", () => ({
       return Promise.resolve(value);
     },
     expire: (_key: string, _seconds: number) => Promise.resolve(1),
+    incr: (key: string) => {
+      const current = Number(testRedisStore.get(key));
+      const next = (Number.isNaN(current) ? 0 : current) + 1;
+      testRedisStore.set(key, String(next));
+      return Promise.resolve(next);
+    },
+    decr: (key: string) => {
+      const current = Number(testRedisStore.get(key));
+      const next = (Number.isNaN(current) ? 0 : current) - 1;
+      testRedisStore.set(key, String(next));
+      return Promise.resolve(next);
+    },
   },
 }));
 

--- a/apps/server/src/routes/public/status.test.ts
+++ b/apps/server/src/routes/public/status.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@std/testing/bdd";
 
 import { app } from "../../index";
+import { STATUS_RATE_LIMIT } from "./status";
 
 const testRedisStore = (globalThis as Record<string, unknown>)
   .__testRedisStore as Map<string, string> | undefined;
@@ -471,6 +472,76 @@ describe("Status Route: Maintenance detection", () => {
 
     // Clean up
     await db.delete(maintenance).where(eq(maintenance.id, futureMaint.id));
+  });
+});
+
+describe("Status Route: Rate limiting", () => {
+  test("returns 429 once the per-IP limit is exceeded", async () => {
+    const headers = { "x-forwarded-for": "203.0.113.10" };
+    for (let i = 0; i < STATUS_RATE_LIMIT; i++) {
+      const res = await app.request(
+        `/public/status/${TEST_PREFIX}-page`,
+        { headers },
+      );
+      expect(res.status).toBe(200);
+    }
+
+    const res = await app.request(`/public/status/${TEST_PREFIX}-page`, {
+      headers,
+    });
+    expect(res.status).toBe(429);
+
+    const data = await res.json();
+    expect(data.status).toBe("too_many_requests");
+  });
+
+  test("keys per-IP, so a different IP is not limited", async () => {
+    const exhaustedIp = { "x-forwarded-for": "198.51.100.7" };
+    for (let i = 0; i < STATUS_RATE_LIMIT; i++) {
+      await app.request(`/public/status/${TEST_PREFIX}-page`, {
+        headers: exhaustedIp,
+      });
+    }
+
+    expect(
+      (await app.request(`/public/status/${TEST_PREFIX}-page`, {
+        headers: exhaustedIp,
+      })).status,
+    ).toBe(429);
+
+    const other = await app.request(`/public/status/${TEST_PREFIX}-page`, {
+      headers: { "x-forwarded-for": "198.51.100.8" },
+    });
+    expect(other.status).toBe(200);
+    expect(await other.json()).toEqual({ status: "operational" });
+  });
+
+  test("keeps limiter counters out of the slug cache namespace", async () => {
+    const slug = "203.0.113.9";
+    const collisionPage = await db
+      .insert(page)
+      .values({
+        workspaceId: 1,
+        title: "Slug/IP Collision Page",
+        description: "Page whose slug equals a client IP string",
+        slug,
+        customDomain: "",
+        accessType: "public",
+      })
+      .returning()
+      .get();
+
+    const headers = { "x-forwarded-for": slug };
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request(`/public/status/${slug}`, { headers });
+      expect(res.status).toBe(200);
+    }
+
+    expect(testRedisStore?.get(`rl:${slug}`)).toBe("5");
+    // The raw-slug key holds the cached status, not a limiter counter.
+    expect(testRedisStore?.get(slug)).toBe("operational");
+
+    await db.delete(page).where(eq(page.id, collisionPage.id));
   });
 });
 

--- a/apps/server/src/routes/public/status.ts
+++ b/apps/server/src/routes/public/status.ts
@@ -2,16 +2,35 @@ import { getLogger } from "@logtape/logtape";
 import { db, eq } from "@openstatus/db";
 import { page } from "@openstatus/db/src/schema";
 import { Hono } from "hono";
+import { rateLimiter } from "hono-rate-limiter";
 import { endTime, setMetric, startTime } from "hono/timing";
 
 const logger = getLogger("api-server");
 import { Status, Tracker } from "@openstatus/tracker";
 
 import { redis } from "../../libs/clients";
+import {
+  createStatusRateLimitStore,
+  parseRateLimitKey,
+} from "../../utils/rate-limit";
 
-// TODO: include ratelimiting
+export const STATUS_RATE_LIMIT = 100;
+const STATUS_RATE_LIMIT_WINDOW_MS = 60_000;
+
+// Coarse per-IP abuse guard across the whole public surface; deliberately not
+// scoped per-slug, so a shared egress IP can't blow its budget on page flips.
+const limiter = rateLimiter({
+  windowMs: STATUS_RATE_LIMIT_WINDOW_MS,
+  limit: STATUS_RATE_LIMIT,
+  standardHeaders: "draft-7",
+  keyGenerator: parseRateLimitKey,
+  handler: (c) => c.json({ status: "too_many_requests" }, 429),
+  store: createStatusRateLimitStore(redis, STATUS_RATE_LIMIT_WINDOW_MS),
+});
 
 export const status = new Hono();
+
+status.use("*", limiter);
 
 status.get("/:slug", async (c) => {
   try {

--- a/apps/server/src/utils/rate-limit.ts
+++ b/apps/server/src/utils/rate-limit.ts
@@ -1,0 +1,52 @@
+import type { Redis } from "@openstatus/upstash";
+import type { Context } from "hono";
+import type { Store } from "hono-rate-limiter";
+import { getConnInfo } from "hono/deno";
+
+// x-forwarded-for is attacker-spoofable when the client is direct; the header
+// only constrains clients routed through the trusted edge that sets it.
+export function parseRateLimitKey(c: Context): string {
+  const forwarded = c.req.header("x-forwarded-for");
+  const first = forwarded?.split(",")[0]?.trim();
+  if (first) return first;
+  try {
+    const { remote } = getConnInfo(c);
+    if (remote.address) return remote.address;
+  } catch {
+    // Non-Deno runtime (tests, adapters) exposes no socket info.
+  }
+  // Fail open when no address is observable (non-Deno runtime, or a client not
+  // routed through a trusted proxy): the per-request UUID never trips the
+  // limit, so these clients are NOT rate limited. Put a trusted proxy in front
+  // (setting x-forwarded-for) for the limit to apply.
+  return crypto.randomUUID();
+}
+
+// Namespaced so limiter keys can never collide with the raw-slug page cache.
+export const STATUS_RATE_LIMIT_KEY_PREFIX = "rl:";
+
+// incr + expire are separate commands, so a crash between them can leave a
+// TTL-less key; harmless since the key only exists once a client has hit us.
+export function createStatusRateLimitStore(
+  redis: Redis,
+  windowMs: number,
+): Store {
+  const ttlSeconds = windowMs / 1000;
+  return {
+    localKeys: false,
+    increment: async (key) => {
+      const namespaced = `${STATUS_RATE_LIMIT_KEY_PREFIX}${key}`;
+      const totalHits = await redis.incr(namespaced);
+      if (totalHits === 1) await redis.expire(namespaced, ttlSeconds);
+      return { totalHits, resetTime: undefined };
+    },
+    decrement: async (key) => {
+      const namespaced = `${STATUS_RATE_LIMIT_KEY_PREFIX}${key}`;
+      const current = Number(await redis.get(namespaced)) || 0;
+      if (current > 0) await redis.decr(namespaced);
+    },
+    resetKey: async (key) => {
+      await redis.del(`${STATUS_RATE_LIMIT_KEY_PREFIX}${key}`);
+    },
+  };
+}


### PR DESCRIPTION
## summary
Adds a coarse per-IP rate limit (100 req/min) to the public status endpoint, backed by a namespaced Redis store so limiter keys never collide with the slug cache. Returns 429 once exceeded; unobservable IPs fail open. Includes tests covering the limit, per-IP isolation, and cache-key namespacing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

