### PR TITLE
feat: add maintenance updates for status page communications

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/[maintenanceId]/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/[maintenanceId]/layout.tsx
@@ -1,0 +1,22 @@
+import { HydrateClient, fetchQueryOrNotFound, trpc } from "@/lib/trpc/server";
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ id: string; maintenanceId: string }>;
+}) {
+  const { id, maintenanceId } = await params;
+  await Promise.all([
+    fetchQueryOrNotFound(
+      trpc.maintenance.get.queryOptions({
+        id: Number.parseInt(maintenanceId),
+      }),
+    ),
+    fetchQueryOrNotFound(
+      trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
+    ),
+  ]);
+  return <HydrateClient>{children}</HydrateClient>;
+}

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/[maintenanceId]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/[maintenanceId]/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Add } from "@openstatus/icons";
+import { Button } from "@openstatus/ui/components/ui/button";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { useParams } from "next/navigation";
+
+import {
+  EmptyStateContainer,
+  EmptyStateDescription,
+} from "@/components/content/empty-state";
+import {
+  Section,
+  SectionDescription,
+  SectionGroup,
+  SectionHeader,
+  SectionHeaderRow,
+  SectionTitle,
+} from "@/components/content/section";
+import { FormCardGroup } from "@/components/forms/form-card";
+import { FormSheetWithDirtyProtection } from "@/components/forms/form-sheet";
+import { FormMaintenanceUpdateCard } from "@/components/forms/maintenance-update/card";
+import { FormSheetMaintenanceUpdate } from "@/components/forms/maintenance-update/sheet";
+import { useTRPC } from "@/lib/trpc/client";
+
+export default function Page() {
+  const { maintenanceId } = useParams<{
+    id: string;
+    maintenanceId: string;
+  }>();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const input = { id: Number.parseInt(maintenanceId) };
+  const { data: maintenance, refetch } = useQuery(
+    trpc.maintenance.get.queryOptions(input),
+  );
+
+  const invalidateMaintenanceQueries = () => {
+    refetch();
+    queryClient.invalidateQueries({
+      queryKey: trpc.maintenance.list.queryKey(),
+    });
+    queryClient.invalidateQueries({
+      queryKey: trpc.page.list.queryKey(),
+    });
+  };
+
+  const notifyMutation = useMutation(
+    trpc.subscriberNotification.maintenance.mutationOptions(),
+  );
+  const createMutation = useMutation(
+    trpc.maintenance.createUpdate.mutationOptions({
+      onSuccess: (update) => {
+        if (update?.notifySubscribers) {
+          notifyMutation.mutate({ id: update.id });
+        }
+        invalidateMaintenanceQueries();
+      },
+    }),
+  );
+  const updateMutation = useMutation(
+    trpc.maintenance.updateUpdate.mutationOptions({
+      onSuccess: invalidateMaintenanceQueries,
+    }),
+  );
+  const deleteMutation = useMutation(
+    trpc.maintenance.deleteUpdate.mutationOptions({
+      onSuccess: invalidateMaintenanceQueries,
+    }),
+  );
+
+  if (!maintenance) return null;
+
+  const updates = [...maintenance.updates].sort(
+    (a, b) => b.date.getTime() - a.date.getTime() || b.id - a.id,
+  );
+  const affected = maintenance.pageComponents
+    .map((component) => component.name)
+    .join(", ");
+
+  return (
+    <SectionGroup>
+      <Section>
+        <SectionHeaderRow>
+          <SectionHeader>
+            <SectionTitle>{maintenance.title}</SectionTitle>
+            <SectionDescription>
+              {format(maintenance.from, "PPP 'at' p")} –{" "}
+              {format(maintenance.to, "PPP 'at' p")}. Affects{" "}
+              <span className="text-foreground">{affected || "zero"}</span>{" "}
+              component(s).
+            </SectionDescription>
+          </SectionHeader>
+        </SectionHeaderRow>
+
+        <EmptyStateContainer className="my-8 border-dashed">
+          <EmptyStateDescription>Maintenance Updates</EmptyStateDescription>
+          <FormSheetMaintenanceUpdate
+            onSubmit={async (values) => {
+              await createMutation.mutateAsync({
+                maintenanceId: maintenance.id,
+                message: values.message,
+                date: values.date,
+                notifySubscribers: values.notifySubscribers,
+              });
+            }}
+          >
+            <Button size="sm">
+              <Add />
+              Create Maintenance Update
+            </Button>
+          </FormSheetMaintenanceUpdate>
+        </EmptyStateContainer>
+
+        <FormCardGroup>
+          {updates.map((update, index) => (
+            <FormSheetWithDirtyProtection key={update.id}>
+              <FormMaintenanceUpdateCard
+                index={index}
+                total={updates.length}
+                update={update}
+                onSubmit={async (values) => {
+                  await updateMutation.mutateAsync({
+                    id: update.id,
+                    message: values.message,
+                    date: values.date,
+                  });
+                }}
+                onDelete={async () => {
+                  await deleteMutation.mutateAsync({ id: update.id });
+                }}
+              />
+            </FormSheetWithDirtyProtection>
+          ))}
+        </FormCardGroup>
+      </Section>
+    </SectionGroup>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/maintenances/page.tsx
@@ -2,8 +2,8 @@
 
 import { Add } from "@openstatus/icons";
 import { Button } from "@openstatus/ui/components/ui/button";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { useParams } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useParams, useRouter } from "next/navigation";
 
 import { Link } from "@/components/common/link";
 import {
@@ -22,7 +22,9 @@ import { useTRPC } from "@/lib/trpc/client";
 
 export default function Page() {
   const { id } = useParams<{ id: string }>();
+  const router = useRouter();
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const { data: statusPage } = useQuery(
     trpc.page.get.queryOptions({ id: Number.parseInt(id) }),
   );
@@ -38,9 +40,12 @@ export default function Page() {
     trpc.maintenance.new.mutationOptions({
       onSuccess: (maintenance) => {
         refetch();
+        queryClient.invalidateQueries({
+          queryKey: trpc.page.list.queryKey(),
+        });
         if (maintenance.notifySubscribers) {
           sendMaintenanceUpdateMutation.mutate({
-            id: maintenance.id,
+            id: maintenance.initialUpdateId,
           });
         }
       },
@@ -88,7 +93,13 @@ export default function Page() {
             </FormSheetMaintenance>
           </div>
         </SectionHeaderRow>
-        <DataTable columns={columns} data={maintenances} />
+        <DataTable
+          columns={columns}
+          data={maintenances}
+          onRowClick={(row) =>
+            router.push(`/status-pages/${id}/maintenances/${row.original.id}`)
+          }
+        />
       </Section>
     </SectionGroup>
   );

--- a/apps/dashboard/src/components/chat/tool-renderers/index.tsx
+++ b/apps/dashboard/src/components/chat/tool-renderers/index.tsx
@@ -28,6 +28,11 @@ import { listPrivateLocationsTable } from "./list-private-locations";
 import { listResponseLogsTable } from "./list-response-logs";
 import { listStatusPagesTable } from "./list-status-pages";
 import { listStatusReportsTable } from "./list-status-reports";
+import {
+  addMaintenanceUpdateChanges,
+  deleteMaintenanceUpdateChanges,
+  updateMaintenanceUpdateChanges,
+} from "./maintenance-update";
 import { resolveStatusReportChanges } from "./resolve-status-report";
 import { ResultTable } from "./result-table";
 import { searchDocsTable } from "./search-docs";
@@ -139,6 +144,32 @@ export const toolRenderers: ToolRendererRegistry = {
       />
     ),
     summary: (o) => `ID ${o.id}`,
+  },
+  add_maintenance_update: {
+    renderDraft: (input) => addMaintenanceUpdateChanges(input),
+    renderResult: ({ input, output }) => (
+      <ChangesTable
+        changes={addMaintenanceUpdateChanges(input, {
+          id: output.id,
+          notified: output.notified ?? false,
+        })}
+      />
+    ),
+    summary: (o) => `update #${o.id}`,
+  },
+  update_maintenance_update: {
+    renderDraft: (input) => updateMaintenanceUpdateChanges(input),
+    renderResult: ({ input }) => (
+      <ChangesTable changes={updateMaintenanceUpdateChanges(input)} />
+    ),
+    summary: (o) => `update #${o.id}`,
+  },
+  delete_maintenance_update: {
+    renderDraft: (input) => deleteMaintenanceUpdateChanges(input),
+    renderResult: ({ input }) => (
+      <ChangesTable changes={deleteMaintenanceUpdateChanges(input)} />
+    ),
+    summary: (o) => `deleted #${o.id}`,
   },
   list_monitors: {
     renderResult: ({ output }) => (

--- a/apps/dashboard/src/components/chat/tool-renderers/maintenance-update.tsx
+++ b/apps/dashboard/src/components/chat/tool-renderers/maintenance-update.tsx
@@ -1,0 +1,32 @@
+import type { AgentToolInput } from "@openstatus/services/agent-tools";
+
+import type { ChangeRow } from "@/components/common/changes-table";
+
+export function addMaintenanceUpdateChanges(
+  input: AgentToolInput<"add_maintenance_update">,
+  applied?: { id: number; notified: boolean },
+): ChangeRow[] {
+  return [
+    ...(applied ? [{ field: "id", after: applied.id }] : []),
+    { field: "maintenanceId", after: input.maintenanceId },
+    { field: "message", after: input.message },
+    { field: "date", after: input.date },
+    { field: "notify", after: applied?.notified ?? input.notify },
+  ];
+}
+
+export function updateMaintenanceUpdateChanges(
+  input: AgentToolInput<"update_maintenance_update">,
+): ChangeRow[] {
+  return [
+    { field: "id", after: input.id },
+    ...(input.message ? [{ field: "message", after: input.message }] : []),
+    ...(input.date ? [{ field: "date", after: input.date }] : []),
+  ];
+}
+
+export function deleteMaintenanceUpdateChanges(
+  input: AgentToolInput<"delete_maintenance_update">,
+): ChangeRow[] {
+  return [{ field: "id", before: input.id, after: undefined }];
+}

--- a/apps/dashboard/src/components/chat/tool-renderers/maintenance-update.tsx
+++ b/apps/dashboard/src/components/chat/tool-renderers/maintenance-update.tsx
@@ -10,7 +10,7 @@ export function addMaintenanceUpdateChanges(
     ...(applied ? [{ field: "id", after: applied.id }] : []),
     { field: "maintenanceId", after: input.maintenanceId },
     { field: "message", after: input.message },
-    { field: "date", after: input.date },
+    ...(input.date ? [{ field: "date", after: input.date }] : []),
     { field: "notify", after: applied?.notified ?? input.notify },
   ];
 }
@@ -28,5 +28,5 @@ export function updateMaintenanceUpdateChanges(
 export function deleteMaintenanceUpdateChanges(
   input: AgentToolInput<"delete_maintenance_update">,
 ): ChangeRow[] {
-  return [{ field: "id", before: input.id, after: undefined }];
+  return [{ field: "id", before: input.id }];
 }

--- a/apps/dashboard/src/components/data-table/maintenances/data-table-row-actions.tsx
+++ b/apps/dashboard/src/components/data-table/maintenances/data-table-row-actions.tsx
@@ -50,7 +50,7 @@ export function MaintenanceRowActions({
   );
 
   return (
-    <>
+    <div onClick={(event) => event.stopPropagation()}>
       <QuickActions
         actions={actions}
         deleteAction={{
@@ -89,6 +89,6 @@ export function MaintenanceRowActions({
           Open sheet
         </button>
       </FormSheetMaintenance>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/components/forms/form-alert-dialog.tsx
+++ b/apps/dashboard/src/components/forms/form-alert-dialog.tsx
@@ -35,9 +35,14 @@ export function FormAlertDialog({
   const { copy, isCopied } = useCopyToClipboard();
   const [open, setOpen] = useState(false);
 
-  const handleDelete = async () => {
-    try {
-      startTransition(async () => {
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setValue("");
+  };
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      try {
         const promise = submitAction();
         toast.promise(promise, {
           loading: "Deleting...",
@@ -50,15 +55,15 @@ export function FormAlertDialog({
           },
         });
         await promise;
-        setOpen(false);
-      });
-    } catch (error) {
-      console.error("Failed to revoke:", error);
-    }
+        handleOpenChange(false);
+      } catch (error) {
+        console.error("Failed to delete:", error);
+      }
+    });
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogTrigger asChild>
         {children ?? (
           <Button variant="destructive" size="sm">

--- a/apps/dashboard/src/components/forms/maintenance-update/card.tsx
+++ b/apps/dashboard/src/components/forms/maintenance-update/card.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { RouterOutputs } from "@openstatus/api";
+import { Button } from "@openstatus/ui/components/ui/button";
+
+import { FormAlertDialog } from "@/components/forms/form-alert-dialog";
+import {
+  FormCard,
+  FormCardFooter,
+  FormCardHeader,
+  FormCardTitle,
+} from "@/components/forms/form-card";
+import {
+  FormMaintenanceUpdate,
+  type FormValues,
+} from "@/components/forms/maintenance-update/form";
+
+type MaintenanceUpdate = RouterOutputs["maintenance"]["get"]["updates"][number];
+
+export function FormMaintenanceUpdateCard({
+  index,
+  total,
+  update,
+  onSubmit,
+  onDelete,
+}: {
+  index: number;
+  total: number;
+  update: MaintenanceUpdate;
+  onSubmit: (values: FormValues) => Promise<void>;
+  onDelete: () => Promise<void>;
+}) {
+  const formId = `maintenance-update-${update.id}`;
+  const title = `Maintenance Update #${total - index}`;
+
+  return (
+    <FormCard>
+      <FormCardHeader>
+        <FormCardTitle>{title}</FormCardTitle>
+      </FormCardHeader>
+      <FormMaintenanceUpdate
+        id={formId}
+        defaultValues={{ message: update.message, date: update.date }}
+        onSubmit={onSubmit}
+      />
+      <FormCardFooter className="flex items-center justify-end gap-2 [&>:last-child]:ml-0">
+        <FormAlertDialog confirmationValue={title} submitAction={onDelete}>
+          <Button
+            variant="outline"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+          >
+            Delete
+          </Button>
+        </FormAlertDialog>
+        <Button type="submit" form={formId}>
+          Submit
+        </Button>
+      </FormCardFooter>
+    </FormCard>
+  );
+}

--- a/apps/dashboard/src/components/forms/maintenance-update/card.tsx
+++ b/apps/dashboard/src/components/forms/maintenance-update/card.tsx
@@ -43,15 +43,17 @@ export function FormMaintenanceUpdateCard({
         defaultValues={{ message: update.message, date: update.date }}
         onSubmit={onSubmit}
       />
-      <FormCardFooter className="flex items-center justify-end gap-2 [&>:last-child]:ml-0">
-        <FormAlertDialog confirmationValue={title} submitAction={onDelete}>
-          <Button
-            variant="outline"
-            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-          >
-            Delete
-          </Button>
-        </FormAlertDialog>
+      <FormCardFooter className="flex items-center justify-end gap-2 *:last:ml-0">
+        {total > 1 ? (
+          <FormAlertDialog confirmationValue={title} submitAction={onDelete}>
+            <Button
+              variant="outline"
+              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            >
+              Delete
+            </Button>
+          </FormAlertDialog>
+        ) : null}
         <Button type="submit" form={formId}>
           Submit
         </Button>

--- a/apps/dashboard/src/components/forms/maintenance-update/form.tsx
+++ b/apps/dashboard/src/components/forms/maintenance-update/form.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { Calendar as CalendarIcon, Clock } from "@openstatus/icons";
+import { Button } from "@openstatus/ui/components/ui/button";
+import { Calendar } from "@openstatus/ui/components/ui/calendar";
+import { Checkbox } from "@openstatus/ui/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@openstatus/ui/components/ui/form";
+import { Input } from "@openstatus/ui/components/ui/input";
+import { Label } from "@openstatus/ui/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@openstatus/ui/components/ui/popover";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@openstatus/ui/components/ui/tabs";
+import { Textarea } from "@openstatus/ui/components/ui/textarea";
+import { useIsMobile } from "@openstatus/ui/hooks/use-mobile";
+import { cn } from "@openstatus/ui/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { isTRPCClientError } from "@trpc/client";
+import { format } from "date-fns";
+import React, { useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { ProcessMessage } from "@/components/content/process-message";
+import {
+  FormCardContent,
+  FormCardSeparator,
+} from "@/components/forms/form-card";
+import { useFormSheetDirty } from "@/components/forms/form-sheet";
+import { useTRPC } from "@/lib/trpc/client";
+
+export type FormValues = {
+  message: string;
+  date: Date;
+  notifySubscribers?: boolean;
+};
+
+export function FormMaintenanceUpdate({
+  defaultValues,
+  onSubmit,
+  showNotifySubscribers = false,
+  className,
+  id,
+  ...props
+}: Omit<React.ComponentProps<"form">, "onSubmit"> & {
+  defaultValues?: Partial<FormValues>;
+  onSubmit: (values: FormValues) => Promise<void>;
+  showNotifySubscribers?: boolean;
+}) {
+  const trpc = useTRPC();
+  const { data: workspace } = useQuery(trpc.workspace.get.queryOptions());
+  const mobile = useIsMobile();
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const form = useForm<FormValues>({
+    defaultValues: {
+      message: defaultValues?.message ?? "",
+      date: defaultValues?.date ?? new Date(),
+      notifySubscribers:
+        defaultValues?.notifySubscribers ??
+        !!workspace?.limits["status-subscribers"],
+    },
+  });
+  const message = form.watch("message");
+  const [isPending, startTransition] = useTransition();
+  const { setIsDirty } = useFormSheetDirty();
+
+  React.useEffect(() => {
+    setIsDirty(form.formState.isDirty);
+  }, [form.formState.isDirty, setIsDirty]);
+
+  function submitAction(values: FormValues) {
+    if (isPending) return;
+    startTransition(async () => {
+      const promise = onSubmit(values);
+      toast.promise(promise, {
+        loading: "Saving...",
+        success: "Saved",
+        error: (error) =>
+          isTRPCClientError(error) ? error.message : "Failed to save",
+      });
+      try {
+        await promise;
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  }
+
+  const timeInputId = `${id ?? "maintenance-update"}-time`;
+
+  return (
+    <Form {...form}>
+      <form
+        id={id}
+        className={cn("grid gap-4", className)}
+        onSubmit={form.handleSubmit(submitAction)}
+        {...props}
+      >
+        <FormCardContent>
+          <FormField
+            control={form.control}
+            name="date"
+            render={({ field }) => (
+              <FormItem className="flex flex-col">
+                <FormLabel>Date</FormLabel>
+                <Popover modal>
+                  <FormControl>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="w-full pl-3 text-left font-normal sm:w-[240px]"
+                      >
+                        {format(field.value, "PPP 'at' h:mm a")}
+                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                  </FormControl>
+                  <PopoverContent
+                    className="pointer-events-auto w-auto p-0"
+                    align="start"
+                    side={mobile ? "bottom" : "left"}
+                  >
+                    <Calendar
+                      mode="single"
+                      selected={field.value}
+                      onSelect={(date) => {
+                        if (!date) return;
+                        date.setHours(
+                          field.value.getHours(),
+                          field.value.getMinutes(),
+                          field.value.getSeconds(),
+                          field.value.getMilliseconds(),
+                        );
+                        field.onChange(date);
+                      }}
+                      disabled={(date) =>
+                        date > new Date() || date < new Date("1900-01-01")
+                      }
+                      initialFocus
+                    />
+                    <div className="border-t p-3">
+                      <div className="flex items-center gap-3">
+                        <Label htmlFor={timeInputId} className="text-xs">
+                          Enter time
+                        </Label>
+                        <div className="relative grow">
+                          <Input
+                            id={timeInputId}
+                            type="time"
+                            step="1"
+                            defaultValue={field.value
+                              .toTimeString()
+                              .slice(0, 8)}
+                            className="peer appearance-none ps-9 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+                            onChange={(event) => {
+                              const [hours, minutes, seconds] =
+                                event.target.value.split(":").map(Number);
+                              if (hours === undefined || minutes === undefined)
+                                return;
+                              const date = new Date(field.value);
+                              date.setHours(hours, minutes, seconds ?? 0, 0);
+                              field.onChange(date);
+                            }}
+                          />
+                          <div className="text-muted-foreground/80 pointer-events-none absolute inset-y-0 start-0 flex items-center justify-center ps-3">
+                            <Clock size={16} aria-hidden="true" />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+                <FormDescription>
+                  Shown in your timezone (
+                  <code className="font-commit-mono text-foreground/70">
+                    {timezone}
+                  </code>
+                  ) and saved as UTC.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormCardContent>
+        <FormCardSeparator />
+        <FormCardContent>
+          <Tabs defaultValue="write">
+            <TabsList>
+              <TabsTrigger value="write">Writing</TabsTrigger>
+              <TabsTrigger value="preview">Preview</TabsTrigger>
+            </TabsList>
+            <TabsContent value="write">
+              <FormField
+                control={form.control}
+                name="message"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Message</FormLabel>
+                    <FormControl>
+                      <Textarea rows={6} required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                    <FormDescription>Markdown support</FormDescription>
+                  </FormItem>
+                )}
+              />
+            </TabsContent>
+            <TabsContent value="preview">
+              <div className="grid gap-2">
+                <Label>Preview</Label>
+                <div className="prose prose-sm dark:prose-invert text-foreground rounded-md border px-3 py-2 text-sm">
+                  <ProcessMessage value={message} />
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </FormCardContent>
+        {showNotifySubscribers && workspace?.limits["status-subscribers"] ? (
+          <>
+            <FormCardSeparator />
+            <FormCardContent>
+              <FormField
+                control={form.control}
+                name="notifySubscribers"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Notify Subscribers</FormLabel>
+                    <FormControl>
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id={`${id}-notify-subscribers`}
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                        <Label htmlFor={`${id}-notify-subscribers`}>
+                          Send notification to subscribers
+                        </Label>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </FormCardContent>
+          </>
+        ) : null}
+      </form>
+    </Form>
+  );
+}

--- a/apps/dashboard/src/components/forms/maintenance-update/sheet.tsx
+++ b/apps/dashboard/src/components/forms/maintenance-update/sheet.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Button } from "@openstatus/ui/components/ui/button";
+import { useState } from "react";
+
+import { FormCard, FormCardGroup } from "@/components/forms/form-card";
+import {
+  FormSheetContent,
+  FormSheetDescription,
+  FormSheetFooter,
+  FormSheetHeader,
+  FormSheetTitle,
+  FormSheetTrigger,
+  FormSheetWithDirtyProtection,
+} from "@/components/forms/form-sheet";
+import {
+  FormMaintenanceUpdate,
+  type FormValues,
+} from "@/components/forms/maintenance-update/form";
+
+export function FormSheetMaintenanceUpdate({
+  children,
+  defaultValues,
+  onSubmit,
+}: Omit<React.ComponentProps<typeof FormSheetTrigger>, "onSubmit"> & {
+  defaultValues?: Partial<FormValues>;
+  onSubmit: (values: FormValues) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <FormSheetWithDirtyProtection open={open} onOpenChange={setOpen}>
+      <FormSheetTrigger asChild>{children}</FormSheetTrigger>
+      <FormSheetContent className="sm:max-w-lg">
+        <FormSheetHeader>
+          <FormSheetTitle>Maintenance Update</FormSheetTitle>
+          <FormSheetDescription>
+            Post a dated update to this maintenance.
+          </FormSheetDescription>
+        </FormSheetHeader>
+        <FormCardGroup className="overflow-y-auto">
+          <FormCard className="overflow-auto rounded-none border-none">
+            <FormMaintenanceUpdate
+              id="maintenance-update-form"
+              className="my-4"
+              defaultValues={defaultValues}
+              showNotifySubscribers
+              onSubmit={async (values) => {
+                await onSubmit(values);
+                setOpen(false);
+              }}
+            />
+          </FormCard>
+        </FormCardGroup>
+        <FormSheetFooter>
+          <Button type="submit" form="maintenance-update-form">
+            Submit
+          </Button>
+        </FormSheetFooter>
+      </FormSheetContent>
+    </FormSheetWithDirtyProtection>
+  );
+}

--- a/apps/dashboard/src/components/forms/maintenance/sheet-create.tsx
+++ b/apps/dashboard/src/components/forms/maintenance/sheet-create.tsx
@@ -73,7 +73,9 @@ export function FormSheetMaintenanceCreate({
     trpc.maintenance.new.mutationOptions({
       onSuccess: (maintenance) => {
         if (maintenance.notifySubscribers) {
-          sendMaintenanceUpdateMutation.mutate({ id: maintenance.id });
+          sendMaintenanceUpdateMutation.mutate({
+            id: maintenance.initialUpdateId,
+          });
         }
         // no-input prefix key — matches every maintenance.list query
         queryClient.invalidateQueries({

--- a/apps/server/src/routes/mcp/handler.test.ts
+++ b/apps/server/src/routes/mcp/handler.test.ts
@@ -84,9 +84,11 @@ describe("MCP transport", () => {
     const tools = (body.result as { tools: { name: string }[] }).tools;
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
+      "add_maintenance_update",
       "add_status_report_update",
       "create_maintenance",
       "create_status_report",
+      "delete_maintenance_update",
       "get_audit_log",
       "get_monitor",
       "get_monitor_status",
@@ -102,6 +104,7 @@ describe("MCP transport", () => {
       "list_status_pages",
       "list_status_reports",
       "resolve_status_report",
+      "update_maintenance_update",
       "update_status_report",
     ]);
   });

--- a/apps/server/src/routes/mcp/tools/maintenance.ts
+++ b/apps/server/src/routes/mcp/tools/maintenance.ts
@@ -4,8 +4,11 @@ import type {
 } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServiceContext } from "@openstatus/services";
 import {
+  addMaintenanceUpdateTool,
   createMaintenanceTool,
+  deleteMaintenanceUpdateTool,
   listMaintenancesTool,
+  updateMaintenanceUpdateTool,
 } from "@openstatus/services/agent-tools";
 
 import { registerRegistryTools } from "./registry-adapter";
@@ -17,5 +20,8 @@ export function registerMaintenanceTools(
   return registerRegistryTools(server, ctx, [
     listMaintenancesTool,
     createMaintenanceTool,
+    addMaintenanceUpdateTool,
+    updateMaintenanceUpdateTool,
+    deleteMaintenanceUpdateTool,
   ]);
 }

--- a/apps/server/src/routes/mcp/tools/tools.test.ts
+++ b/apps/server/src/routes/mcp/tools/tools.test.ts
@@ -653,6 +653,9 @@ describe("scope filter", () => {
     expect(reportTools.has("update_status_report")).toBe(false);
     expect(reportTools.has("resolve_status_report")).toBe(false);
     expect(maintenanceTools.has("create_maintenance")).toBe(false);
+    expect(maintenanceTools.has("add_maintenance_update")).toBe(false);
+    expect(maintenanceTools.has("update_maintenance_update")).toBe(false);
+    expect(maintenanceTools.has("delete_maintenance_update")).toBe(false);
   });
 
   test("write key sees both read and write tools", () => {

--- a/apps/server/src/routes/rpc/handlers/maintenance/__tests__/maintenance.test.ts
+++ b/apps/server/src/routes/rpc/handlers/maintenance/__tests__/maintenance.test.ts
@@ -1,6 +1,7 @@
 import { db, eq } from "@openstatus/db";
 import {
   maintenance,
+  maintenanceUpdate,
   maintenancesToPageComponents,
   page,
   pageComponent,
@@ -531,6 +532,14 @@ describe("MaintenanceService.CreateMaintenance", () => {
     expect(subscriptionSpies.dispatchMaintenanceUpdate).toHaveBeenCalledTimes(
       1,
     );
+    const initialUpdate = await db
+      .select({ id: maintenanceUpdate.id })
+      .from(maintenanceUpdate)
+      .where(eq(maintenanceUpdate.maintenanceId, Number(data.maintenance.id)))
+      .get();
+    expect(subscriptionSpies.dispatchMaintenanceUpdate).toHaveBeenCalledWith(
+      initialUpdate?.id,
+    );
 
     // Clean up
     await db
@@ -672,6 +681,7 @@ describe("MaintenanceService.GetMaintenance", () => {
     expect(data.maintenance).toHaveProperty("updatedAt");
     expect(data.maintenance).toHaveProperty("from");
     expect(data.maintenance).toHaveProperty("to");
+    expect(Array.isArray(data.maintenance.updates)).toBe(true);
   });
 
   test("returns 401 when no auth key provided", async () => {
@@ -737,6 +747,83 @@ describe("MaintenanceService.GetMaintenance", () => {
     );
 
     expect(res.status).toBe(400);
+  });
+});
+
+describe("MaintenanceService maintenance update CRUD", () => {
+  test("adds, updates, and deletes timeline entries", async () => {
+    const first = await connectRequest(
+      "AddMaintenanceUpdate",
+      {
+        maintenanceId: String(testMaintenanceId),
+        message: "First timeline entry",
+        notify: false,
+      },
+      { "x-openstatus-key": authKey },
+    );
+    expect(first.status).toBe(200);
+
+    const second = await connectRequest(
+      "AddMaintenanceUpdate",
+      {
+        maintenanceId: String(testMaintenanceId),
+        message: "Second timeline entry",
+        notify: false,
+      },
+      { "x-openstatus-key": authKey },
+    );
+    expect(second.status).toBe(200);
+    const created = await second.json();
+
+    const updated = await connectRequest(
+      "UpdateMaintenanceUpdate",
+      {
+        id: created.maintenanceUpdate.id,
+        message: "Corrected timeline entry",
+      },
+      { "x-openstatus-key": authKey },
+    );
+    expect(updated.status).toBe(200);
+    expect((await updated.json()).maintenanceUpdate.message).toBe(
+      "Corrected timeline entry",
+    );
+
+    const deleted = await connectRequest(
+      "DeleteMaintenanceUpdate",
+      { id: created.maintenanceUpdate.id },
+      { "x-openstatus-key": authKey },
+    );
+    expect(deleted.status).toBe(200);
+    expect(await deleted.json()).toEqual({ success: true });
+  });
+
+  test("scopes update mutations to the authenticated workspace", async () => {
+    const otherMaintenance = await db
+      .insert(maintenance)
+      .values({
+        workspaceId: OTHER_WORKSPACE_ID,
+        title: `${TEST_PREFIX}-other-update`,
+        message: "Other",
+        from: new Date(Date.now() + 1000),
+        to: new Date(Date.now() + 2000),
+      })
+      .returning()
+      .get();
+    try {
+      const res = await connectRequest(
+        "AddMaintenanceUpdate",
+        {
+          maintenanceId: String(otherMaintenance.id),
+          message: "Not allowed",
+        },
+        { "x-openstatus-key": authKey },
+      );
+      expect(res.status).toBe(404);
+    } finally {
+      await db
+        .delete(maintenance)
+        .where(eq(maintenance.id, otherMaintenance.id));
+    }
   });
 });
 

--- a/apps/server/src/routes/rpc/handlers/maintenance/converters.ts
+++ b/apps/server/src/routes/rpc/handlers/maintenance/converters.ts
@@ -1,6 +1,7 @@
 import type {
   Maintenance,
   MaintenanceSummary,
+  MaintenanceUpdate,
 } from "@openstatus/proto/maintenance/v1";
 
 type DBMaintenance = {
@@ -42,6 +43,7 @@ export function dbMaintenanceToProtoSummary(
 export function dbMaintenanceToProto(
   maintenance: DBMaintenance,
   pageComponentIds: string[],
+  updates: DBMaintenanceUpdate[],
 ): Maintenance {
   return {
     $typeName: "openstatus.maintenance.v1.Maintenance" as const,
@@ -54,5 +56,29 @@ export function dbMaintenanceToProto(
     pageComponentIds,
     createdAt: maintenance.createdAt?.toISOString() ?? "",
     updatedAt: maintenance.updatedAt?.toISOString() ?? "",
+    updates: updates.map(dbMaintenanceUpdateToProto),
+  };
+}
+
+type DBMaintenanceUpdate = {
+  id: number;
+  message: string;
+  date: Date;
+  maintenanceId: number;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+};
+
+export function dbMaintenanceUpdateToProto(
+  update: DBMaintenanceUpdate,
+): MaintenanceUpdate {
+  return {
+    $typeName: "openstatus.maintenance.v1.MaintenanceUpdate" as const,
+    id: String(update.id),
+    message: update.message,
+    date: update.date.toISOString(),
+    maintenanceId: String(update.maintenanceId),
+    createdAt: update.createdAt?.toISOString() ?? "",
+    updatedAt: update.updatedAt?.toISOString() ?? "",
   };
 }

--- a/apps/server/src/routes/rpc/handlers/maintenance/errors.ts
+++ b/apps/server/src/routes/rpc/handlers/maintenance/errors.ts
@@ -6,6 +6,7 @@ import { Code, ConnectError } from "@connectrpc/connect";
 export const ErrorReason = {
   MAINTENANCE_NOT_FOUND: "MAINTENANCE_NOT_FOUND",
   MAINTENANCE_ID_REQUIRED: "MAINTENANCE_ID_REQUIRED",
+  MAINTENANCE_UPDATE_ID_REQUIRED: "MAINTENANCE_UPDATE_ID_REQUIRED",
   MAINTENANCE_CREATE_FAILED: "MAINTENANCE_CREATE_FAILED",
   MAINTENANCE_UPDATE_FAILED: "MAINTENANCE_UPDATE_FAILED",
   INVALID_DATE_FORMAT: "INVALID_DATE_FORMAT",
@@ -59,6 +60,17 @@ export function maintenanceIdRequiredError(): ConnectError {
     "Maintenance ID is required",
     Code.InvalidArgument,
     ErrorReason.MAINTENANCE_ID_REQUIRED,
+  );
+}
+
+/**
+ * Creates a "maintenance update ID required" error.
+ */
+export function maintenanceUpdateIdRequiredError(): ConnectError {
+  return createError(
+    "Maintenance update ID is required",
+    Code.InvalidArgument,
+    ErrorReason.MAINTENANCE_UPDATE_ID_REQUIRED,
   );
 }
 

--- a/apps/server/src/routes/rpc/handlers/maintenance/index.ts
+++ b/apps/server/src/routes/rpc/handlers/maintenance/index.ts
@@ -19,7 +19,11 @@ import {
   dbMaintenanceToProtoSummary,
   dbMaintenanceUpdateToProto,
 } from "./converters";
-import { invalidDateFormatError, maintenanceIdRequiredError } from "./errors";
+import {
+  invalidDateFormatError,
+  maintenanceIdRequiredError,
+  maintenanceUpdateIdRequiredError,
+} from "./errors";
 
 function parseDate(dateString: string): Date {
   const date = new Date(dateString);
@@ -31,14 +35,8 @@ function parseDate(dateString: string): Date {
 
 function parsePageComponentIds(ids: ReadonlyArray<string>): number[] {
   return ids.map((id) => {
-    // `Number.parseInt(id, 10)` rather than `Number(id)` — `Number("")`
-    // is `0` (finite!), so the previous guard silently coerced an
-    // empty-string id into component 0 and the service's
-    // `NotFoundError` ended up as a misleading 404 on the wire.
-    // `parseInt` returns NaN for `""`, which fails the finite check
-    // and surfaces the correct `InvalidArgument` here.
-    const n = Number.parseInt(id, 10);
-    if (!Number.isFinite(n)) {
+    const n = Number(id);
+    if (id.trim() === "" || !Number.isSafeInteger(n)) {
       throw new ConnectError(
         `Invalid page component id: "${id}"`,
         Code.InvalidArgument,
@@ -242,7 +240,7 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
     try {
       const rpcCtx = getRpcContext(ctx);
       if (!req.id?.trim()) {
-        throw maintenanceIdRequiredError();
+        throw maintenanceUpdateIdRequiredError();
       }
       const update = await updateMaintenanceUpdate({
         ctx: toServiceCtx(rpcCtx),
@@ -262,7 +260,7 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
     try {
       const rpcCtx = getRpcContext(ctx);
       if (!req.id?.trim()) {
-        throw maintenanceIdRequiredError();
+        throw maintenanceUpdateIdRequiredError();
       }
       await deleteMaintenanceUpdate({
         ctx: toServiceCtx(rpcCtx),

--- a/apps/server/src/routes/rpc/handlers/maintenance/index.ts
+++ b/apps/server/src/routes/rpc/handlers/maintenance/index.ts
@@ -1,12 +1,15 @@
 import { Code, ConnectError, type ServiceImpl } from "@connectrpc/connect";
 import type { MaintenanceService } from "@openstatus/proto/maintenance/v1";
 import {
+  addMaintenanceUpdate,
   createMaintenance,
   deleteMaintenance,
+  deleteMaintenanceUpdate,
   getMaintenance,
   listMaintenances,
   notifyMaintenance,
   updateMaintenance,
+  updateMaintenanceUpdate,
 } from "@openstatus/services/maintenance";
 
 import { toConnectError, toServiceCtx } from "../../adapter";
@@ -14,6 +17,7 @@ import { getRpcContext } from "../../interceptors";
 import {
   dbMaintenanceToProto,
   dbMaintenanceToProtoSummary,
+  dbMaintenanceUpdateToProto,
 } from "./converters";
 import { invalidDateFormatError, maintenanceIdRequiredError } from "./errors";
 
@@ -50,7 +54,7 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
       const rpcCtx = getRpcContext(ctx);
       const sCtx = toServiceCtx(rpcCtx);
 
-      const record = await createMaintenance({
+      const result = await createMaintenance({
         ctx: sCtx,
         input: {
           title: req.title,
@@ -76,7 +80,7 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
         // that affordance.
         await notifyMaintenance({
           ctx: sCtx,
-          input: { maintenanceId: record.id },
+          input: { maintenanceUpdateId: result.initialUpdate.id },
         });
       }
 
@@ -85,12 +89,13 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
       // createNotification.
       const full = await getMaintenance({
         ctx: sCtx,
-        input: { id: record.id },
+        input: { id: result.maintenance.id },
       });
       return {
         maintenance: dbMaintenanceToProto(
           full,
           full.pageComponentIds.map(String),
+          full.updates,
         ),
       };
     } catch (err) {
@@ -112,6 +117,7 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
         maintenance: dbMaintenanceToProto(
           full,
           full.pageComponentIds.map(String),
+          full.updates,
         ),
       };
     } catch (err) {
@@ -179,6 +185,7 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
         maintenance: dbMaintenanceToProto(
           full,
           full.pageComponentIds.map(String),
+          full.updates,
         ),
       };
     } catch (err) {
@@ -193,6 +200,71 @@ export const maintenanceServiceImpl: ServiceImpl<typeof MaintenanceService> = {
         throw maintenanceIdRequiredError();
       }
       await deleteMaintenance({
+        ctx: toServiceCtx(rpcCtx),
+        input: { id: Number(req.id) },
+      });
+      return { success: true };
+    } catch (err) {
+      toConnectError(err);
+    }
+  },
+
+  async addMaintenanceUpdate(req, ctx) {
+    try {
+      const rpcCtx = getRpcContext(ctx);
+      const sCtx = toServiceCtx(rpcCtx);
+      if (!req.maintenanceId?.trim()) {
+        throw maintenanceIdRequiredError();
+      }
+      const result = await addMaintenanceUpdate({
+        ctx: sCtx,
+        input: {
+          maintenanceId: Number(req.maintenanceId),
+          message: req.message,
+          date: req.date ? parseDate(req.date) : undefined,
+        },
+      });
+      if (req.notify) {
+        await notifyMaintenance({
+          ctx: sCtx,
+          input: { maintenanceUpdateId: result.maintenanceUpdate.id },
+        });
+      }
+      return {
+        maintenanceUpdate: dbMaintenanceUpdateToProto(result.maintenanceUpdate),
+      };
+    } catch (err) {
+      toConnectError(err);
+    }
+  },
+
+  async updateMaintenanceUpdate(req, ctx) {
+    try {
+      const rpcCtx = getRpcContext(ctx);
+      if (!req.id?.trim()) {
+        throw maintenanceIdRequiredError();
+      }
+      const update = await updateMaintenanceUpdate({
+        ctx: toServiceCtx(rpcCtx),
+        input: {
+          id: Number(req.id),
+          message: req.message,
+          date: req.date ? parseDate(req.date) : undefined,
+        },
+      });
+      return { maintenanceUpdate: dbMaintenanceUpdateToProto(update) };
+    } catch (err) {
+      toConnectError(err);
+    }
+  },
+
+  async deleteMaintenanceUpdate(req, ctx) {
+    try {
+      const rpcCtx = getRpcContext(ctx);
+      if (!req.id?.trim()) {
+        throw maintenanceIdRequiredError();
+      }
+      await deleteMaintenanceUpdate({
         ctx: toServiceCtx(rpcCtx),
         input: { id: Number(req.id) },
       });

--- a/apps/server/src/routes/rpc/interceptors/tracking.ts
+++ b/apps/server/src/routes/rpc/interceptors/tracking.ts
@@ -87,6 +87,15 @@ export const RPC_EVENT_MAP: Record<string, RpcEventMapping> = {
   "openstatus.maintenance.v1.MaintenanceService/DeleteMaintenance": {
     event: Events.DeleteMaintenance,
   },
+  "openstatus.maintenance.v1.MaintenanceService/AddMaintenanceUpdate": {
+    event: Events.CreateMaintenanceUpdate,
+  },
+  "openstatus.maintenance.v1.MaintenanceService/UpdateMaintenanceUpdate": {
+    event: Events.UpdateMaintenanceUpdate,
+  },
+  "openstatus.maintenance.v1.MaintenanceService/DeleteMaintenanceUpdate": {
+    event: Events.DeleteMaintenanceUpdate,
+  },
 
   // NotificationService
   "openstatus.notification.v1.NotificationService/CreateNotification": {

--- a/apps/server/src/routes/v1/index.ts
+++ b/apps/server/src/routes/v1/index.ts
@@ -162,7 +162,7 @@ api.route("/status_report", statusReportsApi);
 api.route("/status_report_update", statusReportUpdatesApi);
 api.route("/incident", incidentsApi);
 api.route("/maintenance", maintenancesApi);
-api.route("/maintenanceUpdates", maintenanceUpdatesApi);
+api.route("/maintenance_update", maintenanceUpdatesApi);
 api.route("/notification", notificationsApi);
 api.route("/page_subscriber", pageSubscribersApi);
 api.route("/check", checkApi);

--- a/apps/server/src/routes/v1/index.ts
+++ b/apps/server/src/routes/v1/index.ts
@@ -10,6 +10,7 @@ import { authMiddleware, requireWriteScope } from "@/libs/middlewares";
 import { checkApi } from "./check";
 import { incidentsApi } from "./incidents";
 import { maintenancesApi } from "./maintenances";
+import { maintenanceUpdatesApi } from "./maintenanceUpdates";
 import { monitorsApi } from "./monitors";
 import { notificationsApi } from "./notifications";
 import { pagesApi } from "./pages";
@@ -85,6 +86,11 @@ if (process.env.NODE_ENV === "production") {
         "x-displayName": "Maintenance",
       },
       {
+        name: "maintenance_update",
+        description: "Maintenance update related endpoints",
+        "x-displayName": "Maintenance Update",
+      },
+      {
         name: "notification",
         description: "Notification related endpoints",
         "x-displayName": "Notification",
@@ -156,6 +162,7 @@ api.route("/status_report", statusReportsApi);
 api.route("/status_report_update", statusReportUpdatesApi);
 api.route("/incident", incidentsApi);
 api.route("/maintenance", maintenancesApi);
+api.route("/maintenanceUpdates", maintenanceUpdatesApi);
 api.route("/notification", notificationsApi);
 api.route("/page_subscriber", pageSubscribersApi);
 api.route("/check", checkApi);

--- a/apps/server/src/routes/v1/maintenanceUpdates/delete.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/delete.ts
@@ -1,0 +1,46 @@
+import { createRoute } from "@hono/zod-openapi";
+import { Events } from "@openstatus/analytics";
+import { deleteMaintenanceUpdate } from "@openstatus/services/maintenance";
+
+import { openApiErrorResponses } from "@/libs/errors";
+import { trackMiddleware } from "@/libs/middlewares";
+
+import type { maintenanceUpdatesApi } from "./index";
+import { DeleteMaintenanceUpdateResponseSchema, ParamsSchema } from "./schema";
+import { throwApiError, toServiceContext } from "./utils";
+
+const route = createRoute({
+  method: "delete",
+  tags: ["maintenance_update"],
+  summary: "Delete a maintenance update",
+  path: "/{id}",
+  middleware: [trackMiddleware(Events.DeleteMaintenanceUpdate)],
+  request: { params: ParamsSchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: DeleteMaintenanceUpdateResponseSchema,
+        },
+      },
+      description: "The deletion result",
+    },
+    ...openApiErrorResponses,
+  },
+});
+
+export function registerDeleteMaintenanceUpdate(
+  api: typeof maintenanceUpdatesApi,
+) {
+  return api.openapi(route, async (c) => {
+    try {
+      await deleteMaintenanceUpdate({
+        ctx: toServiceContext(c),
+        input: { id: Number(c.req.valid("param").id) },
+      });
+      return c.json({ success: true }, 200);
+    } catch (error) {
+      throwApiError(error);
+    }
+  });
+}

--- a/apps/server/src/routes/v1/maintenanceUpdates/get.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/get.ts
@@ -1,0 +1,39 @@
+import { createRoute } from "@hono/zod-openapi";
+import { getMaintenanceUpdate } from "@openstatus/services/maintenance";
+
+import { openApiErrorResponses } from "@/libs/errors";
+
+import type { maintenanceUpdatesApi } from "./index";
+import { MaintenanceUpdateSchema, ParamsSchema } from "./schema";
+import { throwApiError, toServiceContext } from "./utils";
+
+const route = createRoute({
+  method: "get",
+  tags: ["maintenance_update"],
+  summary: "Get a maintenance update",
+  path: "/{id}",
+  request: { params: ParamsSchema },
+  responses: {
+    200: {
+      content: { "application/json": { schema: MaintenanceUpdateSchema } },
+      description: "The maintenance update",
+    },
+    ...openApiErrorResponses,
+  },
+});
+
+export function registerGetMaintenanceUpdate(
+  api: typeof maintenanceUpdatesApi,
+) {
+  return api.openapi(route, async (c) => {
+    try {
+      const update = await getMaintenanceUpdate({
+        ctx: toServiceContext(c),
+        input: { id: Number(c.req.valid("param").id) },
+      });
+      return c.json(MaintenanceUpdateSchema.parse(update), 200);
+    } catch (error) {
+      throwApiError(error);
+    }
+  });
+}

--- a/apps/server/src/routes/v1/maintenanceUpdates/index.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/index.ts
@@ -1,0 +1,20 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+
+import { handleZodError } from "@/libs/errors";
+
+import type { Variables } from "../index";
+import { registerDeleteMaintenanceUpdate } from "./delete";
+import { registerGetMaintenanceUpdate } from "./get";
+import { registerPostMaintenanceUpdate } from "./post";
+import { registerPutMaintenanceUpdate } from "./put";
+
+export const maintenanceUpdatesApi = new OpenAPIHono<{
+  Variables: Variables;
+}>({
+  defaultHook: handleZodError,
+});
+
+registerGetMaintenanceUpdate(maintenanceUpdatesApi);
+registerPostMaintenanceUpdate(maintenanceUpdatesApi);
+registerPutMaintenanceUpdate(maintenanceUpdatesApi);
+registerDeleteMaintenanceUpdate(maintenanceUpdatesApi);

--- a/apps/server/src/routes/v1/maintenanceUpdates/maintenance-updates.test.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/maintenance-updates.test.ts
@@ -9,7 +9,7 @@ const headers = {
 };
 
 test("maintenance update REST CRUD", async () => {
-  const created = await app.request("/v1/maintenanceUpdates", {
+  const created = await app.request("/v1/maintenance_update", {
     method: "POST",
     headers,
     body: JSON.stringify({
@@ -21,12 +21,12 @@ test("maintenance update REST CRUD", async () => {
   expect(created.status).toBe(200);
   const update = await created.json();
 
-  const fetched = await app.request(`/v1/maintenanceUpdates/${update.id}`, {
+  const fetched = await app.request(`/v1/maintenance_update/${update.id}`, {
     headers,
   });
   expect(fetched.status).toBe(200);
 
-  const edited = await app.request(`/v1/maintenanceUpdates/${update.id}`, {
+  const edited = await app.request(`/v1/maintenance_update/${update.id}`, {
     method: "PUT",
     headers,
     body: JSON.stringify({ message: "Edited REST maintenance update" }),
@@ -34,7 +34,7 @@ test("maintenance update REST CRUD", async () => {
   expect(edited.status).toBe(200);
   expect((await edited.json()).message).toBe("Edited REST maintenance update");
 
-  const deleted = await app.request(`/v1/maintenanceUpdates/${update.id}`, {
+  const deleted = await app.request(`/v1/maintenance_update/${update.id}`, {
     method: "DELETE",
     headers,
   });
@@ -43,6 +43,6 @@ test("maintenance update REST CRUD", async () => {
 });
 
 test("maintenance update REST requires authentication", async () => {
-  const response = await app.request("/v1/maintenanceUpdates/1");
+  const response = await app.request("/v1/maintenance_update/1");
   expect(response.status).toBe(401);
 });

--- a/apps/server/src/routes/v1/maintenanceUpdates/maintenance-updates.test.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/maintenance-updates.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "@std/expect";
+import { test } from "@std/testing/bdd";
+
+import { app } from "@/index";
+
+const headers = {
+  "x-openstatus-key": "1",
+  "content-type": "application/json",
+};
+
+test("maintenance update REST CRUD", async () => {
+  const created = await app.request("/v1/maintenanceUpdates", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      maintenanceId: 1,
+      message: "REST maintenance update",
+      notify: false,
+    }),
+  });
+  expect(created.status).toBe(200);
+  const update = await created.json();
+
+  const fetched = await app.request(`/v1/maintenanceUpdates/${update.id}`, {
+    headers,
+  });
+  expect(fetched.status).toBe(200);
+
+  const edited = await app.request(`/v1/maintenanceUpdates/${update.id}`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({ message: "Edited REST maintenance update" }),
+  });
+  expect(edited.status).toBe(200);
+  expect((await edited.json()).message).toBe("Edited REST maintenance update");
+
+  const deleted = await app.request(`/v1/maintenanceUpdates/${update.id}`, {
+    method: "DELETE",
+    headers,
+  });
+  expect(deleted.status).toBe(200);
+  expect(await deleted.json()).toEqual({ success: true });
+});
+
+test("maintenance update REST requires authentication", async () => {
+  const response = await app.request("/v1/maintenanceUpdates/1");
+  expect(response.status).toBe(401);
+});

--- a/apps/server/src/routes/v1/maintenanceUpdates/post.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/post.ts
@@ -1,0 +1,62 @@
+import { createRoute } from "@hono/zod-openapi";
+import { Events } from "@openstatus/analytics";
+import {
+  addMaintenanceUpdate,
+  notifyMaintenance,
+} from "@openstatus/services/maintenance";
+
+import { openApiErrorResponses } from "@/libs/errors";
+import { trackMiddleware } from "@/libs/middlewares";
+
+import type { maintenanceUpdatesApi } from "./index";
+import {
+  CreateMaintenanceUpdateSchema,
+  MaintenanceUpdateSchema,
+} from "./schema";
+import { throwApiError, toServiceContext } from "./utils";
+
+const route = createRoute({
+  method: "post",
+  tags: ["maintenance_update"],
+  summary: "Create a maintenance update",
+  path: "/",
+  middleware: [trackMiddleware(Events.CreateMaintenanceUpdate)],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: CreateMaintenanceUpdateSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: MaintenanceUpdateSchema } },
+      description: "The created maintenance update",
+    },
+    ...openApiErrorResponses,
+  },
+});
+
+export function registerPostMaintenanceUpdate(
+  api: typeof maintenanceUpdatesApi,
+) {
+  return api.openapi(route, async (c) => {
+    try {
+      const input = c.req.valid("json");
+      const ctx = toServiceContext(c);
+      const result = await addMaintenanceUpdate({ ctx, input });
+      if (input.notify) {
+        await notifyMaintenance({
+          ctx,
+          input: { maintenanceUpdateId: result.maintenanceUpdate.id },
+        });
+      }
+      return c.json(
+        MaintenanceUpdateSchema.parse(result.maintenanceUpdate),
+        200,
+      );
+    } catch (error) {
+      throwApiError(error);
+    }
+  });
+}

--- a/apps/server/src/routes/v1/maintenanceUpdates/post.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/post.ts
@@ -46,10 +46,17 @@ export function registerPostMaintenanceUpdate(
       const ctx = toServiceContext(c);
       const result = await addMaintenanceUpdate({ ctx, input });
       if (input.notify) {
-        await notifyMaintenance({
-          ctx,
-          input: { maintenanceUpdateId: result.maintenanceUpdate.id },
-        });
+        try {
+          await notifyMaintenance({
+            ctx,
+            input: { maintenanceUpdateId: result.maintenanceUpdate.id },
+          });
+        } catch (err) {
+          console.warn(
+            "notifyMaintenance failed after create maintenance update",
+            err,
+          );
+        }
       }
       return c.json(
         MaintenanceUpdateSchema.parse(result.maintenanceUpdate),

--- a/apps/server/src/routes/v1/maintenanceUpdates/put.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/put.ts
@@ -1,0 +1,56 @@
+import { createRoute } from "@hono/zod-openapi";
+import { Events } from "@openstatus/analytics";
+import { updateMaintenanceUpdate } from "@openstatus/services/maintenance";
+
+import { openApiErrorResponses } from "@/libs/errors";
+import { trackMiddleware } from "@/libs/middlewares";
+
+import type { maintenanceUpdatesApi } from "./index";
+import {
+  MaintenanceUpdateSchema,
+  ParamsSchema,
+  UpdateMaintenanceUpdateSchema,
+} from "./schema";
+import { throwApiError, toServiceContext } from "./utils";
+
+const route = createRoute({
+  method: "put",
+  tags: ["maintenance_update"],
+  summary: "Update a maintenance update",
+  path: "/{id}",
+  middleware: [trackMiddleware(Events.UpdateMaintenanceUpdate)],
+  request: {
+    params: ParamsSchema,
+    body: {
+      content: {
+        "application/json": { schema: UpdateMaintenanceUpdateSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: MaintenanceUpdateSchema } },
+      description: "The updated maintenance update",
+    },
+    ...openApiErrorResponses,
+  },
+});
+
+export function registerPutMaintenanceUpdate(
+  api: typeof maintenanceUpdatesApi,
+) {
+  return api.openapi(route, async (c) => {
+    try {
+      const update = await updateMaintenanceUpdate({
+        ctx: toServiceContext(c),
+        input: {
+          id: Number(c.req.valid("param").id),
+          ...c.req.valid("json"),
+        },
+      });
+      return c.json(MaintenanceUpdateSchema.parse(update), 200);
+    } catch (error) {
+      throwApiError(error);
+    }
+  });
+}

--- a/apps/server/src/routes/v1/maintenanceUpdates/schema.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/schema.ts
@@ -4,6 +4,7 @@ export const ParamsSchema = z.object({
   id: z
     .string()
     .min(1)
+    .regex(/^\d+$/, "ID must be a numeric string")
     .openapi({
       param: { name: "id", in: "path" },
       description: "The maintenance update id",

--- a/apps/server/src/routes/v1/maintenanceUpdates/schema.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/schema.ts
@@ -1,0 +1,45 @@
+import { z } from "@hono/zod-openapi";
+
+export const ParamsSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .openapi({
+      param: { name: "id", in: "path" },
+      description: "The maintenance update id",
+      example: "1",
+    }),
+});
+
+export const MaintenanceUpdateSchema = z
+  .object({
+    id: z.coerce.string().openapi({ description: "The update id" }),
+    message: z.string().min(1).openapi({ description: "The public message" }),
+    date: z.coerce.date().openapi({ description: "The update date" }),
+    maintenanceId: z.number().int().openapi({
+      description: "The maintenance id",
+    }),
+    createdAt: z.coerce.date().nullable(),
+    updatedAt: z.coerce.date().nullable(),
+  })
+  .openapi("MaintenanceUpdate");
+
+export const CreateMaintenanceUpdateSchema = z.object({
+  maintenanceId: z.number().int(),
+  message: z.string().min(1),
+  date: z.coerce.date().optional(),
+  notify: z.boolean().default(false),
+});
+
+export const UpdateMaintenanceUpdateSchema = z
+  .object({
+    message: z.string().min(1).optional(),
+    date: z.coerce.date().optional(),
+  })
+  .refine((input) => input.message !== undefined || input.date !== undefined, {
+    message: "At least one field must be provided.",
+  });
+
+export const DeleteMaintenanceUpdateResponseSchema = z.object({
+  success: z.boolean(),
+});

--- a/apps/server/src/routes/v1/maintenanceUpdates/utils.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/utils.ts
@@ -1,0 +1,44 @@
+import { ServiceError, type ServiceContext } from "@openstatus/services";
+
+import { tb } from "@/libs/clients";
+import { OpenStatusApiError } from "@/libs/errors";
+
+import type { Variables } from "../index";
+
+export function toServiceContext(c: {
+  get<K extends keyof Variables>(key: K): Variables[K];
+}): ServiceContext {
+  const apiKey = c.get("apiKey");
+  return {
+    workspace: c.get("workspace"),
+    actor: {
+      type: "apiKey",
+      keyId: apiKey.id,
+      userId: apiKey.createdById,
+      scopes: apiKey.scopes,
+    },
+    requestId: c.get("requestId"),
+    tb,
+  };
+}
+
+export function throwApiError(error: unknown): never {
+  if (error instanceof ServiceError) {
+    const code =
+      error.code === "NOT_FOUND"
+        ? "NOT_FOUND"
+        : error.code === "FORBIDDEN"
+          ? "FORBIDDEN"
+          : error.code === "UNAUTHORIZED"
+            ? "UNAUTHORIZED"
+            : error.code === "CONFLICT" ||
+                error.code === "VALIDATION" ||
+                error.code === "PRECONDITION_FAILED"
+              ? "BAD_REQUEST"
+              : error.code === "LIMIT_EXCEEDED"
+                ? "CONFLICT"
+                : "INTERNAL_SERVER_ERROR";
+    throw new OpenStatusApiError({ code, message: error.message });
+  }
+  throw error;
+}

--- a/apps/server/src/routes/v1/maintenanceUpdates/utils.ts
+++ b/apps/server/src/routes/v1/maintenanceUpdates/utils.ts
@@ -31,12 +31,11 @@ export function throwApiError(error: unknown): never {
           ? "FORBIDDEN"
           : error.code === "UNAUTHORIZED"
             ? "UNAUTHORIZED"
-            : error.code === "CONFLICT" ||
-                error.code === "VALIDATION" ||
-                error.code === "PRECONDITION_FAILED"
-              ? "BAD_REQUEST"
-              : error.code === "LIMIT_EXCEEDED"
-                ? "CONFLICT"
+            : error.code === "CONFLICT" || error.code === "LIMIT_EXCEEDED"
+              ? "CONFLICT"
+              : error.code === "VALIDATION" ||
+                  error.code === "PRECONDITION_FAILED"
+                ? "BAD_REQUEST"
                 : "INTERNAL_SERVER_ERROR";
     throw new OpenStatusApiError({ code, message: error.message });
   }

--- a/apps/server/src/routes/v1/maintenances/post.test.ts
+++ b/apps/server/src/routes/v1/maintenances/post.test.ts
@@ -1,5 +1,5 @@
 import { db, eq } from "@openstatus/db";
-import { maintenance } from "@openstatus/db/src/schema";
+import { maintenance, maintenanceUpdate } from "@openstatus/db/src/schema";
 import { expect } from "@std/expect";
 import { beforeEach, test } from "@std/testing/bdd";
 
@@ -245,11 +245,16 @@ test("create a maintenance calls dispatchMaintenanceUpdate", async () => {
   const result = MaintenanceSchema.safeParse(await res.json());
   expect(result.success).toBe(true);
   expect(spies.dispatchMaintenanceUpdate.mock.calls.length).toBe(1);
-  expect(typeof spies.dispatchMaintenanceUpdate.mock.calls[0][0]).toBe(
-    "number",
-  );
 
   if (result.success) {
+    const initialUpdate = await db
+      .select({ id: maintenanceUpdate.id })
+      .from(maintenanceUpdate)
+      .where(eq(maintenanceUpdate.maintenanceId, result.data.id))
+      .get();
+    expect(spies.dispatchMaintenanceUpdate.mock.calls[0][0]).toBe(
+      initialUpdate?.id,
+    );
     await db.delete(maintenance).where(eq(maintenance.id, result.data.id));
   }
 });

--- a/apps/server/src/routes/v1/maintenances/post.ts
+++ b/apps/server/src/routes/v1/maintenances/post.ts
@@ -2,7 +2,10 @@ import { createRoute } from "@hono/zod-openapi";
 import { Events } from "@openstatus/analytics";
 import { and, db, eq, inArray, isNull } from "@openstatus/db";
 import { monitor, page } from "@openstatus/db/src/schema";
-import { maintenance } from "@openstatus/db/src/schema/maintenances";
+import {
+  maintenance,
+  maintenanceUpdate,
+} from "@openstatus/db/src/schema/maintenances";
 import {
   maintenancesToPageComponents,
   pageComponent,
@@ -108,6 +111,16 @@ export function registerPostMaintenance(api: typeof maintenancesApi) {
         .returning()
         .get();
 
+      const initialUpdate = await tx
+        .insert(maintenanceUpdate)
+        .values({
+          maintenanceId: newMaintenance.id,
+          message: newMaintenance.message,
+          date: newMaintenance.createdAt ?? newMaintenance.from,
+        })
+        .returning()
+        .get();
+
       if (monitorIds?.length && newMaintenance.pageId) {
         // Get page components for the given monitors and page
         const pageComponents = await tx
@@ -135,15 +148,15 @@ export function registerPostMaintenance(api: typeof maintenancesApi) {
         }
       }
 
-      return newMaintenance;
+      return { maintenance: newMaintenance, initialUpdate };
     });
 
-    if (limits["status-subscribers"] && _newMaintenance.pageId) {
-      await dispatchMaintenanceUpdate(_newMaintenance.id);
+    if (limits["status-subscribers"] && _newMaintenance.maintenance.pageId) {
+      await dispatchMaintenanceUpdate(_newMaintenance.initialUpdate.id);
     }
 
     const data = MaintenanceSchema.parse({
-      ..._newMaintenance,
+      ..._newMaintenance.maintenance,
       monitorIds: input.monitorIds,
     });
 

--- a/apps/server/src/routes/v1/maintenances/post.ts
+++ b/apps/server/src/routes/v1/maintenances/post.ts
@@ -10,8 +10,10 @@ import {
   maintenancesToPageComponents,
   pageComponent,
 } from "@openstatus/db/src/schema/page_components";
+import { emitAudit } from "@openstatus/services";
 import { dispatchMaintenanceUpdate } from "@openstatus/subscriptions";
 
+import { tb } from "@/libs/clients";
 import { OpenStatusApiError, openApiErrorResponses } from "@/libs/errors";
 import { trackMiddleware } from "@/libs/middlewares";
 
@@ -56,11 +58,25 @@ const postRoute = createRoute({
 
 export function registerPostMaintenance(api: typeof maintenancesApi) {
   return api.openapi(postRoute, async (c) => {
-    const workspaceId = c.get("workspace").id;
+    const workspace = c.get("workspace");
+    const workspaceId = workspace.id;
+    const apiKey = c.get("apiKey");
     const input = c.req.valid("json");
-    const limits = c.get("workspace").limits;
+    const limits = workspace.limits;
 
     const { monitorIds, pageId } = input;
+
+    const serviceCtx = {
+      workspace,
+      actor: {
+        type: "apiKey" as const,
+        keyId: apiKey.id,
+        userId: apiKey.createdById,
+        scopes: apiKey.scopes,
+      },
+      requestId: c.get("requestId"),
+      tb,
+    };
 
     if (input.from > input.to) {
       throw new OpenStatusApiError({
@@ -120,6 +136,14 @@ export function registerPostMaintenance(api: typeof maintenancesApi) {
         })
         .returning()
         .get();
+
+      await emitAudit(tx, serviceCtx, {
+        action: "maintenance_update.create",
+        entityType: "maintenance_update",
+        entityId: initialUpdate.id,
+        after: initialUpdate,
+        metadata: { maintenanceId: newMaintenance.id },
+      });
 
       if (monitorIds?.length && newMaintenance.pageId) {
         // Get page components for the given monitors and page

--- a/apps/server/src/routes/v1/maintenances/put.test.ts
+++ b/apps/server/src/routes/v1/maintenances/put.test.ts
@@ -1,3 +1,5 @@
+import { db, desc, eq } from "@openstatus/db";
+import { maintenanceUpdate } from "@openstatus/db/src/schema";
 import { expect } from "@std/expect";
 import { test } from "@std/testing/bdd";
 
@@ -95,6 +97,14 @@ test("update only the message", async () => {
   expect(res.status).toBe(200);
   expect(result.success).toBe(true);
   expect(result.data?.message).toBe("Only Message Updated");
+
+  const latestUpdate = await db
+    .select()
+    .from(maintenanceUpdate)
+    .where(eq(maintenanceUpdate.maintenanceId, 1))
+    .orderBy(desc(maintenanceUpdate.date), desc(maintenanceUpdate.id))
+    .get();
+  expect(latestUpdate?.message).toBe("Only Message Updated");
 });
 
 test.ignore("update only the dates", async () => {

--- a/apps/server/src/routes/v1/maintenances/put.ts
+++ b/apps/server/src/routes/v1/maintenances/put.ts
@@ -1,13 +1,18 @@
 import { createRoute } from "@hono/zod-openapi";
 import { Events } from "@openstatus/analytics";
-import { and, db, eq, inArray, isNull } from "@openstatus/db";
+import { and, db, desc, eq, inArray, isNull } from "@openstatus/db";
 import { monitor, page } from "@openstatus/db/src/schema";
-import { maintenance } from "@openstatus/db/src/schema/maintenances";
+import {
+  maintenance,
+  maintenanceUpdate,
+} from "@openstatus/db/src/schema/maintenances";
 import {
   maintenancesToPageComponents,
   pageComponent,
 } from "@openstatus/db/src/schema/page_components";
+import { updateMaintenanceUpdate } from "@openstatus/services/maintenance";
 
+import { tb } from "@/libs/clients";
 import { OpenStatusApiError, openApiErrorResponses } from "@/libs/errors";
 import { trackMiddleware } from "@/libs/middlewares";
 
@@ -53,9 +58,22 @@ const putRoute = createRoute({
 
 export function registerPutMaintenance(api: typeof maintenancesApi) {
   return api.openapi(putRoute, async (c) => {
-    const workspaceId = c.get("workspace").id;
+    const workspace = c.get("workspace");
+    const workspaceId = workspace.id;
+    const apiKey = c.get("apiKey");
     const { id } = c.req.valid("param");
     const input = c.req.valid("json");
+    const serviceCtx = {
+      workspace,
+      actor: {
+        type: "apiKey" as const,
+        keyId: apiKey.id,
+        userId: apiKey.createdById,
+        scopes: apiKey.scopes,
+      },
+      requestId: c.get("requestId"),
+      tb,
+    };
 
     const { monitorIds, pageId } = input;
 
@@ -127,6 +145,27 @@ export function registerPutMaintenance(api: typeof maintenancesApi) {
     }
 
     const updatedMaintenance = await db.transaction(async (tx) => {
+      if (input.message !== undefined) {
+        const latestUpdate = await tx
+          .select({ id: maintenanceUpdate.id })
+          .from(maintenanceUpdate)
+          .where(eq(maintenanceUpdate.maintenanceId, Number(id)))
+          .orderBy(desc(maintenanceUpdate.date), desc(maintenanceUpdate.id))
+          .get();
+
+        if (!latestUpdate) {
+          throw new OpenStatusApiError({
+            code: "CONFLICT",
+            message: "A maintenance must have at least one update.",
+          });
+        }
+
+        await updateMaintenanceUpdate({
+          ctx: { ...serviceCtx, db: tx },
+          input: { id: latestUpdate.id, message: input.message },
+        });
+      }
+
       const updated = await tx
         .update(maintenance)
         .set({

--- a/apps/server/static/openapi.yaml
+++ b/apps/server/static/openapi.yaml
@@ -102,6 +102,45 @@ components:
         - SERVING_STATUS_SERVING
         - SERVING_STATUS_NOT_SERVING
       description: ServingStatus represents the health status of the service.
+    openstatus.maintenance.v1.AddMaintenanceUpdateRequest:
+      type: object
+      properties:
+        maintenanceId:
+          type: string
+          title: maintenance_id
+          minLength: 1
+          description: ID of the maintenance to update (required).
+        message:
+          type: string
+          title: message
+          minLength: 1
+          description: Public update message (required).
+        date:
+          type:
+            - string
+            - "null"
+          title: date
+          pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$
+          description: Optional date for the update (RFC 3339 format). Defaults to current time.
+        notify:
+          type:
+            - boolean
+            - "null"
+          title: notify
+          description: Whether to notify subscribers about this update.
+      title: AddMaintenanceUpdateRequest
+      additionalProperties: false
+      description: AddMaintenanceUpdateRequest is the request to append a maintenance update.
+    openstatus.maintenance.v1.AddMaintenanceUpdateResponse:
+      type: object
+      properties:
+        maintenanceUpdate:
+          title: maintenance_update
+          description: The created update.
+          $ref: '#/components/schemas/openstatus.maintenance.v1.MaintenanceUpdate'
+      title: AddMaintenanceUpdateResponse
+      additionalProperties: false
+      description: AddMaintenanceUpdateResponse is the response after appending an update.
     openstatus.maintenance.v1.CreateMaintenanceRequest:
       type: object
       properties:
@@ -183,6 +222,27 @@ components:
       title: DeleteMaintenanceResponse
       additionalProperties: false
       description: DeleteMaintenanceResponse is the response after deleting a maintenance window.
+    openstatus.maintenance.v1.DeleteMaintenanceUpdateRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          minLength: 1
+          description: ID of the update to remove (required).
+      title: DeleteMaintenanceUpdateRequest
+      additionalProperties: false
+      description: DeleteMaintenanceUpdateRequest is the request to remove an update.
+    openstatus.maintenance.v1.DeleteMaintenanceUpdateResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          title: success
+          description: Whether the deletion was successful.
+      title: DeleteMaintenanceUpdateResponse
+      additionalProperties: false
+      description: DeleteMaintenanceUpdateResponse is the response after removing an update.
     openstatus.maintenance.v1.GetMaintenanceRequest:
       type: object
       properties:
@@ -291,6 +351,12 @@ components:
           type: string
           title: updated_at
           description: Timestamp when the maintenance was last updated (RFC 3339 format).
+        updates:
+          type: array
+          items:
+            $ref: '#/components/schemas/openstatus.maintenance.v1.MaintenanceUpdate'
+          title: updates
+          description: Full maintenance update timeline, newest first.
       title: Maintenance
       additionalProperties: false
       description: Maintenance represents a maintenance window with full details.
@@ -338,6 +404,36 @@ components:
       title: MaintenanceSummary
       additionalProperties: false
       description: MaintenanceSummary represents metadata for a maintenance window (used in list responses).
+    openstatus.maintenance.v1.MaintenanceUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: Unique identifier for the update.
+        message:
+          type: string
+          title: message
+          description: Public update message.
+        date:
+          type: string
+          title: date
+          description: Date of the update (RFC 3339 format).
+        maintenanceId:
+          type: string
+          title: maintenance_id
+          description: ID of the maintenance this update belongs to.
+        createdAt:
+          type: string
+          title: created_at
+          description: Timestamp when the update was created (RFC 3339 format).
+        updatedAt:
+          type: string
+          title: updated_at
+          description: Timestamp when the update was last updated (RFC 3339 format).
+      title: MaintenanceUpdate
+      additionalProperties: false
+      description: MaintenanceUpdate represents a timeline entry for a maintenance window.
     openstatus.maintenance.v1.UpdateMaintenanceRequest:
       type: object
       properties:
@@ -409,6 +505,41 @@ components:
       title: UpdateMaintenanceResponse
       additionalProperties: false
       description: UpdateMaintenanceResponse is the response after updating a maintenance window.
+    openstatus.maintenance.v1.UpdateMaintenanceUpdateRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          minLength: 1
+          description: ID of the update to edit (required).
+        message:
+          type:
+            - string
+            - "null"
+          title: message
+          minLength: 1
+          description: New public message.
+        date:
+          type:
+            - string
+            - "null"
+          title: date
+          pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$
+          description: New update date (RFC 3339 format).
+      title: UpdateMaintenanceUpdateRequest
+      additionalProperties: false
+      description: UpdateMaintenanceUpdateRequest is the request to edit an update.
+    openstatus.maintenance.v1.UpdateMaintenanceUpdateResponse:
+      type: object
+      properties:
+        maintenanceUpdate:
+          title: maintenance_update
+          description: The updated timeline entry.
+          $ref: '#/components/schemas/openstatus.maintenance.v1.MaintenanceUpdate'
+      title: UpdateMaintenanceUpdateResponse
+      additionalProperties: false
+      description: UpdateMaintenanceUpdateResponse is the response after editing an update.
     openstatus.monitor.v1.BodyAssertion:
       type: object
       properties:
@@ -4812,6 +4943,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/openstatus.health.v1.CheckResponse'
+  /rpc/openstatus.maintenance.v1.MaintenanceService/AddMaintenanceUpdate:
+    post:
+      tags:
+        - MaintenanceService
+      summary: AddMaintenanceUpdate
+      description: AddMaintenanceUpdate appends a public update to a maintenance timeline.
+      operationId: MaintenanceService_AddMaintenanceUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/openstatus.maintenance.v1.AddMaintenanceUpdateRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openstatus.maintenance.v1.AddMaintenanceUpdateResponse'
   /rpc/openstatus.maintenance.v1.MaintenanceService/CreateMaintenance:
     post:
       tags:
@@ -4864,6 +5021,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/openstatus.maintenance.v1.DeleteMaintenanceResponse'
+  /rpc/openstatus.maintenance.v1.MaintenanceService/DeleteMaintenanceUpdate:
+    post:
+      tags:
+        - MaintenanceService
+      summary: DeleteMaintenanceUpdate
+      description: DeleteMaintenanceUpdate removes an existing maintenance update.
+      operationId: MaintenanceService_DeleteMaintenanceUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/openstatus.maintenance.v1.DeleteMaintenanceUpdateRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openstatus.maintenance.v1.DeleteMaintenanceUpdateResponse'
   /rpc/openstatus.maintenance.v1.MaintenanceService/GetMaintenance:
     get:
       tags:
@@ -4994,6 +5177,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/openstatus.maintenance.v1.UpdateMaintenanceResponse'
+  /rpc/openstatus.maintenance.v1.MaintenanceService/UpdateMaintenanceUpdate:
+    post:
+      tags:
+        - MaintenanceService
+      summary: UpdateMaintenanceUpdate
+      description: UpdateMaintenanceUpdate edits an existing maintenance update.
+      operationId: MaintenanceService_UpdateMaintenanceUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/openstatus.maintenance.v1.UpdateMaintenanceUpdateRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openstatus.maintenance.v1.UpdateMaintenanceUpdateResponse'
   /rpc/openstatus.monitor.v1.MonitorService/CreateDNSMonitor:
     post:
       tags:

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/[type]/route.ts
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/[type]/route.ts
@@ -81,12 +81,27 @@ export async function GET(
 
     for (const maintenance of page.maintenances ?? []) {
       const maintenanceUrl = `${baseUrl}/events/maintenance/${maintenance.id}`;
+      const updates = [...(maintenance.maintenanceUpdates ?? [])].sort(
+        (a, b) => b.date.getTime() - a.date.getTime(),
+      );
+      const description =
+        updates.length > 0
+          ? updates
+              .map(
+                (update) => `${update.date.toISOString()}: ${update.message}`,
+              )
+              .join("\n\n")
+          : maintenance.message;
       feed.addItem({
         id: maintenanceUrl,
         title: `${statusLabel("maintenance")} - ${maintenance.title}`,
         link: maintenanceUrl,
-        description: maintenance.message,
-        date: maintenance.updatedAt ?? maintenance.createdAt ?? new Date(),
+        description,
+        date:
+          updates[0]?.date ??
+          maintenance.updatedAt ??
+          maintenance.createdAt ??
+          new Date(),
       });
     }
 

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/[type]/route.ts
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/[type]/route.ts
@@ -97,11 +97,7 @@ export async function GET(
         title: `${statusLabel("maintenance")} - ${maintenance.title}`,
         link: maintenanceUrl,
         description,
-        date:
-          updates[0]?.date ??
-          maintenance.updatedAt ??
-          maintenance.createdAt ??
-          new Date(),
+        date: maintenance.updatedAt ?? maintenance.createdAt ?? new Date(),
       });
     }
 

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/json/route.ts
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/json/route.ts
@@ -78,7 +78,7 @@ export async function GET(
         return {
           id: maintenance.id,
           name: maintenance.title,
-          message: updates.length === 0 ? maintenance.message : undefined,
+          message: maintenance.message,
           maintenanceUpdates: updates.map((update) => ({
             id: update.id,
             message: update.message,

--- a/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/json/route.ts
+++ b/apps/status-page/src/app/(status-page)/[domain]/[locale]/(public)/feed/json/route.ts
@@ -71,22 +71,33 @@ export async function GET(
         id: group.id,
         name: group.name,
       })),
-      maintenances: page.maintenances.map((maintenance) => ({
-        id: maintenance.id,
-        name: maintenance.title,
-        message: maintenance.message,
-        from: maintenance.from,
-        to: maintenance.to,
-        updatedAt: maintenance.updatedAt,
-        // @deprecated Use components instead - returning monitor IDs for backwards compatibility
-        monitors: maintenance.maintenancesToPageComponents
-          .map((item) => item.pageComponent.monitorId)
-          .filter((id): id is number => id !== null),
-        // New field - references page component IDs
-        pageComponents: maintenance.maintenancesToPageComponents.map(
-          (item) => item.pageComponentId,
-        ),
-      })),
+      maintenances: page.maintenances.map((maintenance) => {
+        const updates = [...(maintenance.maintenanceUpdates ?? [])].sort(
+          (a, b) => b.date.getTime() - a.date.getTime(),
+        );
+        return {
+          id: maintenance.id,
+          name: maintenance.title,
+          message: updates.length === 0 ? maintenance.message : undefined,
+          maintenanceUpdates: updates.map((update) => ({
+            id: update.id,
+            message: update.message,
+            date: update.date,
+            updatedAt: update.updatedAt,
+          })),
+          from: maintenance.from,
+          to: maintenance.to,
+          updatedAt: maintenance.updatedAt,
+          // @deprecated Use components instead - returning monitor IDs for backwards compatibility
+          monitors: maintenance.maintenancesToPageComponents
+            .map((item) => item.pageComponent.monitorId)
+            .filter((id): id is number => id !== null),
+          // New field - references page component IDs
+          pageComponents: maintenance.maintenancesToPageComponents.map(
+            (item) => item.pageComponentId,
+          ),
+        };
+      }),
       statusReports: page.statusReports.map((report) => ({
         id: report.id,
         title: report.title,

--- a/apps/status-page/src/content/markdown/generators.test.ts
+++ b/apps/status-page/src/content/markdown/generators.test.ts
@@ -539,6 +539,28 @@ describe("generateMaintenance", () => {
     expect(withUrls).toContain('contact_url: "mailto:status@acme.com"');
   });
 
+  test("renders updates newest-first without the parent message", () => {
+    const withUpdates = {
+      ...maintenance,
+      maintenanceUpdates: [
+        {
+          date: new Date("2026-06-20T00:15:00.000Z"),
+          message: "Work started.",
+        },
+        {
+          date: new Date("2026-06-20T00:45:00.000Z"),
+          message: "Work completed.",
+        },
+      ],
+    } as unknown as MaintenanceDetail;
+    const out = generateMaintenance(withUpdates, BASE);
+    expect(out).toContain("## Updates");
+    expect(out.indexOf("Work completed.")).toBeLessThan(
+      out.indexOf("Work started."),
+    );
+    expect(out).not.toContain("Brief downtime.");
+  });
+
   test("null `to` renders 'ongoing', not a bogus duration", () => {
     const openEnded = {
       ...maintenance,

--- a/apps/status-page/src/content/markdown/generators.ts
+++ b/apps/status-page/src/content/markdown/generators.ts
@@ -52,6 +52,14 @@ function avg(values: number[]): number | null {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
 
+function newestMaintenanceUpdates<T extends { date: Date | string | number }>(
+  updates: T[] | undefined,
+): T[] {
+  return [...(updates ?? [])].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+}
+
 export function generateOverview(
   page: OverviewPage,
   components: UptimeComponent[],
@@ -144,7 +152,14 @@ export function generateOverview(
         mdUrl(`events/maintenance/${m.id}`),
       ].filter(Boolean);
       out.push(head.join(" · "));
-      if (m.message) out.push(`  ${m.message}`);
+      const updates = newestMaintenanceUpdates(m.maintenanceUpdates);
+      if (updates.length > 0) {
+        for (const update of updates) {
+          out.push(`  - ${formatDayTime(update.date)} — ${update.message}`);
+        }
+      } else if (m.message) {
+        out.push(`  ${m.message}`);
+      }
     }
     out.push("");
   }
@@ -332,13 +347,26 @@ export function generateEventsList(
     }
   }
   for (const m of page.maintenances) {
-    logRows.push({
-      timestamp: m.from,
-      label: "MAINTENANCE",
-      glyph: statusGlyph("info"),
-      ref: `maintenance/${m.id}`,
-      title: m.title,
-    });
+    const updates = newestMaintenanceUpdates(m.maintenanceUpdates);
+    if (updates.length > 0) {
+      for (const update of updates) {
+        logRows.push({
+          timestamp: update.date,
+          label: "MAINTENANCE",
+          glyph: statusGlyph("info"),
+          ref: `maintenance/${m.id}`,
+          title: m.title,
+        });
+      }
+    } else {
+      logRows.push({
+        timestamp: m.from,
+        label: "MAINTENANCE",
+        glyph: statusGlyph("info"),
+        ref: `maintenance/${m.id}`,
+        title: m.title,
+      });
+    }
     // Only log a COMPLETED entry once the window has actually ended. (`m.to`
     // is non-null per schema; the truthy check is just defensive.)
     if (m.to && new Date(m.to).getTime() <= now) {
@@ -436,6 +464,14 @@ export function generateEventsList(
         `### [${escapeLinkLabel(m.title)}](${mdUrl(`events/maintenance/${m.id}`)})`,
       );
       out.push(meta.join(" · "));
+      const updates = newestMaintenanceUpdates(m.maintenanceUpdates);
+      if (updates.length > 0) {
+        for (const update of updates) {
+          out.push(`- ${formatDayTime(update.date)} — ${update.message}`);
+        }
+      } else if (m.message) {
+        out.push(m.message);
+      }
       out.push("");
     }
   }
@@ -561,8 +597,17 @@ export function generateMaintenance(
     out.push(`**Affected components:** ${components.join(", ")}\n`);
   }
 
-  out.push("## Details\n");
-  out.push(`${maintenance.message}\n`);
+  const updates = newestMaintenanceUpdates(maintenance.maintenanceUpdates);
+  if (updates.length > 0) {
+    out.push("## Updates\n");
+    for (const update of updates) {
+      out.push(`### ${formatDayTime(update.date)}\n`);
+      out.push(`${update.message}\n`);
+    }
+  } else {
+    out.push("## Details\n");
+    out.push(`${maintenance.message}\n`);
+  }
 
   return `${out.join("\n").trimEnd()}\n`;
 }

--- a/apps/status-page/src/content/status-json.test.ts
+++ b/apps/status-page/src/content/status-json.test.ts
@@ -96,6 +96,12 @@ const page = {
       title: "DB upgrade",
       from: new Date("2026-06-20T00:00:00.000Z"),
       to: new Date("2026-06-20T01:00:00.000Z"),
+      maintenanceUpdates: [
+        {
+          message: "Upgrade scheduled.",
+          date: new Date("2026-06-19T12:00:00.000Z"),
+        },
+      ],
     },
   ],
 } as unknown as Page;
@@ -143,6 +149,12 @@ describe("toSummary", () => {
       status: "scheduled",
       scheduled_for: "2026-06-20T00:00:00.000Z",
     });
+    expect(summary.scheduled_maintenances[0].maintenance_updates).toEqual([
+      {
+        body: "Upgrade scheduled.",
+        created_at: "2026-06-19T12:00:00.000Z",
+      },
+    ]);
   });
 });
 

--- a/apps/status-page/src/content/status-json.ts
+++ b/apps/status-page/src/content/status-json.ts
@@ -84,6 +84,12 @@ function scheduledMaintenances(page: Page, now: number) {
       status: maintenanceState(m.from, now),
       scheduled_for: isoOrNull(m.from),
       scheduled_until: isoOrNull(m.to),
+      maintenance_updates: [...(m.maintenanceUpdates ?? [])]
+        .sort((a, b) => b.date.getTime() - a.date.getTime())
+        .map((update) => ({
+          body: update.message,
+          created_at: isoOrNull(update.date),
+        })),
     }));
 }
 

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -120,6 +120,18 @@ export const Events = {
     name: "maintenance_deleted",
     channel: "maintenance",
   },
+  CreateMaintenanceUpdate: {
+    name: "maintenance_update_created",
+    channel: "maintenance",
+  },
+  UpdateMaintenanceUpdate: {
+    name: "maintenance_update_updated",
+    channel: "maintenance",
+  },
+  DeleteMaintenanceUpdate: {
+    name: "maintenance_update_deleted",
+    channel: "maintenance",
+  },
   NotifyMaintenance: {
     name: "maintenance_notified",
     channel: "maintenance",

--- a/packages/api/src/router/maintenance.test.ts
+++ b/packages/api/src/router/maintenance.test.ts
@@ -246,6 +246,8 @@ test("maintenance update procedures provide full CRUD", async () => {
   });
   createdMaintenanceIds.push(created.id);
 
+  createdMaintenanceUpdateIds.push(created.initialUpdateId);
+
   const added = await caller.maintenance.createUpdate({
     maintenanceId: created.id,
     message: "Second update",

--- a/packages/api/src/router/maintenance.test.ts
+++ b/packages/api/src/router/maintenance.test.ts
@@ -1,6 +1,7 @@
 import { db, eq } from "@openstatus/db";
 import {
   maintenance,
+  maintenanceUpdate,
   maintenancesToPageComponents,
   page,
   pageComponent,
@@ -24,6 +25,7 @@ let otherWorkspaceComponentId: number;
 // inherit its actor attribution. See docs/adr/test-audit-cleanup.md.
 const createdMaintenanceIds: number[] = [];
 const updatedMaintenanceIds: number[] = [];
+const createdMaintenanceUpdateIds: number[] = [];
 
 beforeAll(async () => {
   const p = await db
@@ -103,6 +105,12 @@ afterAll(async () => {
     await clearAuditLogFor({
       entityType: "maintenance",
       entityIds: updatedMaintenanceIds,
+    });
+  }
+  if (createdMaintenanceUpdateIds.length > 0) {
+    await clearAuditLogFor({
+      entityType: "maintenance_update",
+      entityIds: createdMaintenanceUpdateIds,
     });
   }
 });
@@ -218,4 +226,58 @@ test("maintenance.new succeeds for own workspace page", async () => {
     .delete(maintenancesToPageComponents)
     .where(eq(maintenancesToPageComponents.maintenanceId, result.id));
   await db.delete(maintenance).where(eq(maintenance.id, result.id));
+});
+
+test("maintenance update procedures provide full CRUD", async () => {
+  const ctx = createInnerTRPCContext({
+    req: undefined,
+    session: { user: { id: "1" } },
+    // @ts-expect-error - minimal workspace for test
+    workspace: { id: 1 },
+  });
+  const caller = edgeRouter.createCaller(ctx);
+  const created = await caller.maintenance.new({
+    title: "Maintenance update CRUD",
+    message: "Initial update",
+    pageId: 1,
+    startDate: new Date(),
+    endDate: new Date(Date.now() + 3_600_000),
+    pageComponents: [1],
+  });
+  createdMaintenanceIds.push(created.id);
+
+  const added = await caller.maintenance.createUpdate({
+    maintenanceId: created.id,
+    message: "Second update",
+    date: new Date(),
+    notifySubscribers: true,
+  });
+  createdMaintenanceUpdateIds.push(added.id);
+  expect(added.notifySubscribers).toBe(true);
+
+  const edited = await caller.maintenance.updateUpdate({
+    id: added.id,
+    message: "Edited update",
+  });
+  expect(edited.message).toBe("Edited update");
+
+  const found = await caller.maintenance.get({ id: created.id });
+  expect(found.updates.length).toBe(2);
+  expect(found.message).toBe("Edited update");
+
+  await caller.maintenance.deleteUpdate({ id: added.id });
+  const deleted = await db.query.maintenanceUpdate.findFirst({
+    where: eq(maintenanceUpdate.id, added.id),
+  });
+  expect(deleted).toBeUndefined();
+
+  try {
+    await caller.maintenance.deleteUpdate({ id: created.initialUpdateId });
+    throw new Error("Should have thrown");
+  } catch (error) {
+    expect(error).toBeInstanceOf(TRPCError);
+    expect((error as TRPCError).code).toBe("CONFLICT");
+  }
+
+  await caller.maintenance.delete({ id: created.id });
 });

--- a/packages/api/src/router/maintenance.ts
+++ b/packages/api/src/router/maintenance.ts
@@ -194,11 +194,16 @@ export const maintenanceRouter = createTRPCRouter({
   updateUpdate: protectedProcedure
     .meta({ track: Events.UpdateMaintenanceUpdate })
     .input(
-      z.object({
-        id: z.number(),
-        message: z.string().optional(),
-        date: z.coerce.date().optional(),
-      }),
+      z
+        .object({
+          id: z.number(),
+          message: z.string().min(1).optional(),
+          date: z.coerce.date().optional(),
+        })
+        .refine(
+          (input) => input.message !== undefined || input.date !== undefined,
+          { message: "At least one field must be provided." },
+        ),
     )
     .mutation(async ({ ctx, input }) => {
       try {

--- a/packages/api/src/router/maintenance.ts
+++ b/packages/api/src/router/maintenance.ts
@@ -1,10 +1,14 @@
 import { Events } from "@openstatus/analytics";
 import { NotFoundError } from "@openstatus/services";
 import {
+  addMaintenanceUpdate,
   createMaintenance,
   deleteMaintenance,
+  deleteMaintenanceUpdate,
+  getMaintenance,
   listMaintenances,
   updateMaintenance,
+  updateMaintenanceUpdate,
 } from "@openstatus/services/maintenance";
 import { z } from "zod";
 
@@ -13,6 +17,35 @@ import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { periods } from "./utils";
 
 export const maintenanceRouter = createTRPCRouter({
+  createUpdate: protectedProcedure
+    .meta({ track: Events.CreateMaintenanceUpdate })
+    .input(
+      z.object({
+        maintenanceId: z.number(),
+        message: z.string(),
+        date: z.coerce.date().optional(),
+        notifySubscribers: z.boolean().nullish(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { maintenanceUpdate } = await addMaintenanceUpdate({
+          ctx: toServiceCtx(ctx),
+          input: {
+            maintenanceId: input.maintenanceId,
+            message: input.message,
+            date: input.date,
+          },
+        });
+        return {
+          ...maintenanceUpdate,
+          notifySubscribers: input.notifySubscribers,
+        };
+      } catch (err) {
+        toTRPCError(err);
+      }
+    }),
+
   delete: protectedProcedure
     .meta({ track: Events.DeleteMaintenance })
     .input(z.object({ id: z.number() }))
@@ -31,6 +64,33 @@ export const maintenanceRouter = createTRPCRouter({
         // delete silently succeeded when the row was already gone. Connect
         // still returns 404 on missing; external API semantics preserved.
         if (err instanceof NotFoundError) return [] as Array<never>;
+        toTRPCError(err);
+      }
+    }),
+
+  deleteUpdate: protectedProcedure
+    .meta({ track: Events.DeleteMaintenanceUpdate })
+    .input(z.object({ id: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await deleteMaintenanceUpdate({
+          ctx: toServiceCtx(ctx),
+          input: { id: input.id },
+        });
+      } catch (err) {
+        toTRPCError(err);
+      }
+    }),
+
+  get: protectedProcedure
+    .input(z.object({ id: z.number() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        return await getMaintenance({
+          ctx: toServiceCtx(ctx),
+          input: { id: input.id },
+        });
+      } catch (err) {
         toTRPCError(err);
       }
     }),
@@ -80,7 +140,7 @@ export const maintenanceRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        const record = await createMaintenance({
+        const result = await createMaintenance({
           ctx: toServiceCtx(ctx),
           input: {
             title: input.title,
@@ -91,7 +151,11 @@ export const maintenanceRouter = createTRPCRouter({
             pageComponentIds: input.pageComponents ?? [],
           },
         });
-        return { ...record, notifySubscribers: input.notifySubscribers };
+        return {
+          ...result.maintenance,
+          initialUpdateId: result.initialUpdate.id,
+          notifySubscribers: input.notifySubscribers,
+        };
       } catch (err) {
         toTRPCError(err);
       }
@@ -121,6 +185,26 @@ export const maintenanceRouter = createTRPCRouter({
             to: input.endDate,
             pageComponentIds: input.pageComponents,
           },
+        });
+      } catch (err) {
+        toTRPCError(err);
+      }
+    }),
+
+  updateUpdate: protectedProcedure
+    .meta({ track: Events.UpdateMaintenanceUpdate })
+    .input(
+      z.object({
+        id: z.number(),
+        message: z.string().optional(),
+        date: z.coerce.date().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await updateMaintenanceUpdate({
+          ctx: toServiceCtx(ctx),
+          input,
         });
       } catch (err) {
         toTRPCError(err);

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -120,6 +120,9 @@ export const statusPageRouter = createTRPCRouter({
           },
           maintenances: {
             with: {
+              maintenanceUpdates: {
+                orderBy: (updates, { desc }) => desc(updates.date),
+              },
               maintenancesToPageComponents: { with: { pageComponent: true } },
             },
             orderBy: (maintenances, { desc }) => desc(maintenances.from),
@@ -502,6 +505,9 @@ export const statusPageRouter = createTRPCRouter({
           },
           maintenances: {
             with: {
+              maintenanceUpdates: {
+                orderBy: (updates, { desc }) => desc(updates.date),
+              },
               maintenancesToPageComponents: { with: { pageComponent: true } },
             },
             orderBy: (maintenances, { desc }) => desc(maintenances.from),
@@ -625,6 +631,9 @@ export const statusPageRouter = createTRPCRouter({
           eq(maintenance.pageId, _page.id),
         ),
         with: {
+          maintenanceUpdates: {
+            orderBy: (updates, { desc }) => desc(updates.date),
+          },
           maintenancesToPageComponents: {
             with: { pageComponent: { with: { monitor: true } } },
           },
@@ -662,6 +671,9 @@ export const statusPageRouter = createTRPCRouter({
         with: {
           maintenances: {
             with: {
+              maintenanceUpdates: {
+                orderBy: (updates, { desc }) => desc(updates.date),
+              },
               maintenancesToPageComponents: { with: { pageComponent: true } },
             },
           },

--- a/packages/api/src/router/subscriber-notification.ts
+++ b/packages/api/src/router/subscriber-notification.ts
@@ -40,7 +40,7 @@ export const subscriberNotificationRouter = createTRPCRouter({
       try {
         await notifyMaintenance({
           ctx: toServiceCtx(ctx),
-          input: { maintenanceId: input.id },
+          input: { maintenanceUpdateId: input.id },
         });
         return { success: true };
       } catch (err) {

--- a/packages/db/drizzle/0084_mean_thunderbird.sql
+++ b/packages/db/drizzle/0084_mean_thunderbird.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `maintenance_update` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`message` text NOT NULL,
+	`date` integer NOT NULL,
+	`maintenance_id` integer NOT NULL,
+	`created_at` integer DEFAULT (strftime('%s', 'now')),
+	`updated_at` integer DEFAULT (strftime('%s', 'now')),
+	FOREIGN KEY (`maintenance_id`) REFERENCES `maintenance`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `maintenance_update_maintenance_id_idx` ON `maintenance_update` (`maintenance_id`);
+--> statement-breakpoint
+INSERT INTO `maintenance_update` (`message`, `date`, `maintenance_id`)
+SELECT `message`, COALESCE(`created_at`, `from`), `id`
+FROM `maintenance`;

--- a/packages/db/drizzle/meta/0084_snapshot.json
+++ b/packages/db/drizzle/meta/0084_snapshot.json
@@ -1,0 +1,5037 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2855038f-b409-4990-b445-ce9d0b54a9a4",
+  "prevId": "6d3f5d66-7abe-46a6-bb0e-8db6c9f3b401",
+  "tables": {
+    "workspace": {
+      "name": "workspace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_until": {
+          "name": "paid_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limits": {
+          "name": "limits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "workos_organization_id": {
+          "name": "workos_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sso_enabled": {
+          "name": "sso_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "dsn": {
+          "name": "dsn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_slug_unique": {
+          "name": "workspace_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "workspace_stripe_id_unique": {
+          "name": "workspace_stripe_id_unique",
+          "columns": [
+            "stripe_id"
+          ],
+          "isUnique": true
+        },
+        "workspace_workos_organization_id_unique": {
+          "name": "workspace_workos_organization_id_unique",
+          "columns": [
+            "workos_organization_id"
+          ],
+          "isUnique": true
+        },
+        "workspace_id_dsn_unique": {
+          "name": "workspace_id_dsn_unique",
+          "columns": [
+            "id",
+            "dsn"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sso_domain": {
+      "name": "workspace_sso_domain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "workspace_sso_domain_domain_unique": {
+          "name": "workspace_sso_domain_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        },
+        "workspace_sso_domain_workspace_id_idx": {
+          "name": "workspace_sso_domain_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sso_domain_workspace_id_workspace_id_fk": {
+          "name": "workspace_sso_domain_workspace_id_workspace_id_fk",
+          "tableFrom": "workspace_sso_domain",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_provider_account_id_pk": {
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "name": "account_provider_provider_account_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_tenant_id_unique": {
+          "name": "user_tenant_id_unique",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_to_workspaces": {
+      "name": "users_to_workspaces",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "users_to_workspaces_workspace_id_idx": {
+          "name": "users_to_workspaces_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_to_workspaces_user_id_user_id_fk": {
+          "name": "users_to_workspaces_user_id_user_id_fk",
+          "tableFrom": "users_to_workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_workspaces_workspace_id_workspace_id_fk": {
+          "name": "users_to_workspaces_workspace_id_workspace_id_fk",
+          "tableFrom": "users_to_workspaces",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_workspaces_user_id_workspace_id_pk": {
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ],
+          "name": "users_to_workspaces_user_id_workspace_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification_token": {
+      "name": "verification_token",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verification_token_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "status_report": {
+      "name": "status_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "status_report_workspace_created_idx": {
+          "name": "status_report_workspace_created_idx",
+          "columns": [
+            "workspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "status_report_page_id_idx": {
+          "name": "status_report_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "status_report_workspace_id_workspace_id_fk": {
+          "name": "status_report_workspace_id_workspace_id_fk",
+          "tableFrom": "status_report",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "status_report_page_id_page_id_fk": {
+          "name": "status_report_page_id_page_id_fk",
+          "tableFrom": "status_report",
+          "tableTo": "page",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "status_report_update": {
+      "name": "status_report_update",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_report_id": {
+          "name": "status_report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "status_report_update_status_report_id_idx": {
+          "name": "status_report_update_status_report_id_idx",
+          "columns": [
+            "status_report_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "status_report_update_status_report_id_status_report_id_fk": {
+          "name": "status_report_update_status_report_id_status_report_id_fk",
+          "tableFrom": "status_report_update",
+          "tableTo": "status_report",
+          "columnsFrom": [
+            "status_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integration": {
+      "name": "integration",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential": {
+          "name": "credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "integration_workspace_id_idx": {
+          "name": "integration_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "integration_workspace_id_workspace_id_fk": {
+          "name": "integration_workspace_id_workspace_id_fk",
+          "tableFrom": "integration",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "page": {
+      "name": "page",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "force_theme": {
+          "name": "force_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "custom_theme": {
+          "name": "custom_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_protected": {
+          "name": "password_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "auth_email_domains": {
+          "name": "auth_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_ip_ranges": {
+          "name": "allowed_ip_ranges",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_url": {
+          "name": "contact_url",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "locales": {
+          "name": "locales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_page": {
+          "name": "legacy_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allow_index": {
+          "name": "allow_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "show_monitor_values": {
+          "name": "show_monitor_values",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "page_slug_unique": {
+          "name": "page_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "page_lower_slug_idx": {
+          "name": "page_lower_slug_idx",
+          "columns": [
+            "LOWER(\"slug\")"
+          ],
+          "isUnique": false
+        },
+        "page_lower_custom_domain_idx": {
+          "name": "page_lower_custom_domain_idx",
+          "columns": [
+            "LOWER(\"custom_domain\")"
+          ],
+          "isUnique": false
+        },
+        "page_workspace_id_idx": {
+          "name": "page_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "page_workspace_id_workspace_id_fk": {
+          "name": "page_workspace_id_workspace_id_fk",
+          "tableFrom": "page",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monitor": {
+      "name": "monitor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "periodicity": {
+          "name": "periodicity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "regions": {
+          "name": "regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'GET'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 45000
+        },
+        "degraded_after": {
+          "name": "degraded_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otel_endpoint": {
+          "name": "otel_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otel_headers": {
+          "name": "otel_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "retry": {
+          "name": "retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 3
+        },
+        "follow_redirects": {
+          "name": "follow_redirects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "monitor_workspace_id_active_idx": {
+          "name": "monitor_workspace_id_active_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false,
+          "where": "\"monitor\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "monitor_workspace_id_workspace_id_fk": {
+          "name": "monitor_workspace_id_workspace_id_fk",
+          "tableFrom": "monitor",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "page_subscriber": {
+      "name": "page_subscriber",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_config": {
+          "name": "channel_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'self_signup'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "page_subscriber_page_id_idx": {
+          "name": "page_subscriber_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        },
+        "idx_page_subscriber_email_page_active": {
+          "name": "idx_page_subscriber_email_page_active",
+          "columns": [
+            "LOWER(\"email\")",
+            "page_id"
+          ],
+          "isUnique": true,
+          "where": "\"page_subscriber\".\"unsubscribed_at\" IS NULL AND \"page_subscriber\".\"channel_type\" = 'email'"
+        },
+        "idx_page_subscriber_webhook_page_active": {
+          "name": "idx_page_subscriber_webhook_page_active",
+          "columns": [
+            "LOWER(\"webhook_url\")",
+            "page_id"
+          ],
+          "isUnique": true,
+          "where": "\"page_subscriber\".\"unsubscribed_at\" IS NULL AND \"page_subscriber\".\"channel_type\" = 'webhook'"
+        },
+        "idx_page_subscriber_slack_channel_page_active": {
+          "name": "idx_page_subscriber_slack_channel_page_active",
+          "columns": [
+            "slack_channel_id",
+            "page_id"
+          ],
+          "isUnique": true,
+          "where": "\"page_subscriber\".\"unsubscribed_at\" IS NULL AND \"page_subscriber\".\"channel_type\" = 'slack'"
+        }
+      },
+      "foreignKeys": {
+        "page_subscriber_page_id_page_id_fk": {
+          "name": "page_subscriber_page_id_page_id_fk",
+          "tableFrom": "page_subscriber",
+          "tableTo": "page",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "page_subscriber_channel_check": {
+          "name": "page_subscriber_channel_check",
+          "value": "(\"page_subscriber\".\"channel_type\" = 'email' AND \"page_subscriber\".\"email\" IS NOT NULL AND \"page_subscriber\".\"webhook_url\" IS NULL) OR (\"page_subscriber\".\"channel_type\" = 'webhook' AND \"page_subscriber\".\"webhook_url\" IS NOT NULL AND \"page_subscriber\".\"email\" IS NULL) OR (\"page_subscriber\".\"channel_type\" = 'slack' AND \"page_subscriber\".\"slack_channel_id\" IS NOT NULL AND \"page_subscriber\".\"email\" IS NULL AND \"page_subscriber\".\"webhook_url\" IS NULL)"
+        }
+      }
+    },
+    "page_subscriber_to_page_component": {
+      "name": "page_subscriber_to_page_component",
+      "columns": {
+        "page_subscriber_id": {
+          "name": "page_subscriber_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_component_id": {
+          "name": "page_component_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_subscriber_to_page_component_page_subscriber_id_page_subscriber_id_fk": {
+          "name": "page_subscriber_to_page_component_page_subscriber_id_page_subscriber_id_fk",
+          "tableFrom": "page_subscriber_to_page_component",
+          "tableTo": "page_subscriber",
+          "columnsFrom": [
+            "page_subscriber_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_subscriber_to_page_component_page_component_id_page_component_id_fk": {
+          "name": "page_subscriber_to_page_component_page_component_id_page_component_id_fk",
+          "tableFrom": "page_subscriber_to_page_component",
+          "tableTo": "page_component",
+          "columnsFrom": [
+            "page_component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "page_subscriber_to_page_component_page_subscriber_id_page_component_id_pk": {
+          "columns": [
+            "page_subscriber_id",
+            "page_component_id"
+          ],
+          "name": "page_subscriber_to_page_component_page_subscriber_id_page_component_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "notification_workspace_id_idx": {
+          "name": "notification_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_workspace_id_workspace_id_fk": {
+          "name": "notification_workspace_id_workspace_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_trigger": {
+      "name": "notification_trigger",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_timestamp": {
+          "name": "cron_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_id_monitor_id_crontimestampe": {
+          "name": "notification_id_monitor_id_crontimestampe",
+          "columns": [
+            "notification_id",
+            "monitor_id",
+            "cron_timestamp"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_trigger_monitor_id_monitor_id_fk": {
+          "name": "notification_trigger_monitor_id_monitor_id_fk",
+          "tableFrom": "notification_trigger",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_trigger_notification_id_notification_id_fk": {
+          "name": "notification_trigger_notification_id_notification_id_fk",
+          "tableFrom": "notification_trigger",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications_to_monitors": {
+      "name": "notifications_to_monitors",
+      "columns": {
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "notifications_to_monitors_notification_id_idx": {
+          "name": "notifications_to_monitors_notification_id_idx",
+          "columns": [
+            "notification_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_to_monitors_monitor_id_monitor_id_fk": {
+          "name": "notifications_to_monitors_monitor_id_monitor_id_fk",
+          "tableFrom": "notifications_to_monitors",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_to_monitors_notification_id_notification_id_fk": {
+          "name": "notifications_to_monitors_notification_id_notification_id_fk",
+          "tableFrom": "notifications_to_monitors",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notifications_to_monitors_monitor_id_notification_id_pk": {
+          "columns": [
+            "monitor_id",
+            "notification_id"
+          ],
+          "name": "notifications_to_monitors_monitor_id_notification_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monitor_status": {
+      "name": "monitor_status",
+      "columns": {
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "monitor_status_idx": {
+          "name": "monitor_status_idx",
+          "columns": [
+            "monitor_id",
+            "region"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "monitor_status_monitor_id_monitor_id_fk": {
+          "name": "monitor_status_monitor_id_monitor_id_fk",
+          "tableFrom": "monitor_status",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monitor_status_monitor_id_region_pk": {
+          "columns": [
+            "monitor_id",
+            "region"
+          ],
+          "name": "monitor_status_monitor_id_region_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_workspace_id_idx": {
+          "name": "invitation_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "incident": {
+      "name": "incident",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'triage'"
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acknowledged_by": {
+          "name": "acknowledged_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incident_screenshot_url": {
+          "name": "incident_screenshot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recovery_screenshot_url": {
+          "name": "recovery_screenshot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_resolved": {
+          "name": "auto_resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "incident_workspace_id_started_at_idx": {
+          "name": "incident_workspace_id_started_at_idx",
+          "columns": [
+            "workspace_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "incident_open_idx": {
+          "name": "incident_open_idx",
+          "columns": [
+            "monitor_id"
+          ],
+          "isUnique": false,
+          "where": "\"incident\".\"resolved_at\" IS NULL"
+        },
+        "incident_monitor_id_started_at_unique": {
+          "name": "incident_monitor_id_started_at_unique",
+          "columns": [
+            "monitor_id",
+            "started_at"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "incident_monitor_id_monitor_id_fk": {
+          "name": "incident_monitor_id_monitor_id_fk",
+          "tableFrom": "incident",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set default",
+          "onUpdate": "no action"
+        },
+        "incident_workspace_id_workspace_id_fk": {
+          "name": "incident_workspace_id_workspace_id_fk",
+          "tableFrom": "incident",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incident_acknowledged_by_user_id_fk": {
+          "name": "incident_acknowledged_by_user_id_fk",
+          "tableFrom": "incident",
+          "tableTo": "user",
+          "columnsFrom": [
+            "acknowledged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incident_resolved_by_user_id_fk": {
+          "name": "incident_resolved_by_user_id_fk",
+          "tableFrom": "incident",
+          "tableTo": "user",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monitor_tag": {
+      "name": "monitor_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "monitor_tag_workspace_id_idx": {
+          "name": "monitor_tag_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "monitor_tag_workspace_id_workspace_id_fk": {
+          "name": "monitor_tag_workspace_id_workspace_id_fk",
+          "tableFrom": "monitor_tag",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monitor_tag_to_monitor": {
+      "name": "monitor_tag_to_monitor",
+      "columns": {
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitor_tag_id": {
+          "name": "monitor_tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "monitor_tag_to_monitor_monitor_tag_id_idx": {
+          "name": "monitor_tag_to_monitor_monitor_tag_id_idx",
+          "columns": [
+            "monitor_tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "monitor_tag_to_monitor_monitor_id_monitor_id_fk": {
+          "name": "monitor_tag_to_monitor_monitor_id_monitor_id_fk",
+          "tableFrom": "monitor_tag_to_monitor",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitor_tag_to_monitor_monitor_tag_id_monitor_tag_id_fk": {
+          "name": "monitor_tag_to_monitor_monitor_tag_id_monitor_tag_id_fk",
+          "tableFrom": "monitor_tag_to_monitor",
+          "tableTo": "monitor_tag",
+          "columnsFrom": [
+            "monitor_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monitor_tag_to_monitor_monitor_id_monitor_tag_id_pk": {
+          "columns": [
+            "monitor_id",
+            "monitor_tag_id"
+          ],
+          "name": "monitor_tag_to_monitor_monitor_id_monitor_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application": {
+      "name": "application",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dsn": {
+          "name": "dsn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "application_dsn_unique": {
+          "name": "application_dsn_unique",
+          "columns": [
+            "dsn"
+          ],
+          "isUnique": true
+        },
+        "application_workspace_id_idx": {
+          "name": "application_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "application_workspace_id_workspace_id_fk": {
+          "name": "application_workspace_id_workspace_id_fk",
+          "tableFrom": "application",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance": {
+      "name": "maintenance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from": {
+          "name": "from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to": {
+          "name": "to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "maintenance_page_id_idx": {
+          "name": "maintenance_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        },
+        "maintenance_workspace_id_idx": {
+          "name": "maintenance_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "maintenance_workspace_id_workspace_id_fk": {
+          "name": "maintenance_workspace_id_workspace_id_fk",
+          "tableFrom": "maintenance",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maintenance_page_id_page_id_fk": {
+          "name": "maintenance_page_id_page_id_fk",
+          "tableFrom": "maintenance",
+          "tableTo": "page",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_update": {
+      "name": "maintenance_update",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "maintenance_id": {
+          "name": "maintenance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "maintenance_update_maintenance_id_idx": {
+          "name": "maintenance_update_maintenance_id_idx",
+          "columns": [
+            "maintenance_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "maintenance_update_maintenance_id_maintenance_id_fk": {
+          "name": "maintenance_update_maintenance_id_maintenance_id_fk",
+          "tableFrom": "maintenance_update",
+          "tableTo": "maintenance",
+          "columnsFrom": [
+            "maintenance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "check": {
+      "name": "check",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "regions": {
+          "name": "regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text(4096)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'GET'"
+        },
+        "count_requests": {
+          "name": "count_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "check_workspace_id_idx": {
+          "name": "check_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "check_workspace_id_workspace_id_fk": {
+          "name": "check_workspace_id_workspace_id_fk",
+          "tableFrom": "check",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monitor_run": {
+      "name": "monitor_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runned_at": {
+          "name": "runned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "monitor_run_workspace_id_created_at_idx": {
+          "name": "monitor_run_workspace_id_created_at_idx",
+          "columns": [
+            "workspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "monitor_run_monitor_id_idx": {
+          "name": "monitor_run_monitor_id_idx",
+          "columns": [
+            "monitor_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "monitor_run_workspace_id_workspace_id_fk": {
+          "name": "monitor_run_workspace_id_workspace_id_fk",
+          "tableFrom": "monitor_run",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "monitor_run_monitor_id_monitor_id_fk": {
+          "name": "monitor_run_monitor_id_monitor_id_fk",
+          "tableFrom": "monitor_run",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "private_location_monitor_status": {
+      "name": "private_location_monitor_status",
+      "columns": {
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_location_id": {
+          "name": "private_location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "cron_timestamp": {
+          "name": "cron_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "private_location_monitor_status_pl_id_idx": {
+          "name": "private_location_monitor_status_pl_id_idx",
+          "columns": [
+            "private_location_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "private_location_monitor_status_monitor_id_monitor_id_fk": {
+          "name": "private_location_monitor_status_monitor_id_monitor_id_fk",
+          "tableFrom": "private_location_monitor_status",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "private_location_monitor_status_private_location_id_private_location_id_fk": {
+          "name": "private_location_monitor_status_private_location_id_private_location_id_fk",
+          "tableFrom": "private_location_monitor_status",
+          "tableTo": "private_location",
+          "columnsFrom": [
+            "private_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "private_location_monitor_status_monitor_id_private_location_id_pk": {
+          "columns": [
+            "monitor_id",
+            "private_location_id"
+          ],
+          "name": "private_location_monitor_status_monitor_id_private_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "private_location": {
+      "name": "private_location",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'error'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "private_location_workspace_id_idx": {
+          "name": "private_location_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "private_location_workspace_id_workspace_id_fk": {
+          "name": "private_location_workspace_id_workspace_id_fk",
+          "tableFrom": "private_location",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "private_location_to_monitor": {
+      "name": "private_location_to_monitor",
+      "columns": {
+        "private_location_id": {
+          "name": "private_location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "private_location_to_monitor_private_location_id_idx": {
+          "name": "private_location_to_monitor_private_location_id_idx",
+          "columns": [
+            "private_location_id"
+          ],
+          "isUnique": false
+        },
+        "private_location_to_monitor_monitor_id_idx": {
+          "name": "private_location_to_monitor_monitor_id_idx",
+          "columns": [
+            "monitor_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "private_location_to_monitor_private_location_id_private_location_id_fk": {
+          "name": "private_location_to_monitor_private_location_id_private_location_id_fk",
+          "tableFrom": "private_location_to_monitor",
+          "tableTo": "private_location",
+          "columnsFrom": [
+            "private_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "private_location_to_monitor_monitor_id_monitor_id_fk": {
+          "name": "private_location_to_monitor_monitor_id_monitor_id_fk",
+          "tableFrom": "private_location_to_monitor",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monitor_group": {
+      "name": "monitor_group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "monitor_group_workspace_id_idx": {
+          "name": "monitor_group_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "monitor_group_page_id_idx": {
+          "name": "monitor_group_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "monitor_group_workspace_id_workspace_id_fk": {
+          "name": "monitor_group_workspace_id_workspace_id_fk",
+          "tableFrom": "monitor_group",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitor_group_page_id_page_id_fk": {
+          "name": "monitor_group_page_id_page_id_fk",
+          "tableFrom": "monitor_group",
+          "tableTo": "page",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "viewer": {
+      "name": "viewer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "viewer_email_unique": {
+          "name": "viewer_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "viewer_accounts": {
+      "name": "viewer_accounts",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "viewer_accounts_user_id_viewer_id_fk": {
+          "name": "viewer_accounts_user_id_viewer_id_fk",
+          "tableFrom": "viewer_accounts",
+          "tableTo": "viewer",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "viewer_accounts_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "viewer_accounts_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "viewer_session": {
+      "name": "viewer_session",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "viewer_session_user_id_viewer_id_fk": {
+          "name": "viewer_session_user_id_viewer_id_fk",
+          "tableFrom": "viewer_session",
+          "tableTo": "viewer",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_key": {
+      "name": "api_key",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"write\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_key_prefix_unique": {
+          "name": "api_key_prefix_unique",
+          "columns": [
+            "prefix"
+          ],
+          "isUnique": true
+        },
+        "api_key_hashed_token_unique": {
+          "name": "api_key_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        },
+        "api_key_prefix_idx": {
+          "name": "api_key_prefix_idx",
+          "columns": [
+            "prefix"
+          ],
+          "isUnique": false
+        },
+        "api_key_workspace_id_idx": {
+          "name": "api_key_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_key_workspace_id_workspace_id_fk": {
+          "name": "api_key_workspace_id_workspace_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_id_user_id_fk": {
+          "name": "api_key_created_by_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_to_page_component": {
+      "name": "maintenance_to_page_component",
+      "columns": {
+        "maintenance_id": {
+          "name": "maintenance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_component_id": {
+          "name": "page_component_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "maintenance_to_page_component_page_component_id_idx": {
+          "name": "maintenance_to_page_component_page_component_id_idx",
+          "columns": [
+            "page_component_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "maintenance_to_page_component_maintenance_id_maintenance_id_fk": {
+          "name": "maintenance_to_page_component_maintenance_id_maintenance_id_fk",
+          "tableFrom": "maintenance_to_page_component",
+          "tableTo": "maintenance",
+          "columnsFrom": [
+            "maintenance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maintenance_to_page_component_page_component_id_page_component_id_fk": {
+          "name": "maintenance_to_page_component_page_component_id_page_component_id_fk",
+          "tableFrom": "maintenance_to_page_component",
+          "tableTo": "page_component",
+          "columnsFrom": [
+            "page_component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "maintenance_to_page_component_maintenance_id_page_component_id_pk": {
+          "columns": [
+            "maintenance_id",
+            "page_component_id"
+          ],
+          "name": "maintenance_to_page_component_maintenance_id_page_component_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "page_component": {
+      "name": "page_component",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'monitor'"
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_order": {
+          "name": "group_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "page_component_workspace_id_idx": {
+          "name": "page_component_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "page_component_page_id_monitor_id_unique": {
+          "name": "page_component_page_id_monitor_id_unique",
+          "columns": [
+            "page_id",
+            "monitor_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "page_component_workspace_id_workspace_id_fk": {
+          "name": "page_component_workspace_id_workspace_id_fk",
+          "tableFrom": "page_component",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_component_page_id_page_id_fk": {
+          "name": "page_component_page_id_page_id_fk",
+          "tableFrom": "page_component",
+          "tableTo": "page",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_component_monitor_id_monitor_id_fk": {
+          "name": "page_component_monitor_id_monitor_id_fk",
+          "tableFrom": "page_component",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_component_group_id_page_component_groups_id_fk": {
+          "name": "page_component_group_id_page_component_groups_id_fk",
+          "tableFrom": "page_component",
+          "tableTo": "page_component_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "page_component_type_check": {
+          "name": "page_component_type_check",
+          "value": "\"page_component\".\"type\" = 'monitor' AND \"page_component\".\"monitor_id\" IS NOT NULL OR \"page_component\".\"type\" = 'static' AND \"page_component\".\"monitor_id\" IS NULL"
+        }
+      }
+    },
+    "status_report_update_to_page_component": {
+      "name": "status_report_update_to_page_component",
+      "columns": {
+        "status_report_update_id": {
+          "name": "status_report_update_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_component_id": {
+          "name": "page_component_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "status_report_update_to_page_component_page_component_id_idx": {
+          "name": "status_report_update_to_page_component_page_component_id_idx",
+          "columns": [
+            "page_component_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "status_report_update_to_page_component_status_report_update_id_status_report_update_id_fk": {
+          "name": "status_report_update_to_page_component_status_report_update_id_status_report_update_id_fk",
+          "tableFrom": "status_report_update_to_page_component",
+          "tableTo": "status_report_update",
+          "columnsFrom": [
+            "status_report_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "status_report_update_to_page_component_page_component_id_page_component_id_fk": {
+          "name": "status_report_update_to_page_component_page_component_id_page_component_id_fk",
+          "tableFrom": "status_report_update_to_page_component",
+          "tableTo": "page_component",
+          "columnsFrom": [
+            "page_component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "status_report_update_to_page_component_status_report_update_id_page_component_id_pk": {
+          "columns": [
+            "status_report_update_id",
+            "page_component_id"
+          ],
+          "name": "status_report_update_to_page_component_status_report_update_id_page_component_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "status_report_to_page_component": {
+      "name": "status_report_to_page_component",
+      "columns": {
+        "status_report_id": {
+          "name": "status_report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_component_id": {
+          "name": "page_component_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "status_report_to_page_component_page_component_id_idx": {
+          "name": "status_report_to_page_component_page_component_id_idx",
+          "columns": [
+            "page_component_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "status_report_to_page_component_status_report_id_status_report_id_fk": {
+          "name": "status_report_to_page_component_status_report_id_status_report_id_fk",
+          "tableFrom": "status_report_to_page_component",
+          "tableTo": "status_report",
+          "columnsFrom": [
+            "status_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "status_report_to_page_component_page_component_id_page_component_id_fk": {
+          "name": "status_report_to_page_component_page_component_id_page_component_id_fk",
+          "tableFrom": "status_report_to_page_component",
+          "tableTo": "page_component",
+          "columnsFrom": [
+            "page_component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "status_report_to_page_component_status_report_id_page_component_id_pk": {
+          "columns": [
+            "status_report_id",
+            "page_component_id"
+          ],
+          "name": "status_report_to_page_component_status_report_id_page_component_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "page_component_groups": {
+      "name": "page_component_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_open": {
+          "name": "default_open",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "page_component_groups_page_id_idx": {
+          "name": "page_component_groups_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        },
+        "page_component_groups_workspace_id_idx": {
+          "name": "page_component_groups_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "page_component_groups_workspace_id_workspace_id_fk": {
+          "name": "page_component_groups_workspace_id_workspace_id_fk",
+          "tableFrom": "page_component_groups",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_component_groups_page_id_page_id_fk": {
+          "name": "page_component_groups_page_id_page_id_fk",
+          "tableFrom": "page_component_groups",
+          "tableTo": "page",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "feedback_workspace_id_idx": {
+          "name": "feedback_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_workspace_id_workspace_id_fk": {
+          "name": "feedback_workspace_id_workspace_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_user_id_user_id_fk": {
+          "name": "feedback_user_id_user_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_fields": {
+          "name": "changed_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_workspace_created_idx": {
+          "name": "audit_log_workspace_created_idx",
+          "columns": [
+            "workspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            "workspace_id",
+            "entity_type",
+            "entity_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_service": {
+      "name": "external_service",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_array())"
+        },
+        "name": {
+          "name": "name",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_page_url": {
+          "name": "status_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_config": {
+          "name": "api_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "external_service_slug_unique": {
+          "name": "external_service_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "external_service_deleted_at_idx": {
+          "name": "external_service_deleted_at_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_service_component": {
+      "name": "external_service_component",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_service_id": {
+          "name": "external_service_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_component_id": {
+          "name": "upstream_component_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_array())"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "indicator": {
+          "name": "indicator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "external_service_component_unique_idx": {
+          "name": "external_service_component_unique_idx",
+          "columns": [
+            "external_service_id",
+            "upstream_component_id"
+          ],
+          "isUnique": true
+        },
+        "external_service_component_slug_unique_idx": {
+          "name": "external_service_component_slug_unique_idx",
+          "columns": [
+            "external_service_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "external_service_component_external_service_id_external_service_id_fk": {
+          "name": "external_service_component_external_service_id_external_service_id_fk",
+          "tableFrom": "external_service_component",
+          "tableTo": "external_service",
+          "columnsFrom": [
+            "external_service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_service_incident": {
+      "name": "external_service_incident",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_service_id": {
+          "name": "external_service_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_incident_id": {
+          "name": "provider_incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shortlink": {
+          "name": "shortlink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "affected_component_ids": {
+          "name": "affected_component_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_payload_purged_at": {
+          "name": "raw_payload_purged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "external_service_incident_unique_idx": {
+          "name": "external_service_incident_unique_idx",
+          "columns": [
+            "external_service_id",
+            "provider_incident_id"
+          ],
+          "isUnique": true
+        },
+        "external_service_incident_started_at_idx": {
+          "name": "external_service_incident_started_at_idx",
+          "columns": [
+            "external_service_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "external_service_incident_resolved_at_idx": {
+          "name": "external_service_incident_resolved_at_idx",
+          "columns": [
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "external_service_incident_external_service_id_external_service_id_fk": {
+          "name": "external_service_incident_external_service_id_external_service_id_fk",
+          "tableFrom": "external_service_incident",
+          "tableTo": "external_service",
+          "columnsFrom": [
+            "external_service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_service_report": {
+      "name": "external_service_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_service_id": {
+          "name": "external_service_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_service_component_id": {
+          "name": "external_service_component_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_hash": {
+          "name": "reporter_hash",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "external_service_report_service_idx": {
+          "name": "external_service_report_service_idx",
+          "columns": [
+            "external_service_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "external_service_report_component_idx": {
+          "name": "external_service_report_component_idx",
+          "columns": [
+            "external_service_component_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "external_service_report_external_service_id_external_service_id_fk": {
+          "name": "external_service_report_external_service_id_external_service_id_fk",
+          "tableFrom": "external_service_report",
+          "tableTo": "external_service",
+          "columnsFrom": [
+            "external_service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_service_report_external_service_component_id_external_service_component_id_fk": {
+          "name": "external_service_report_external_service_component_id_external_service_component_id_fk",
+          "tableFrom": "external_service_report",
+          "tableTo": "external_service_component",
+          "columnsFrom": [
+            "external_service_component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_session": {
+      "name": "chat_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_session_workspace_user_updated_idx": {
+          "name": "chat_session_workspace_user_updated_idx",
+          "columns": [
+            "workspace_id",
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_session_workspace_id_workspace_id_fk": {
+          "name": "chat_session_workspace_id_workspace_id_fk",
+          "tableFrom": "chat_session",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_user_id_user_id_fk": {
+          "name": "chat_session_user_id_user_id_fk",
+          "tableFrom": "chat_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "frozen_monitor_uptime": {
+      "name": "frozen_monitor_uptime",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "days": {
+          "name": "days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "frozen_monitor_uptime_workspace_id_idx": {
+          "name": "frozen_monitor_uptime_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "frozen_monitor_uptime_monitor_id_month_unique": {
+          "name": "frozen_monitor_uptime_monitor_id_month_unique",
+          "columns": [
+            "monitor_id",
+            "month"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "frozen_monitor_uptime_workspace_id_workspace_id_fk": {
+          "name": "frozen_monitor_uptime_workspace_id_workspace_id_fk",
+          "tableFrom": "frozen_monitor_uptime",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frozen_monitor_uptime_monitor_id_monitor_id_fk": {
+          "name": "frozen_monitor_uptime_monitor_id_monitor_id_fk",
+          "tableFrom": "frozen_monitor_uptime",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "page_lower_slug_idx": {
+        "columns": {
+          "LOWER(\"slug\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "page_lower_custom_domain_idx": {
+        "columns": {
+          "LOWER(\"custom_domain\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_page_subscriber_email_page_active": {
+        "columns": {
+          "LOWER(\"email\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_page_subscriber_webhook_page_active": {
+        "columns": {
+          "LOWER(\"webhook_url\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1785227235369,
       "tag": "0083_wide_otto_octavius",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "6",
+      "when": 1786110973865,
+      "tag": "0084_mean_thunderbird",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/audit_logs/validation.ts
+++ b/packages/db/src/schema/audit_logs/validation.ts
@@ -110,6 +110,18 @@ const maintenanceActions = [
   action("maintenance.delete", "maintenance", intId),
 ] as const;
 
+const maintenanceUpdateActions = [
+  action("maintenance_update.create", "maintenance_update", intId, {
+    optionalMetadata: true,
+  }),
+  action("maintenance_update.update", "maintenance_update", intId, {
+    optionalMetadata: true,
+  }),
+  action("maintenance_update.delete", "maintenance_update", intId, {
+    optionalMetadata: true,
+  }),
+] as const;
+
 const incidentActions = [
   action("incident.update", "incident", intId),
   action("incident.delete", "incident", intId),
@@ -210,6 +222,7 @@ export const auditActionSchema = z.discriminatedUnion("action", [
   ...userActions,
   ...workspaceActions,
   ...maintenanceActions,
+  ...maintenanceUpdateActions,
   ...incidentActions,
   ...statusReportActions,
   ...statusReportUpdateActions,

--- a/packages/db/src/schema/maintenances/maintenance.ts
+++ b/packages/db/src/schema/maintenances/maintenance.ts
@@ -49,9 +49,7 @@ export const maintenanceUpdate = sqliteTable(
       sql`(strftime('%s', 'now'))`,
     ),
   },
-  (t) => [
-    index("maintenance_update_maintenance_id_idx").on(t.maintenanceId),
-  ],
+  (t) => [index("maintenance_update_maintenance_id_idx").on(t.maintenanceId)],
 );
 
 export const maintenanceRelations = relations(maintenance, ({ one, many }) => ({

--- a/packages/db/src/schema/maintenances/maintenance.ts
+++ b/packages/db/src/schema/maintenances/maintenance.ts
@@ -33,8 +33,30 @@ export const maintenance = sqliteTable(
   ],
 );
 
+export const maintenanceUpdate = sqliteTable(
+  "maintenance_update",
+  {
+    id: integer("id").primaryKey(),
+    message: text("message").notNull(),
+    date: integer("date", { mode: "timestamp" }).notNull(),
+    maintenanceId: integer("maintenance_id")
+      .references(() => maintenance.id, { onDelete: "cascade" })
+      .notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).default(
+      sql`(strftime('%s', 'now'))`,
+    ),
+    updatedAt: integer("updated_at", { mode: "timestamp" }).default(
+      sql`(strftime('%s', 'now'))`,
+    ),
+  },
+  (t) => [
+    index("maintenance_update_maintenance_id_idx").on(t.maintenanceId),
+  ],
+);
+
 export const maintenanceRelations = relations(maintenance, ({ one, many }) => ({
   maintenancesToPageComponents: many(maintenancesToPageComponents),
+  maintenanceUpdates: many(maintenanceUpdate),
   page: one(page, {
     fields: [maintenance.pageId],
     references: [page.id],
@@ -44,3 +66,13 @@ export const maintenanceRelations = relations(maintenance, ({ one, many }) => ({
     references: [workspace.id],
   }),
 }));
+
+export const maintenanceUpdateRelations = relations(
+  maintenanceUpdate,
+  ({ one }) => ({
+    maintenance: one(maintenance, {
+      fields: [maintenanceUpdate.maintenanceId],
+      references: [maintenance.id],
+    }),
+  }),
+);

--- a/packages/db/src/schema/maintenances/validation.ts
+++ b/packages/db/src/schema/maintenances/validation.ts
@@ -1,7 +1,7 @@
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 
-import { maintenance } from "./maintenance";
+import { maintenance, maintenanceUpdate } from "./maintenance";
 
 export const insertMaintenanceSchema = createInsertSchema(maintenance)
   .extend({
@@ -25,5 +25,19 @@ export const selectMaintenanceSchema = createSelectSchema(maintenance).extend({
   monitors: z.number().array().prefault([]).optional(),
 });
 
+export const insertMaintenanceUpdateSchema = createInsertSchema(
+  maintenanceUpdate,
+).extend({
+  message: z.string().min(1),
+  date: z.coerce.date(),
+});
+
+export const selectMaintenanceUpdateSchema =
+  createSelectSchema(maintenanceUpdate);
+
 export type InsertMaintenance = z.infer<typeof insertMaintenanceSchema>;
 export type Maintenance = z.infer<typeof selectMaintenanceSchema>;
+export type InsertMaintenanceUpdate = z.infer<
+  typeof insertMaintenanceUpdateSchema
+>;
+export type MaintenanceUpdate = z.infer<typeof selectMaintenanceUpdateSchema>;

--- a/packages/db/src/schema/shared.ts
+++ b/packages/db/src/schema/shared.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { selectIncidentSchema } from "./incidents/validation";
-import { selectMaintenanceSchema } from "./maintenances";
+import {
+  selectMaintenanceSchema,
+  selectMaintenanceUpdateSchema,
+} from "./maintenances";
 import { selectMonitorGroupSchema } from "./monitor_groups";
 import { selectMonitorSchema } from "./monitors";
 import { selectPageComponentGroupSchema } from "./page_component_groups";
@@ -55,6 +58,7 @@ export const selectStatusReportPageSchema = selectStatusReportSchema.extend({
 });
 
 export const selectMaintenancePageSchema = selectMaintenanceSchema.extend({
+  maintenanceUpdates: z.array(selectMaintenanceUpdateSchema).prefault([]),
   maintenancesToPageComponents: z
     .array(
       z.object({

--- a/packages/proto/api/openstatus/maintenance/v1/maintenance.proto
+++ b/packages/proto/api/openstatus/maintenance/v1/maintenance.proto
@@ -4,6 +4,27 @@ package openstatus.maintenance.v1;
 
 option go_package = "github.com/openstatushq/openstatus/packages/proto/openstatus/maintenance/v1;maintenancev1";
 
+// MaintenanceUpdate represents a timeline entry for a maintenance window.
+message MaintenanceUpdate {
+  // Unique identifier for the update.
+  string id = 1;
+
+  // Public update message.
+  string message = 2;
+
+  // Date of the update (RFC 3339 format).
+  string date = 3;
+
+  // ID of the maintenance this update belongs to.
+  string maintenance_id = 4;
+
+  // Timestamp when the update was created (RFC 3339 format).
+  string created_at = 5;
+
+  // Timestamp when the update was last updated (RFC 3339 format).
+  string updated_at = 6;
+}
+
 // MaintenanceSummary represents metadata for a maintenance window (used in list responses).
 message MaintenanceSummary {
   // Unique identifier for the maintenance.
@@ -32,6 +53,7 @@ message MaintenanceSummary {
 
   // Timestamp when the maintenance was last updated (RFC 3339 format).
   string updated_at = 9;
+
 }
 
 // Maintenance represents a maintenance window with full details.
@@ -62,4 +84,7 @@ message Maintenance {
 
   // Timestamp when the maintenance was last updated (RFC 3339 format).
   string updated_at = 9;
+
+  // Full maintenance update timeline, newest first.
+  repeated MaintenanceUpdate updates = 10;
 }

--- a/packages/proto/api/openstatus/maintenance/v1/service.proto
+++ b/packages/proto/api/openstatus/maintenance/v1/service.proto
@@ -28,6 +28,15 @@ service MaintenanceService {
 
   // DeleteMaintenance removes a maintenance window.
   rpc DeleteMaintenance(DeleteMaintenanceRequest) returns (DeleteMaintenanceResponse);
+
+  // AddMaintenanceUpdate appends a public update to a maintenance timeline.
+  rpc AddMaintenanceUpdate(AddMaintenanceUpdateRequest) returns (AddMaintenanceUpdateResponse);
+
+  // UpdateMaintenanceUpdate edits an existing maintenance update.
+  rpc UpdateMaintenanceUpdate(UpdateMaintenanceUpdateRequest) returns (UpdateMaintenanceUpdateResponse);
+
+  // DeleteMaintenanceUpdate removes an existing maintenance update.
+  rpc DeleteMaintenanceUpdate(DeleteMaintenanceUpdateRequest) returns (DeleteMaintenanceUpdateResponse);
 }
 
 // CreateMaintenanceRequest is the request to create a new maintenance window.
@@ -154,6 +163,57 @@ message DeleteMaintenanceRequest {
 
 // DeleteMaintenanceResponse is the response after deleting a maintenance window.
 message DeleteMaintenanceResponse {
+  // Whether the deletion was successful.
+  bool success = 1;
+}
+
+// AddMaintenanceUpdateRequest is the request to append a maintenance update.
+message AddMaintenanceUpdateRequest {
+  // ID of the maintenance to update (required).
+  string maintenance_id = 1 [(buf.validate.field).string.min_len = 1];
+
+  // Public update message (required).
+  string message = 2 [(buf.validate.field).string.min_len = 1];
+
+  // Optional date for the update (RFC 3339 format). Defaults to current time.
+  optional string date = 3 [(buf.validate.field).string.pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"];
+
+  // Whether to notify subscribers about this update.
+  optional bool notify = 4;
+}
+
+// AddMaintenanceUpdateResponse is the response after appending an update.
+message AddMaintenanceUpdateResponse {
+  // The created update.
+  MaintenanceUpdate maintenance_update = 1;
+}
+
+// UpdateMaintenanceUpdateRequest is the request to edit an update.
+message UpdateMaintenanceUpdateRequest {
+  // ID of the update to edit (required).
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+
+  // New public message.
+  optional string message = 2 [(buf.validate.field).string.min_len = 1];
+
+  // New update date (RFC 3339 format).
+  optional string date = 3 [(buf.validate.field).string.pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"];
+}
+
+// UpdateMaintenanceUpdateResponse is the response after editing an update.
+message UpdateMaintenanceUpdateResponse {
+  // The updated timeline entry.
+  MaintenanceUpdate maintenance_update = 1;
+}
+
+// DeleteMaintenanceUpdateRequest is the request to remove an update.
+message DeleteMaintenanceUpdateRequest {
+  // ID of the update to remove (required).
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+}
+
+// DeleteMaintenanceUpdateResponse is the response after removing an update.
+message DeleteMaintenanceUpdateResponse {
   // Whether the deletion was successful.
   bool success = 1;
 }

--- a/packages/proto/gen/openapi.yaml
+++ b/packages/proto/gen/openapi.yaml
@@ -102,6 +102,45 @@ components:
         - SERVING_STATUS_SERVING
         - SERVING_STATUS_NOT_SERVING
       description: ServingStatus represents the health status of the service.
+    openstatus.maintenance.v1.AddMaintenanceUpdateRequest:
+      type: object
+      properties:
+        maintenanceId:
+          type: string
+          title: maintenance_id
+          minLength: 1
+          description: ID of the maintenance to update (required).
+        message:
+          type: string
+          title: message
+          minLength: 1
+          description: Public update message (required).
+        date:
+          type:
+            - string
+            - "null"
+          title: date
+          pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$
+          description: Optional date for the update (RFC 3339 format). Defaults to current time.
+        notify:
+          type:
+            - boolean
+            - "null"
+          title: notify
+          description: Whether to notify subscribers about this update.
+      title: AddMaintenanceUpdateRequest
+      additionalProperties: false
+      description: AddMaintenanceUpdateRequest is the request to append a maintenance update.
+    openstatus.maintenance.v1.AddMaintenanceUpdateResponse:
+      type: object
+      properties:
+        maintenanceUpdate:
+          title: maintenance_update
+          description: The created update.
+          $ref: '#/components/schemas/openstatus.maintenance.v1.MaintenanceUpdate'
+      title: AddMaintenanceUpdateResponse
+      additionalProperties: false
+      description: AddMaintenanceUpdateResponse is the response after appending an update.
     openstatus.maintenance.v1.CreateMaintenanceRequest:
       type: object
       properties:
@@ -183,6 +222,27 @@ components:
       title: DeleteMaintenanceResponse
       additionalProperties: false
       description: DeleteMaintenanceResponse is the response after deleting a maintenance window.
+    openstatus.maintenance.v1.DeleteMaintenanceUpdateRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          minLength: 1
+          description: ID of the update to remove (required).
+      title: DeleteMaintenanceUpdateRequest
+      additionalProperties: false
+      description: DeleteMaintenanceUpdateRequest is the request to remove an update.
+    openstatus.maintenance.v1.DeleteMaintenanceUpdateResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          title: success
+          description: Whether the deletion was successful.
+      title: DeleteMaintenanceUpdateResponse
+      additionalProperties: false
+      description: DeleteMaintenanceUpdateResponse is the response after removing an update.
     openstatus.maintenance.v1.GetMaintenanceRequest:
       type: object
       properties:
@@ -291,6 +351,12 @@ components:
           type: string
           title: updated_at
           description: Timestamp when the maintenance was last updated (RFC 3339 format).
+        updates:
+          type: array
+          items:
+            $ref: '#/components/schemas/openstatus.maintenance.v1.MaintenanceUpdate'
+          title: updates
+          description: Full maintenance update timeline, newest first.
       title: Maintenance
       additionalProperties: false
       description: Maintenance represents a maintenance window with full details.
@@ -338,6 +404,36 @@ components:
       title: MaintenanceSummary
       additionalProperties: false
       description: MaintenanceSummary represents metadata for a maintenance window (used in list responses).
+    openstatus.maintenance.v1.MaintenanceUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: Unique identifier for the update.
+        message:
+          type: string
+          title: message
+          description: Public update message.
+        date:
+          type: string
+          title: date
+          description: Date of the update (RFC 3339 format).
+        maintenanceId:
+          type: string
+          title: maintenance_id
+          description: ID of the maintenance this update belongs to.
+        createdAt:
+          type: string
+          title: created_at
+          description: Timestamp when the update was created (RFC 3339 format).
+        updatedAt:
+          type: string
+          title: updated_at
+          description: Timestamp when the update was last updated (RFC 3339 format).
+      title: MaintenanceUpdate
+      additionalProperties: false
+      description: MaintenanceUpdate represents a timeline entry for a maintenance window.
     openstatus.maintenance.v1.UpdateMaintenanceRequest:
       type: object
       properties:
@@ -409,6 +505,41 @@ components:
       title: UpdateMaintenanceResponse
       additionalProperties: false
       description: UpdateMaintenanceResponse is the response after updating a maintenance window.
+    openstatus.maintenance.v1.UpdateMaintenanceUpdateRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          minLength: 1
+          description: ID of the update to edit (required).
+        message:
+          type:
+            - string
+            - "null"
+          title: message
+          minLength: 1
+          description: New public message.
+        date:
+          type:
+            - string
+            - "null"
+          title: date
+          pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$
+          description: New update date (RFC 3339 format).
+      title: UpdateMaintenanceUpdateRequest
+      additionalProperties: false
+      description: UpdateMaintenanceUpdateRequest is the request to edit an update.
+    openstatus.maintenance.v1.UpdateMaintenanceUpdateResponse:
+      type: object
+      properties:
+        maintenanceUpdate:
+          title: maintenance_update
+          description: The updated timeline entry.
+          $ref: '#/components/schemas/openstatus.maintenance.v1.MaintenanceUpdate'
+      title: UpdateMaintenanceUpdateResponse
+      additionalProperties: false
+      description: UpdateMaintenanceUpdateResponse is the response after editing an update.
     openstatus.monitor.v1.BodyAssertion:
       type: object
       properties:
@@ -4812,6 +4943,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/openstatus.health.v1.CheckResponse'
+  /rpc/openstatus.maintenance.v1.MaintenanceService/AddMaintenanceUpdate:
+    post:
+      tags:
+        - MaintenanceService
+      summary: AddMaintenanceUpdate
+      description: AddMaintenanceUpdate appends a public update to a maintenance timeline.
+      operationId: MaintenanceService_AddMaintenanceUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/openstatus.maintenance.v1.AddMaintenanceUpdateRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openstatus.maintenance.v1.AddMaintenanceUpdateResponse'
   /rpc/openstatus.maintenance.v1.MaintenanceService/CreateMaintenance:
     post:
       tags:
@@ -4864,6 +5021,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/openstatus.maintenance.v1.DeleteMaintenanceResponse'
+  /rpc/openstatus.maintenance.v1.MaintenanceService/DeleteMaintenanceUpdate:
+    post:
+      tags:
+        - MaintenanceService
+      summary: DeleteMaintenanceUpdate
+      description: DeleteMaintenanceUpdate removes an existing maintenance update.
+      operationId: MaintenanceService_DeleteMaintenanceUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/openstatus.maintenance.v1.DeleteMaintenanceUpdateRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openstatus.maintenance.v1.DeleteMaintenanceUpdateResponse'
   /rpc/openstatus.maintenance.v1.MaintenanceService/GetMaintenance:
     get:
       tags:
@@ -4994,6 +5177,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/openstatus.maintenance.v1.UpdateMaintenanceResponse'
+  /rpc/openstatus.maintenance.v1.MaintenanceService/UpdateMaintenanceUpdate:
+    post:
+      tags:
+        - MaintenanceService
+      summary: UpdateMaintenanceUpdate
+      description: UpdateMaintenanceUpdate edits an existing maintenance update.
+      operationId: MaintenanceService_UpdateMaintenanceUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/openstatus.maintenance.v1.UpdateMaintenanceUpdateRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openstatus.maintenance.v1.UpdateMaintenanceUpdateResponse'
   /rpc/openstatus.monitor.v1.MonitorService/CreateDNSMonitor:
     post:
       tags:

--- a/packages/proto/gen/ts/openstatus/maintenance/v1/maintenance_pb.ts
+++ b/packages/proto/gen/ts/openstatus/maintenance/v1/maintenance_pb.ts
@@ -10,7 +10,63 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file openstatus/maintenance/v1/maintenance.proto.
  */
 export const file_openstatus_maintenance_v1_maintenance: GenFile = /*@__PURE__*/
-  fileDesc("CitvcGVuc3RhdHVzL21haW50ZW5hbmNlL3YxL21haW50ZW5hbmNlLnByb3RvEhlvcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxIq8BChJNYWludGVuYW5jZVN1bW1hcnkSCgoCaWQYASABKAkSDQoFdGl0bGUYAiABKAkSDwoHbWVzc2FnZRgDIAEoCRIMCgRmcm9tGAQgASgJEgoKAnRvGAUgASgJEg8KB3BhZ2VfaWQYBiABKAkSGgoScGFnZV9jb21wb25lbnRfaWRzGAcgAygJEhIKCmNyZWF0ZWRfYXQYCCABKAkSEgoKdXBkYXRlZF9hdBgJIAEoCSKoAQoLTWFpbnRlbmFuY2USCgoCaWQYASABKAkSDQoFdGl0bGUYAiABKAkSDwoHbWVzc2FnZRgDIAEoCRIMCgRmcm9tGAQgASgJEgoKAnRvGAUgASgJEg8KB3BhZ2VfaWQYBiABKAkSGgoScGFnZV9jb21wb25lbnRfaWRzGAcgAygJEhIKCmNyZWF0ZWRfYXQYCCABKAkSEgoKdXBkYXRlZF9hdBgJIAEoCUJbWllnaXRodWIuY29tL29wZW5zdGF0dXNocS9vcGVuc3RhdHVzL3BhY2thZ2VzL3Byb3RvL29wZW5zdGF0dXMvbWFpbnRlbmFuY2UvdjE7bWFpbnRlbmFuY2V2MWIGcHJvdG8z");
+  fileDesc("CitvcGVuc3RhdHVzL21haW50ZW5hbmNlL3YxL21haW50ZW5hbmNlLnByb3RvEhlvcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxIn4KEU1haW50ZW5hbmNlVXBkYXRlEgoKAmlkGAEgASgJEg8KB21lc3NhZ2UYAiABKAkSDAoEZGF0ZRgDIAEoCRIWCg5tYWludGVuYW5jZV9pZBgEIAEoCRISCgpjcmVhdGVkX2F0GAUgASgJEhIKCnVwZGF0ZWRfYXQYBiABKAkirwEKEk1haW50ZW5hbmNlU3VtbWFyeRIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRIPCgdtZXNzYWdlGAMgASgJEgwKBGZyb20YBCABKAkSCgoCdG8YBSABKAkSDwoHcGFnZV9pZBgGIAEoCRIaChJwYWdlX2NvbXBvbmVudF9pZHMYByADKAkSEgoKY3JlYXRlZF9hdBgIIAEoCRISCgp1cGRhdGVkX2F0GAkgASgJIucBCgtNYWludGVuYW5jZRIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRIPCgdtZXNzYWdlGAMgASgJEgwKBGZyb20YBCABKAkSCgoCdG8YBSABKAkSDwoHcGFnZV9pZBgGIAEoCRIaChJwYWdlX2NvbXBvbmVudF9pZHMYByADKAkSEgoKY3JlYXRlZF9hdBgIIAEoCRISCgp1cGRhdGVkX2F0GAkgASgJEj0KB3VwZGF0ZXMYCiADKAsyLC5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLk1haW50ZW5hbmNlVXBkYXRlQltaWWdpdGh1Yi5jb20vb3BlbnN0YXR1c2hxL29wZW5zdGF0dXMvcGFja2FnZXMvcHJvdG8vb3BlbnN0YXR1cy9tYWludGVuYW5jZS92MTttYWludGVuYW5jZXYxYgZwcm90bzM");
+
+/**
+ * MaintenanceUpdate represents a timeline entry for a maintenance window.
+ *
+ * @generated from message openstatus.maintenance.v1.MaintenanceUpdate
+ */
+export type MaintenanceUpdate = Message<"openstatus.maintenance.v1.MaintenanceUpdate"> & {
+  /**
+   * Unique identifier for the update.
+   *
+   * @generated from field: string id = 1;
+   */
+  id: string;
+
+  /**
+   * Public update message.
+   *
+   * @generated from field: string message = 2;
+   */
+  message: string;
+
+  /**
+   * Date of the update (RFC 3339 format).
+   *
+   * @generated from field: string date = 3;
+   */
+  date: string;
+
+  /**
+   * ID of the maintenance this update belongs to.
+   *
+   * @generated from field: string maintenance_id = 4;
+   */
+  maintenanceId: string;
+
+  /**
+   * Timestamp when the update was created (RFC 3339 format).
+   *
+   * @generated from field: string created_at = 5;
+   */
+  createdAt: string;
+
+  /**
+   * Timestamp when the update was last updated (RFC 3339 format).
+   *
+   * @generated from field: string updated_at = 6;
+   */
+  updatedAt: string;
+};
+
+/**
+ * Describes the message openstatus.maintenance.v1.MaintenanceUpdate.
+ * Use `create(MaintenanceUpdateSchema)` to create a new message.
+ */
+export const MaintenanceUpdateSchema: GenMessage<MaintenanceUpdate> = /*@__PURE__*/
+  messageDesc(file_openstatus_maintenance_v1_maintenance, 0);
 
 /**
  * MaintenanceSummary represents metadata for a maintenance window (used in list responses).
@@ -87,7 +143,7 @@ export type MaintenanceSummary = Message<"openstatus.maintenance.v1.MaintenanceS
  * Use `create(MaintenanceSummarySchema)` to create a new message.
  */
 export const MaintenanceSummarySchema: GenMessage<MaintenanceSummary> = /*@__PURE__*/
-  messageDesc(file_openstatus_maintenance_v1_maintenance, 0);
+  messageDesc(file_openstatus_maintenance_v1_maintenance, 1);
 
 /**
  * Maintenance represents a maintenance window with full details.
@@ -157,6 +213,13 @@ export type Maintenance = Message<"openstatus.maintenance.v1.Maintenance"> & {
    * @generated from field: string updated_at = 9;
    */
   updatedAt: string;
+
+  /**
+   * Full maintenance update timeline, newest first.
+   *
+   * @generated from field: repeated openstatus.maintenance.v1.MaintenanceUpdate updates = 10;
+   */
+  updates: MaintenanceUpdate[];
 };
 
 /**
@@ -164,5 +227,5 @@ export type Maintenance = Message<"openstatus.maintenance.v1.Maintenance"> & {
  * Use `create(MaintenanceSchema)` to create a new message.
  */
 export const MaintenanceSchema: GenMessage<Maintenance> = /*@__PURE__*/
-  messageDesc(file_openstatus_maintenance_v1_maintenance, 1);
+  messageDesc(file_openstatus_maintenance_v1_maintenance, 2);
 

--- a/packages/proto/gen/ts/openstatus/maintenance/v1/service_pb.ts
+++ b/packages/proto/gen/ts/openstatus/maintenance/v1/service_pb.ts
@@ -6,7 +6,7 @@ import type { GenFile, GenMessage, GenService } from "@bufbuild/protobuf/codegen
 import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
 import { file_buf_validate_validate } from "../../../buf/validate/validate_pb.ts";
 import { file_gnostic_openapi_v3_annotations } from "../../../gnostic/openapi/v3/annotations_pb.ts";
-import type { Maintenance, MaintenanceSummary } from "./maintenance_pb.ts";
+import type { Maintenance, MaintenanceSummary, MaintenanceUpdate } from "./maintenance_pb.ts";
 import { file_openstatus_maintenance_v1_maintenance } from "./maintenance_pb.ts";
 import type { Message } from "@bufbuild/protobuf";
 
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file openstatus/maintenance/v1/service.proto.
  */
 export const file_openstatus_maintenance_v1_service: GenFile = /*@__PURE__*/
-  fileDesc("CidvcGVuc3RhdHVzL21haW50ZW5hbmNlL3YxL3NlcnZpY2UucHJvdG8SGW9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEiqAMKGENyZWF0ZU1haW50ZW5hbmNlUmVxdWVzdBIyCgV0aXRsZRgBIAEoCUIjukcWOhQSEkRhdGFiYXNlIE1pZ3JhdGlvbrpIB3IFEAEYgAISGAoHbWVzc2FnZRgCIAEoCUIHukgEcgIQARJ0CgRmcm9tGAMgASgJQma6Rxg6FhIUMjAyNC0wMy0wMVQwMjowMDowMFq6SEhyRjJEXlxkezR9LVxkezJ9LVxkezJ9VFxkezJ9OlxkezJ9OlxkezJ9KFwuXGR7MSw5fSk/KFp8WystXVxkezJ9OlxkezJ9KSQScgoCdG8YBCABKAlCZrpHGDoWEhQyMDI0LTAzLTAxVDA2OjAwOjAwWrpISHJGMkReXGR7NH0tXGR7Mn0tXGR7Mn1UXGR7Mn06XGR7Mn06XGR7Mn0oXC5cZHsxLDl9KT8oWnxbKy1dXGR7Mn06XGR7Mn0pJBIYCgdwYWdlX2lkGAUgASgJQge6SARyAhABEhoKEnBhZ2VfY29tcG9uZW50X2lkcxgGIAMoCRITCgZub3RpZnkYByABKAhIAIgBAUIJCgdfbm90aWZ5IlgKGUNyZWF0ZU1haW50ZW5hbmNlUmVzcG9uc2USOwoLbWFpbnRlbmFuY2UYASABKAsyJi5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLk1haW50ZW5hbmNlIiwKFUdldE1haW50ZW5hbmNlUmVxdWVzdBITCgJpZBgBIAEoCUIHukgEcgIQASJVChZHZXRNYWludGVuYW5jZVJlc3BvbnNlEjsKC21haW50ZW5hbmNlGAEgASgLMiYub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5NYWludGVuYW5jZSKNAQoXTGlzdE1haW50ZW5hbmNlc1JlcXVlc3QSHQoFbGltaXQYASABKAVCCbpIBhoEGGQoAUgAiAEBEhwKBm9mZnNldBgCIAEoBUIHukgEGgIoAEgBiAEBEhQKB3BhZ2VfaWQYAyABKAlIAogBAUIICgZfbGltaXRCCQoHX29mZnNldEIKCghfcGFnZV9pZCJzChhMaXN0TWFpbnRlbmFuY2VzUmVzcG9uc2USQwoMbWFpbnRlbmFuY2VzGAEgAygLMi0ub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5NYWludGVuYW5jZVN1bW1hcnkSEgoKdG90YWxfc2l6ZRgCIAEoBSLRAwoYVXBkYXRlTWFpbnRlbmFuY2VSZXF1ZXN0EhMKAmlkGAEgASgJQge6SARyAhABEh4KBXRpdGxlGAIgASgJQgq6SAdyBRABGIACSACIAQESFAoHbWVzc2FnZRgDIAEoCUgBiAEBEl4KBGZyb20YBCABKAlCS7pISHJGMkReXGR7NH0tXGR7Mn0tXGR7Mn1UXGR7Mn06XGR7Mn06XGR7Mn0oXC5cZHsxLDl9KT8oWnxbKy1dXGR7Mn06XGR7Mn0pJEgCiAEBElwKAnRvGAUgASgJQku6SEhyRjJEXlxkezR9LVxkezJ9LVxkezJ9VFxkezJ9OlxkezJ9OlxkezJ9KFwuXGR7MSw5fSk/KFp8WystXVxkezJ9OlxkezJ9KSRIA4gBARIYCgdwYWdlX2lkGAYgASgJQgIYAUgEiAEBEhoKEnBhZ2VfY29tcG9uZW50X2lkcxgHIAMoCRImChl1cGRhdGVfcGFnZV9jb21wb25lbnRfaWRzGAggASgISAWIAQFCCAoGX3RpdGxlQgoKCF9tZXNzYWdlQgcKBV9mcm9tQgUKA190b0IKCghfcGFnZV9pZEIcChpfdXBkYXRlX3BhZ2VfY29tcG9uZW50X2lkcyJYChlVcGRhdGVNYWludGVuYW5jZVJlc3BvbnNlEjsKC21haW50ZW5hbmNlGAEgASgLMiYub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5NYWludGVuYW5jZSIvChhEZWxldGVNYWludGVuYW5jZVJlcXVlc3QSEwoCaWQYASABKAlCB7pIBHICEAEiLAoZRGVsZXRlTWFpbnRlbmFuY2VSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIMpMFChJNYWludGVuYW5jZVNlcnZpY2USfgoRQ3JlYXRlTWFpbnRlbmFuY2USMy5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLkNyZWF0ZU1haW50ZW5hbmNlUmVxdWVzdBo0Lm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuQ3JlYXRlTWFpbnRlbmFuY2VSZXNwb25zZRJ6Cg5HZXRNYWludGVuYW5jZRIwLm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuR2V0TWFpbnRlbmFuY2VSZXF1ZXN0GjEub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5HZXRNYWludGVuYW5jZVJlc3BvbnNlIgOQAgESgAEKEExpc3RNYWludGVuYW5jZXMSMi5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLkxpc3RNYWludGVuYW5jZXNSZXF1ZXN0GjMub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5MaXN0TWFpbnRlbmFuY2VzUmVzcG9uc2UiA5ACARJ+ChFVcGRhdGVNYWludGVuYW5jZRIzLm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuVXBkYXRlTWFpbnRlbmFuY2VSZXF1ZXN0GjQub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5VcGRhdGVNYWludGVuYW5jZVJlc3BvbnNlEn4KEURlbGV0ZU1haW50ZW5hbmNlEjMub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5EZWxldGVNYWludGVuYW5jZVJlcXVlc3QaNC5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLkRlbGV0ZU1haW50ZW5hbmNlUmVzcG9uc2VCW1pZZ2l0aHViLmNvbS9vcGVuc3RhdHVzaHEvb3BlbnN0YXR1cy9wYWNrYWdlcy9wcm90by9vcGVuc3RhdHVzL21haW50ZW5hbmNlL3YxO21haW50ZW5hbmNldjFiBnByb3RvMw", [file_buf_validate_validate, file_gnostic_openapi_v3_annotations, file_openstatus_maintenance_v1_maintenance]);
+  fileDesc("CidvcGVuc3RhdHVzL21haW50ZW5hbmNlL3YxL3NlcnZpY2UucHJvdG8SGW9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEiqAMKGENyZWF0ZU1haW50ZW5hbmNlUmVxdWVzdBIyCgV0aXRsZRgBIAEoCUIjukcWOhQSEkRhdGFiYXNlIE1pZ3JhdGlvbrpIB3IFEAEYgAISGAoHbWVzc2FnZRgCIAEoCUIHukgEcgIQARJ0CgRmcm9tGAMgASgJQma6Rxg6FhIUMjAyNC0wMy0wMVQwMjowMDowMFq6SEhyRjJEXlxkezR9LVxkezJ9LVxkezJ9VFxkezJ9OlxkezJ9OlxkezJ9KFwuXGR7MSw5fSk/KFp8WystXVxkezJ9OlxkezJ9KSQScgoCdG8YBCABKAlCZrpHGDoWEhQyMDI0LTAzLTAxVDA2OjAwOjAwWrpISHJGMkReXGR7NH0tXGR7Mn0tXGR7Mn1UXGR7Mn06XGR7Mn06XGR7Mn0oXC5cZHsxLDl9KT8oWnxbKy1dXGR7Mn06XGR7Mn0pJBIYCgdwYWdlX2lkGAUgASgJQge6SARyAhABEhoKEnBhZ2VfY29tcG9uZW50X2lkcxgGIAMoCRITCgZub3RpZnkYByABKAhIAIgBAUIJCgdfbm90aWZ5IlgKGUNyZWF0ZU1haW50ZW5hbmNlUmVzcG9uc2USOwoLbWFpbnRlbmFuY2UYASABKAsyJi5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLk1haW50ZW5hbmNlIiwKFUdldE1haW50ZW5hbmNlUmVxdWVzdBITCgJpZBgBIAEoCUIHukgEcgIQASJVChZHZXRNYWludGVuYW5jZVJlc3BvbnNlEjsKC21haW50ZW5hbmNlGAEgASgLMiYub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5NYWludGVuYW5jZSKNAQoXTGlzdE1haW50ZW5hbmNlc1JlcXVlc3QSHQoFbGltaXQYASABKAVCCbpIBhoEGGQoAUgAiAEBEhwKBm9mZnNldBgCIAEoBUIHukgEGgIoAEgBiAEBEhQKB3BhZ2VfaWQYAyABKAlIAogBAUIICgZfbGltaXRCCQoHX29mZnNldEIKCghfcGFnZV9pZCJzChhMaXN0TWFpbnRlbmFuY2VzUmVzcG9uc2USQwoMbWFpbnRlbmFuY2VzGAEgAygLMi0ub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5NYWludGVuYW5jZVN1bW1hcnkSEgoKdG90YWxfc2l6ZRgCIAEoBSLRAwoYVXBkYXRlTWFpbnRlbmFuY2VSZXF1ZXN0EhMKAmlkGAEgASgJQge6SARyAhABEh4KBXRpdGxlGAIgASgJQgq6SAdyBRABGIACSACIAQESFAoHbWVzc2FnZRgDIAEoCUgBiAEBEl4KBGZyb20YBCABKAlCS7pISHJGMkReXGR7NH0tXGR7Mn0tXGR7Mn1UXGR7Mn06XGR7Mn06XGR7Mn0oXC5cZHsxLDl9KT8oWnxbKy1dXGR7Mn06XGR7Mn0pJEgCiAEBElwKAnRvGAUgASgJQku6SEhyRjJEXlxkezR9LVxkezJ9LVxkezJ9VFxkezJ9OlxkezJ9OlxkezJ9KFwuXGR7MSw5fSk/KFp8WystXVxkezJ9OlxkezJ9KSRIA4gBARIYCgdwYWdlX2lkGAYgASgJQgIYAUgEiAEBEhoKEnBhZ2VfY29tcG9uZW50X2lkcxgHIAMoCRImChl1cGRhdGVfcGFnZV9jb21wb25lbnRfaWRzGAggASgISAWIAQFCCAoGX3RpdGxlQgoKCF9tZXNzYWdlQgcKBV9mcm9tQgUKA190b0IKCghfcGFnZV9pZEIcChpfdXBkYXRlX3BhZ2VfY29tcG9uZW50X2lkcyJYChlVcGRhdGVNYWludGVuYW5jZVJlc3BvbnNlEjsKC21haW50ZW5hbmNlGAEgASgLMiYub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5NYWludGVuYW5jZSIvChhEZWxldGVNYWludGVuYW5jZVJlcXVlc3QSEwoCaWQYASABKAlCB7pIBHICEAEiLAoZRGVsZXRlTWFpbnRlbmFuY2VSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIIuEBChtBZGRNYWludGVuYW5jZVVwZGF0ZVJlcXVlc3QSHwoObWFpbnRlbmFuY2VfaWQYASABKAlCB7pIBHICEAESGAoHbWVzc2FnZRgCIAEoCUIHukgEcgIQARJeCgRkYXRlGAMgASgJQku6SEhyRjJEXlxkezR9LVxkezJ9LVxkezJ9VFxkezJ9OlxkezJ9OlxkezJ9KFwuXGR7MSw5fSk/KFp8WystXVxkezJ9OlxkezJ9KSRIAIgBARITCgZub3RpZnkYBCABKAhIAYgBAUIHCgVfZGF0ZUIJCgdfbm90aWZ5ImgKHEFkZE1haW50ZW5hbmNlVXBkYXRlUmVzcG9uc2USSAoSbWFpbnRlbmFuY2VfdXBkYXRlGAEgASgLMiwub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5NYWludGVuYW5jZVVwZGF0ZSLJAQoeVXBkYXRlTWFpbnRlbmFuY2VVcGRhdGVSZXF1ZXN0EhMKAmlkGAEgASgJQge6SARyAhABEh0KB21lc3NhZ2UYAiABKAlCB7pIBHICEAFIAIgBARJeCgRkYXRlGAMgASgJQku6SEhyRjJEXlxkezR9LVxkezJ9LVxkezJ9VFxkezJ9OlxkezJ9OlxkezJ9KFwuXGR7MSw5fSk/KFp8WystXVxkezJ9OlxkezJ9KSRIAYgBAUIKCghfbWVzc2FnZUIHCgVfZGF0ZSJrCh9VcGRhdGVNYWludGVuYW5jZVVwZGF0ZVJlc3BvbnNlEkgKEm1haW50ZW5hbmNlX3VwZGF0ZRgBIAEoCzIsLm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuTWFpbnRlbmFuY2VVcGRhdGUiNQoeRGVsZXRlTWFpbnRlbmFuY2VVcGRhdGVSZXF1ZXN0EhMKAmlkGAEgASgJQge6SARyAhABIjIKH0RlbGV0ZU1haW50ZW5hbmNlVXBkYXRlUmVzcG9uc2USDwoHc3VjY2VzcxgBIAEoCDLDCAoSTWFpbnRlbmFuY2VTZXJ2aWNlEn4KEUNyZWF0ZU1haW50ZW5hbmNlEjMub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5DcmVhdGVNYWludGVuYW5jZVJlcXVlc3QaNC5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLkNyZWF0ZU1haW50ZW5hbmNlUmVzcG9uc2USegoOR2V0TWFpbnRlbmFuY2USMC5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLkdldE1haW50ZW5hbmNlUmVxdWVzdBoxLm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuR2V0TWFpbnRlbmFuY2VSZXNwb25zZSIDkAIBEoABChBMaXN0TWFpbnRlbmFuY2VzEjIub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5MaXN0TWFpbnRlbmFuY2VzUmVxdWVzdBozLm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuTGlzdE1haW50ZW5hbmNlc1Jlc3BvbnNlIgOQAgESfgoRVXBkYXRlTWFpbnRlbmFuY2USMy5vcGVuc3RhdHVzLm1haW50ZW5hbmNlLnYxLlVwZGF0ZU1haW50ZW5hbmNlUmVxdWVzdBo0Lm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuVXBkYXRlTWFpbnRlbmFuY2VSZXNwb25zZRJ+ChFEZWxldGVNYWludGVuYW5jZRIzLm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuRGVsZXRlTWFpbnRlbmFuY2VSZXF1ZXN0GjQub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5EZWxldGVNYWludGVuYW5jZVJlc3BvbnNlEocBChRBZGRNYWludGVuYW5jZVVwZGF0ZRI2Lm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuQWRkTWFpbnRlbmFuY2VVcGRhdGVSZXF1ZXN0Gjcub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5BZGRNYWludGVuYW5jZVVwZGF0ZVJlc3BvbnNlEpABChdVcGRhdGVNYWludGVuYW5jZVVwZGF0ZRI5Lm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuVXBkYXRlTWFpbnRlbmFuY2VVcGRhdGVSZXF1ZXN0Gjoub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5VcGRhdGVNYWludGVuYW5jZVVwZGF0ZVJlc3BvbnNlEpABChdEZWxldGVNYWludGVuYW5jZVVwZGF0ZRI5Lm9wZW5zdGF0dXMubWFpbnRlbmFuY2UudjEuRGVsZXRlTWFpbnRlbmFuY2VVcGRhdGVSZXF1ZXN0Gjoub3BlbnN0YXR1cy5tYWludGVuYW5jZS52MS5EZWxldGVNYWludGVuYW5jZVVwZGF0ZVJlc3BvbnNlQltaWWdpdGh1Yi5jb20vb3BlbnN0YXR1c2hxL29wZW5zdGF0dXMvcGFja2FnZXMvcHJvdG8vb3BlbnN0YXR1cy9tYWludGVuYW5jZS92MTttYWludGVuYW5jZXYxYgZwcm90bzM", [file_buf_validate_validate, file_gnostic_openapi_v3_annotations, file_openstatus_maintenance_v1_maintenance]);
 
 /**
  * CreateMaintenanceRequest is the request to create a new maintenance window.
@@ -342,6 +342,167 @@ export const DeleteMaintenanceResponseSchema: GenMessage<DeleteMaintenanceRespon
   messageDesc(file_openstatus_maintenance_v1_service, 9);
 
 /**
+ * AddMaintenanceUpdateRequest is the request to append a maintenance update.
+ *
+ * @generated from message openstatus.maintenance.v1.AddMaintenanceUpdateRequest
+ */
+export type AddMaintenanceUpdateRequest = Message<"openstatus.maintenance.v1.AddMaintenanceUpdateRequest"> & {
+  /**
+   * ID of the maintenance to update (required).
+   *
+   * @generated from field: string maintenance_id = 1;
+   */
+  maintenanceId: string;
+
+  /**
+   * Public update message (required).
+   *
+   * @generated from field: string message = 2;
+   */
+  message: string;
+
+  /**
+   * Optional date for the update (RFC 3339 format). Defaults to current time.
+   *
+   * @generated from field: optional string date = 3;
+   */
+  date?: string | undefined;
+
+  /**
+   * Whether to notify subscribers about this update.
+   *
+   * @generated from field: optional bool notify = 4;
+   */
+  notify?: boolean | undefined;
+};
+
+/**
+ * Describes the message openstatus.maintenance.v1.AddMaintenanceUpdateRequest.
+ * Use `create(AddMaintenanceUpdateRequestSchema)` to create a new message.
+ */
+export const AddMaintenanceUpdateRequestSchema: GenMessage<AddMaintenanceUpdateRequest> = /*@__PURE__*/
+  messageDesc(file_openstatus_maintenance_v1_service, 10);
+
+/**
+ * AddMaintenanceUpdateResponse is the response after appending an update.
+ *
+ * @generated from message openstatus.maintenance.v1.AddMaintenanceUpdateResponse
+ */
+export type AddMaintenanceUpdateResponse = Message<"openstatus.maintenance.v1.AddMaintenanceUpdateResponse"> & {
+  /**
+   * The created update.
+   *
+   * @generated from field: openstatus.maintenance.v1.MaintenanceUpdate maintenance_update = 1;
+   */
+  maintenanceUpdate?: MaintenanceUpdate | undefined;
+};
+
+/**
+ * Describes the message openstatus.maintenance.v1.AddMaintenanceUpdateResponse.
+ * Use `create(AddMaintenanceUpdateResponseSchema)` to create a new message.
+ */
+export const AddMaintenanceUpdateResponseSchema: GenMessage<AddMaintenanceUpdateResponse> = /*@__PURE__*/
+  messageDesc(file_openstatus_maintenance_v1_service, 11);
+
+/**
+ * UpdateMaintenanceUpdateRequest is the request to edit an update.
+ *
+ * @generated from message openstatus.maintenance.v1.UpdateMaintenanceUpdateRequest
+ */
+export type UpdateMaintenanceUpdateRequest = Message<"openstatus.maintenance.v1.UpdateMaintenanceUpdateRequest"> & {
+  /**
+   * ID of the update to edit (required).
+   *
+   * @generated from field: string id = 1;
+   */
+  id: string;
+
+  /**
+   * New public message.
+   *
+   * @generated from field: optional string message = 2;
+   */
+  message?: string | undefined;
+
+  /**
+   * New update date (RFC 3339 format).
+   *
+   * @generated from field: optional string date = 3;
+   */
+  date?: string | undefined;
+};
+
+/**
+ * Describes the message openstatus.maintenance.v1.UpdateMaintenanceUpdateRequest.
+ * Use `create(UpdateMaintenanceUpdateRequestSchema)` to create a new message.
+ */
+export const UpdateMaintenanceUpdateRequestSchema: GenMessage<UpdateMaintenanceUpdateRequest> = /*@__PURE__*/
+  messageDesc(file_openstatus_maintenance_v1_service, 12);
+
+/**
+ * UpdateMaintenanceUpdateResponse is the response after editing an update.
+ *
+ * @generated from message openstatus.maintenance.v1.UpdateMaintenanceUpdateResponse
+ */
+export type UpdateMaintenanceUpdateResponse = Message<"openstatus.maintenance.v1.UpdateMaintenanceUpdateResponse"> & {
+  /**
+   * The updated timeline entry.
+   *
+   * @generated from field: openstatus.maintenance.v1.MaintenanceUpdate maintenance_update = 1;
+   */
+  maintenanceUpdate?: MaintenanceUpdate | undefined;
+};
+
+/**
+ * Describes the message openstatus.maintenance.v1.UpdateMaintenanceUpdateResponse.
+ * Use `create(UpdateMaintenanceUpdateResponseSchema)` to create a new message.
+ */
+export const UpdateMaintenanceUpdateResponseSchema: GenMessage<UpdateMaintenanceUpdateResponse> = /*@__PURE__*/
+  messageDesc(file_openstatus_maintenance_v1_service, 13);
+
+/**
+ * DeleteMaintenanceUpdateRequest is the request to remove an update.
+ *
+ * @generated from message openstatus.maintenance.v1.DeleteMaintenanceUpdateRequest
+ */
+export type DeleteMaintenanceUpdateRequest = Message<"openstatus.maintenance.v1.DeleteMaintenanceUpdateRequest"> & {
+  /**
+   * ID of the update to remove (required).
+   *
+   * @generated from field: string id = 1;
+   */
+  id: string;
+};
+
+/**
+ * Describes the message openstatus.maintenance.v1.DeleteMaintenanceUpdateRequest.
+ * Use `create(DeleteMaintenanceUpdateRequestSchema)` to create a new message.
+ */
+export const DeleteMaintenanceUpdateRequestSchema: GenMessage<DeleteMaintenanceUpdateRequest> = /*@__PURE__*/
+  messageDesc(file_openstatus_maintenance_v1_service, 14);
+
+/**
+ * DeleteMaintenanceUpdateResponse is the response after removing an update.
+ *
+ * @generated from message openstatus.maintenance.v1.DeleteMaintenanceUpdateResponse
+ */
+export type DeleteMaintenanceUpdateResponse = Message<"openstatus.maintenance.v1.DeleteMaintenanceUpdateResponse"> & {
+  /**
+   * Whether the deletion was successful.
+   *
+   * @generated from field: bool success = 1;
+   */
+  success: boolean;
+};
+
+/**
+ * Describes the message openstatus.maintenance.v1.DeleteMaintenanceUpdateResponse.
+ * Use `create(DeleteMaintenanceUpdateResponseSchema)` to create a new message.
+ */
+export const DeleteMaintenanceUpdateResponseSchema: GenMessage<DeleteMaintenanceUpdateResponse> = /*@__PURE__*/
+  messageDesc(file_openstatus_maintenance_v1_service, 15);
+
+/**
  * MaintenanceService provides CRUD operations for maintenance windows.
  *
  * @generated from service openstatus.maintenance.v1.MaintenanceService
@@ -396,6 +557,36 @@ export const MaintenanceService: GenService<{
     methodKind: "unary";
     input: typeof DeleteMaintenanceRequestSchema;
     output: typeof DeleteMaintenanceResponseSchema;
+  },
+  /**
+   * AddMaintenanceUpdate appends a public update to a maintenance timeline.
+   *
+   * @generated from rpc openstatus.maintenance.v1.MaintenanceService.AddMaintenanceUpdate
+   */
+  addMaintenanceUpdate: {
+    methodKind: "unary";
+    input: typeof AddMaintenanceUpdateRequestSchema;
+    output: typeof AddMaintenanceUpdateResponseSchema;
+  },
+  /**
+   * UpdateMaintenanceUpdate edits an existing maintenance update.
+   *
+   * @generated from rpc openstatus.maintenance.v1.MaintenanceService.UpdateMaintenanceUpdate
+   */
+  updateMaintenanceUpdate: {
+    methodKind: "unary";
+    input: typeof UpdateMaintenanceUpdateRequestSchema;
+    output: typeof UpdateMaintenanceUpdateResponseSchema;
+  },
+  /**
+   * DeleteMaintenanceUpdate removes an existing maintenance update.
+   *
+   * @generated from rpc openstatus.maintenance.v1.MaintenanceService.DeleteMaintenanceUpdate
+   */
+  deleteMaintenanceUpdate: {
+    methodKind: "unary";
+    input: typeof DeleteMaintenanceUpdateRequestSchema;
+    output: typeof DeleteMaintenanceUpdateResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_openstatus_maintenance_v1_service, 0);

--- a/packages/services/src/agent-tools/__tests__/maintenance-updates.test.ts
+++ b/packages/services/src/agent-tools/__tests__/maintenance-updates.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "@std/expect";
+import { describe, test } from "@std/testing/bdd";
+
+import { agentTools, buildAgentSystemPrompt } from "../index";
+
+describe("maintenance update agent tools", () => {
+  test("registers write-scoped CRUD tools", () => {
+    expect(agentTools.add_maintenance_update.scope).toBe("write");
+    expect(agentTools.update_maintenance_update.scope).toBe("write");
+    expect(agentTools.delete_maintenance_update.scope).toBe("write");
+  });
+
+  test("requires an explicit notify decision when adding an update", () => {
+    expect(
+      agentTools.add_maintenance_update.inputSchema.safeParse({
+        maintenanceId: 1,
+        message: "Update",
+      }).success,
+    ).toBe(false);
+    expect(
+      agentTools.add_maintenance_update.inputSchema.safeParse({
+        maintenanceId: 1,
+        message: "Update",
+        notify: false,
+      }).success,
+    ).toBe(true);
+  });
+
+  test("includes maintenance updates in notification guidance", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceName: "Test",
+      surface: "dashboard",
+      canNotifySubscribers: true,
+    });
+    expect(prompt).toContain("add_maintenance_update");
+    expect(prompt).toContain("Should I notify subscribers? yes/no");
+  });
+});

--- a/packages/services/src/agent-tools/__tests__/maintenance-updates.test.ts
+++ b/packages/services/src/agent-tools/__tests__/maintenance-updates.test.ts
@@ -10,6 +10,20 @@ describe("maintenance update agent tools", () => {
     expect(agentTools.delete_maintenance_update.scope).toBe("write");
   });
 
+  test("rejects id-only update payloads", () => {
+    expect(
+      agentTools.update_maintenance_update.inputSchema.safeParse({
+        id: 1,
+      }).success,
+    ).toBe(false);
+    expect(
+      agentTools.update_maintenance_update.inputSchema.safeParse({
+        id: 1,
+        message: "corrected",
+      }).success,
+    ).toBe(true);
+  });
+
   test("requires an explicit notify decision when adding an update", () => {
     expect(
       agentTools.add_maintenance_update.inputSchema.safeParse({

--- a/packages/services/src/agent-tools/index.ts
+++ b/packages/services/src/agent-tools/index.ts
@@ -2,7 +2,13 @@ import type { z } from "zod";
 
 import { getAuditLogTool, listAuditLogsTool } from "./audit";
 import { getDocPageTool, searchDocsTool } from "./docs";
-import { createMaintenanceTool, listMaintenancesTool } from "./maintenance";
+import {
+  addMaintenanceUpdateTool,
+  createMaintenanceTool,
+  deleteMaintenanceUpdateTool,
+  listMaintenancesTool,
+  updateMaintenanceUpdateTool,
+} from "./maintenance";
 import {
   getMonitorStatusTool,
   getMonitorSummaryTool,
@@ -26,7 +32,13 @@ import type { AnyAgentTool } from "./types";
 
 export { getAuditLogTool, listAuditLogsTool } from "./audit";
 export { getDocPageTool, searchDocsTool } from "./docs";
-export { createMaintenanceTool, listMaintenancesTool } from "./maintenance";
+export {
+  addMaintenanceUpdateTool,
+  createMaintenanceTool,
+  deleteMaintenanceUpdateTool,
+  listMaintenancesTool,
+  updateMaintenanceUpdateTool,
+} from "./maintenance";
 export {
   getMonitorStatusTool,
   getMonitorSummaryTool,
@@ -82,6 +94,9 @@ export const agentTools = {
   resolve_status_report: resolveStatusReportTool,
   list_maintenances: listMaintenancesTool,
   create_maintenance: createMaintenanceTool,
+  add_maintenance_update: addMaintenanceUpdateTool,
+  update_maintenance_update: updateMaintenanceUpdateTool,
+  delete_maintenance_update: deleteMaintenanceUpdateTool,
   list_monitors: listMonitorsTool,
   get_monitor: getMonitorTool,
   get_monitor_status: getMonitorStatusTool,

--- a/packages/services/src/agent-tools/maintenance.ts
+++ b/packages/services/src/agent-tools/maintenance.ts
@@ -60,6 +60,13 @@ const ListMaintenancesOutput = z.object({
       to: z.string(),
       pageId: z.number().int().nullable(),
       pageComponentIds: z.array(z.number().int()),
+      updates: z.array(
+        z.object({
+          id: z.number().int(),
+          message: z.string(),
+          date: z.string(),
+        }),
+      ),
     }),
   ),
   pagination: z.object({
@@ -76,7 +83,7 @@ export const listMaintenancesTool: AgentTool<
 > = {
   name: "list_maintenances",
   description:
-    "List maintenance windows in this workspace, newest first. Paginated via `page` (1-indexed) and `perPage`.",
+    "List maintenance windows in this workspace, newest first. Returns timeline update ids so edit/delete can target a specific entry. Paginated via `page` (1-indexed) and `perPage`.",
   scope: "read",
   destructive: false,
   inputSchema: ListMaintenancesInputShape,
@@ -101,6 +108,11 @@ export const listMaintenancesTool: AgentTool<
         to: m.to.toISOString(),
         pageId: m.pageId,
         pageComponentIds: m.pageComponentIds,
+        updates: m.updates.map((u) => ({
+          id: u.id,
+          message: u.message,
+          date: u.date.toISOString(),
+        })),
       })),
       pagination: {
         page,
@@ -149,6 +161,7 @@ const CreateMaintenanceOutput = z.object({
   from: z.string(),
   to: z.string(),
   pageId: z.number().int().nullable(),
+  initialUpdateId: z.number().int(),
   notified: z.boolean(),
 });
 
@@ -209,11 +222,10 @@ export const createMaintenanceTool: AgentTool<
     let notified = false;
     if (input.notify) {
       try {
-        await notifyMaintenance({
+        notified = await notifyMaintenance({
           ctx,
           input: { maintenanceUpdateId: result.initialUpdate.id },
         });
-        notified = true;
       } catch (err) {
         console.warn("notifyMaintenance failed after create_maintenance", err);
       }
@@ -224,6 +236,7 @@ export const createMaintenanceTool: AgentTool<
       from: result.maintenance.from.toISOString(),
       to: result.maintenance.to.toISOString(),
       pageId: result.maintenance.pageId,
+      initialUpdateId: result.initialUpdate.id,
       notified,
     };
   },
@@ -290,11 +303,10 @@ export const addMaintenanceUpdateTool: AgentTool<
     let notified = false;
     if (input.notify) {
       try {
-        await notifyMaintenance({
+        notified = await notifyMaintenance({
           ctx,
           input: { maintenanceUpdateId: result.maintenanceUpdate.id },
         });
-        notified = true;
       } catch (err) {
         console.warn(
           "notifyMaintenance failed after add_maintenance_update",
@@ -314,7 +326,12 @@ export const addMaintenanceUpdateTool: AgentTool<
 
 const UpdateMaintenanceUpdateInputShape = z
   .object({
-    id: z.number().int().describe("Maintenance update id."),
+    id: z
+      .number()
+      .int()
+      .describe(
+        "Maintenance update id from list_maintenances (or create/add result) — never guess.",
+      ),
     message: z
       .string()
       .min(1)
@@ -332,7 +349,7 @@ export const updateMaintenanceUpdateTool: AgentTool<
 > = {
   name: "update_maintenance_update",
   description:
-    "Edit an existing maintenance timeline entry. PUBLIC and AUDIT-LOGGED. Does not notify subscribers.",
+    "Edit an existing maintenance timeline entry. PUBLIC and AUDIT-LOGGED. Does not notify subscribers. The update id MUST come from list_maintenances (or a prior create/add result).",
   scope: "write",
   destructive: true,
   inputSchema: UpdateMaintenanceUpdateInputShape,
@@ -368,7 +385,12 @@ export const updateMaintenanceUpdateTool: AgentTool<
 };
 
 const DeleteMaintenanceUpdateInputShape = z.object({
-  id: z.number().int().describe("Maintenance update id."),
+  id: z
+    .number()
+    .int()
+    .describe(
+      "Maintenance update id from list_maintenances (or create/add result) — never guess.",
+    ),
 });
 const DeleteMaintenanceUpdateOutput = z.object({
   id: z.number().int(),
@@ -381,7 +403,7 @@ export const deleteMaintenanceUpdateTool: AgentTool<
 > = {
   name: "delete_maintenance_update",
   description:
-    "Delete a maintenance timeline entry. PUBLIC, AUDIT-LOGGED, AND IRREVERSIBLE. A maintenance must retain at least one update.",
+    "Delete a maintenance timeline entry. PUBLIC, AUDIT-LOGGED, AND IRREVERSIBLE. A maintenance must retain at least one update. The update id MUST come from list_maintenances (or a prior create/add result).",
   scope: "write",
   destructive: true,
   inputSchema: DeleteMaintenanceUpdateInputShape,

--- a/packages/services/src/agent-tools/maintenance.ts
+++ b/packages/services/src/agent-tools/maintenance.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
 import {
+  addMaintenanceUpdate,
   createMaintenance,
+  deleteMaintenanceUpdate,
   listMaintenances,
   notifyMaintenance,
+  updateMaintenanceUpdate,
 } from "../maintenance";
 import type { AgentTool } from "./types";
 
@@ -192,7 +195,7 @@ export const createMaintenanceTool: AgentTool<
     verb: "scheduled",
   },
   async run({ ctx, input }) {
-    const record = await createMaintenance({
+    const result = await createMaintenance({
       ctx,
       input: {
         title: input.title,
@@ -208,7 +211,7 @@ export const createMaintenanceTool: AgentTool<
       try {
         await notifyMaintenance({
           ctx,
-          input: { maintenanceId: record.id },
+          input: { maintenanceUpdateId: result.initialUpdate.id },
         });
         notified = true;
       } catch (err) {
@@ -216,12 +219,182 @@ export const createMaintenanceTool: AgentTool<
       }
     }
     return {
-      id: record.id,
-      title: record.title,
-      from: record.from.toISOString(),
-      to: record.to.toISOString(),
-      pageId: record.pageId,
+      id: result.maintenance.id,
+      title: result.maintenance.title,
+      from: result.maintenance.from.toISOString(),
+      to: result.maintenance.to.toISOString(),
+      pageId: result.maintenance.pageId,
       notified,
     };
+  },
+};
+
+const AddMaintenanceUpdateInputShape = z.object({
+  maintenanceId: z
+    .number()
+    .int()
+    .describe("Maintenance id from list_maintenances — never guess."),
+  message: z.string().min(1).describe("Public update message."),
+  date: z.iso
+    .datetime()
+    .optional()
+    .describe("Update time in ISO 8601. Defaults to now."),
+  notify: z
+    .boolean()
+    .describe("Whether to dispatch subscriber notifications for this update."),
+});
+
+const MaintenanceUpdateOutput = z.object({
+  id: z.number().int(),
+  maintenanceId: z.number().int(),
+  message: z.string(),
+  date: z.string(),
+  notified: z.boolean().optional(),
+});
+
+export const addMaintenanceUpdateTool: AgentTool<
+  z.infer<typeof AddMaintenanceUpdateInputShape>,
+  z.infer<typeof MaintenanceUpdateOutput>
+> = {
+  name: "add_maintenance_update",
+  description:
+    "Append a public update to an existing maintenance. PUBLIC, AUDIT-LOGGED, AND POTENTIALLY NOTIFIES SUBSCRIBERS. The maintenanceId MUST come from list_maintenances. Subscriber notification is only available during this call.",
+  scope: "write",
+  destructive: true,
+  inputSchema: AddMaintenanceUpdateInputShape,
+  outputSchema: MaintenanceUpdateOutput,
+  approval: {
+    extraFlags: [{ id: "notify", label: "Notify subscribers" }],
+    applyFlags: (input, flags) => ({ ...input, notify: flags.notify ?? false }),
+    summarize: (input) => ({
+      title: `Publish Maintenance Update #${input.maintenanceId}`,
+      lines: [
+        { label: "Maintenance ID", value: String(input.maintenanceId) },
+        ...(input.date
+          ? [{ label: "Date", value: formatMaintenanceDate(input.date) }]
+          : []),
+        { label: "Message", value: input.message },
+      ],
+    }),
+    verb: "published",
+  },
+  async run({ ctx, input }) {
+    const result = await addMaintenanceUpdate({
+      ctx,
+      input: {
+        maintenanceId: input.maintenanceId,
+        message: input.message,
+        date: input.date ? new Date(input.date) : undefined,
+      },
+    });
+    let notified = false;
+    if (input.notify) {
+      try {
+        await notifyMaintenance({
+          ctx,
+          input: { maintenanceUpdateId: result.maintenanceUpdate.id },
+        });
+        notified = true;
+      } catch (err) {
+        console.warn(
+          "notifyMaintenance failed after add_maintenance_update",
+          err,
+        );
+      }
+    }
+    return {
+      id: result.maintenanceUpdate.id,
+      maintenanceId: result.maintenanceUpdate.maintenanceId,
+      message: result.maintenanceUpdate.message,
+      date: result.maintenanceUpdate.date.toISOString(),
+      notified,
+    };
+  },
+};
+
+const UpdateMaintenanceUpdateInputShape = z
+  .object({
+    id: z.number().int().describe("Maintenance update id."),
+    message: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Replacement public message."),
+    date: z.iso.datetime().optional().describe("Replacement ISO 8601 date."),
+  })
+  .refine((input) => input.message !== undefined || input.date !== undefined, {
+    message: "At least one field must be provided.",
+  });
+
+export const updateMaintenanceUpdateTool: AgentTool<
+  z.infer<typeof UpdateMaintenanceUpdateInputShape>,
+  z.infer<typeof MaintenanceUpdateOutput>
+> = {
+  name: "update_maintenance_update",
+  description:
+    "Edit an existing maintenance timeline entry. PUBLIC and AUDIT-LOGGED. Does not notify subscribers.",
+  scope: "write",
+  destructive: true,
+  inputSchema: UpdateMaintenanceUpdateInputShape,
+  outputSchema: MaintenanceUpdateOutput,
+  approval: {
+    summarize: (input) => ({
+      title: `Edit Maintenance Update #${input.id}`,
+      lines: [
+        ...(input.date
+          ? [{ label: "Date", value: formatMaintenanceDate(input.date) }]
+          : []),
+        ...(input.message ? [{ label: "Message", value: input.message }] : []),
+      ],
+    }),
+    verb: "updated",
+  },
+  async run({ ctx, input }) {
+    const update = await updateMaintenanceUpdate({
+      ctx,
+      input: {
+        id: input.id,
+        message: input.message,
+        date: input.date ? new Date(input.date) : undefined,
+      },
+    });
+    return {
+      id: update.id,
+      maintenanceId: update.maintenanceId,
+      message: update.message,
+      date: update.date.toISOString(),
+    };
+  },
+};
+
+const DeleteMaintenanceUpdateInputShape = z.object({
+  id: z.number().int().describe("Maintenance update id."),
+});
+const DeleteMaintenanceUpdateOutput = z.object({
+  id: z.number().int(),
+  success: z.boolean(),
+});
+
+export const deleteMaintenanceUpdateTool: AgentTool<
+  z.infer<typeof DeleteMaintenanceUpdateInputShape>,
+  z.infer<typeof DeleteMaintenanceUpdateOutput>
+> = {
+  name: "delete_maintenance_update",
+  description:
+    "Delete a maintenance timeline entry. PUBLIC, AUDIT-LOGGED, AND IRREVERSIBLE. A maintenance must retain at least one update.",
+  scope: "write",
+  destructive: true,
+  inputSchema: DeleteMaintenanceUpdateInputShape,
+  outputSchema: DeleteMaintenanceUpdateOutput,
+  approval: {
+    summarize: (input) => ({
+      title: `Delete Maintenance Update #${input.id}`,
+      lines: [{ label: "Update ID", value: String(input.id) }],
+    }),
+    verb: "deleted",
+  },
+  async run({ ctx, input }) {
+    await deleteMaintenanceUpdate({ ctx, input });
+    return { id: input.id, success: true };
   },
 };

--- a/packages/services/src/agent-tools/prompt.ts
+++ b/packages/services/src/agent-tools/prompt.ts
@@ -42,9 +42,9 @@ Exception: after get_doc_page, DO synthesize an answer from the page content —
   // Workspaces without subscriber notify get a different rubric — asking
   // is wasted friction when the field is a server-side no-op anyway.
   const notifyStep = opts.canNotifySubscribers
-    ? `3. For tools with a notify flag (create_status_report, add_status_report_update, resolve_status_report, create_maintenance) ALWAYS ask explicitly: "Should I notify subscribers? yes/no" — never infer the answer.
+    ? `3. For tools with a notify flag (create_status_report, add_status_report_update, resolve_status_report, create_maintenance, add_maintenance_update) ALWAYS ask explicitly: "Should I notify subscribers? yes/no" — never infer the answer.
 4. Only call the tool once the user has confirmed BOTH the content AND the notify decision.`
-    : `3. This workspace plan does NOT support subscriber notifications. For any tool with a notify flag (create_status_report, add_status_report_update, resolve_status_report, create_maintenance) ALWAYS pass \`notify: false\`. Do NOT ask the user about notifications — they would be a no-op anyway. Do NOT mention notifications in your draft.
+    : `3. This workspace plan does NOT support subscriber notifications. For any tool with a notify flag (create_status_report, add_status_report_update, resolve_status_report, create_maintenance, add_maintenance_update) ALWAYS pass \`notify: false\`. Do NOT ask the user about notifications — they would be a no-op anyway. Do NOT mention notifications in your draft.
 4. Only call the tool once the user has confirmed the content.`;
 
   return `${preamble}You are the openstatus assistant for workspace "${opts.workspaceName}".
@@ -82,6 +82,7 @@ Docs knowledge base:
 
 Lifecycle:
 - Status reports flow: create_status_report once → add_status_report_update repeatedly → resolve_status_report.
+- Maintenance communication flows: create_maintenance once → add_maintenance_update for public progress. Use update_maintenance_update only to correct an existing entry and delete_maintenance_update only when the entry must be removed.
 - "provide an update", "we found the cause", "still investigating" → add_status_report_update.
 - "rename the report", "add a component" → update_status_report (metadata only — does not notify).
 - "it's fixed", "incident is resolved" → resolve_status_report (publishes a final update).

--- a/packages/services/src/maintenance/__tests__/maintenance.test.ts
+++ b/packages/services/src/maintenance/__tests__/maintenance.test.ts
@@ -390,6 +390,50 @@ describe("updateMaintenance", () => {
       ).rejects.toBeInstanceOf(ConflictError);
     });
   });
+
+  test("syncs message onto the latest update child and audits", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const { maintenance: record, initialUpdate } = await createMaintenance({
+        ctx,
+        input: {
+          title: `${TEST_PREFIX}-message-sync`,
+          message: "initial",
+          ...futureRange(),
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+
+      const updated = await updateMaintenance({
+        ctx,
+        input: { id: record.id, message: "synced message" },
+      });
+      expect(updated.message).toBe("synced message");
+
+      const child = await tx
+        .select()
+        .from(maintenanceUpdate)
+        .where(eq(maintenanceUpdate.id, initialUpdate.id))
+        .get();
+      expect(child?.message).toBe("synced message");
+
+      await expectAuditRow({
+        workspaceId: teamCtx.workspace.id,
+        action: "maintenance.update",
+        entityType: "maintenance",
+        entityId: record.id,
+        db: tx,
+      });
+      await expectAuditRow({
+        workspaceId: teamCtx.workspace.id,
+        action: "maintenance_update.update",
+        entityType: "maintenance_update",
+        entityId: initialUpdate.id,
+        db: tx,
+      });
+    });
+  });
 });
 
 describe("deleteMaintenance", () => {
@@ -696,14 +740,51 @@ describe("notifyMaintenance", () => {
         },
       });
 
-      await notifyMaintenance({
+      const dispatched = await notifyMaintenance({
         ctx: { ...teamCtx, db: tx },
         input: { maintenanceUpdateId: initialUpdate.id },
       });
+      expect(dispatched).toBe(true);
 
       expect(subscriptionSpies?.dispatchMaintenanceUpdate.mock.calls).toEqual([
         [initialUpdate.id],
       ]);
+    });
+  });
+
+  test("returns false when the plan disables status-subscribers", async () => {
+    await withTestTransaction(async (tx) => {
+      const { initialUpdate } = await createMaintenance({
+        ctx: { ...teamCtx, db: tx },
+        input: {
+          title: `${TEST_PREFIX}-notify-gated`,
+          message: "m",
+          ...futureRange(),
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+
+      const gatedCtx: ServiceContext = {
+        ...teamCtx,
+        db: tx,
+        workspace: {
+          ...teamCtx.workspace,
+          limits: {
+            ...teamCtx.workspace.limits,
+            "status-subscribers": false,
+          },
+        },
+      };
+
+      const dispatched = await notifyMaintenance({
+        ctx: gatedCtx,
+        input: { maintenanceUpdateId: initialUpdate.id },
+      });
+      expect(dispatched).toBe(false);
+      expect(subscriptionSpies?.dispatchMaintenanceUpdate.mock.calls).toEqual(
+        [],
+      );
     });
   });
 });

--- a/packages/services/src/maintenance/__tests__/maintenance.test.ts
+++ b/packages/services/src/maintenance/__tests__/maintenance.test.ts
@@ -1,5 +1,6 @@
 import { db, eq, inArray } from "@openstatus/db";
 import {
+  maintenanceUpdate,
   maintenancesToPageComponents,
   page,
   pageComponent,
@@ -23,11 +24,14 @@ import {
 } from "../../../test/helpers";
 import type { ServiceContext } from "../../context";
 import { ConflictError, ForbiddenError, NotFoundError } from "../../errors";
+import { addMaintenanceUpdate } from "../add-update";
 import { createMaintenance } from "../create";
 import { deleteMaintenance } from "../delete";
+import { deleteMaintenanceUpdate } from "../delete-update";
 import { getMaintenance, listMaintenances } from "../list";
 import { notifyMaintenance } from "../notify";
 import { updateMaintenance } from "../update";
+import { updateMaintenanceUpdate } from "../update-update";
 
 const subscriptionSpies = (globalThis as Record<string, unknown>)
   .__subscriptionSpies as
@@ -137,7 +141,7 @@ describe("createMaintenance", () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
       const range = futureRange();
-      const record = await createMaintenance({
+      const { maintenance: record, initialUpdate } = await createMaintenance({
         ctx,
         input: {
           title: `${TEST_PREFIX}-happy`,
@@ -150,6 +154,8 @@ describe("createMaintenance", () => {
 
       expect(record.title).toBe(`${TEST_PREFIX}-happy`);
       expect(record.pageId).toBe(testPageId);
+      expect(initialUpdate.maintenanceId).toBe(record.id);
+      expect(initialUpdate.message).toBe("planned work");
 
       const assoc = await tx
         .select()
@@ -212,7 +218,7 @@ describe("createMaintenance", () => {
       // Duplicate ids in the input would violate the composite PK on
       // `maintenances_to_page_components` if not deduped. Guard against a
       // regression where the `Set` in `validatePageComponentIds` is dropped.
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx: { ...teamCtx, db: tx },
         input: {
           title: `${TEST_PREFIX}-dedupe`,
@@ -280,7 +286,7 @@ describe("updateMaintenance", () => {
   test("updates title + replaces associations", async () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx,
         input: {
           title: `${TEST_PREFIX}-update`,
@@ -312,7 +318,7 @@ describe("updateMaintenance", () => {
 
   test("throws NotFoundError for cross-workspace update", async () => {
     await withTestTransaction(async (tx) => {
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx: { ...teamCtx, db: tx },
         input: {
           title: `${TEST_PREFIX}-cross-ws-update`,
@@ -339,7 +345,7 @@ describe("updateMaintenance", () => {
       // `{from, to}` submissions. A partial update that moves only `to`
       // earlier than the stored `from` has to be rejected by the service's
       // own effective-range check. Regression guard for that code path.
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx,
         input: {
           title: `${TEST_PREFIX}-range-update`,
@@ -362,7 +368,7 @@ describe("updateMaintenance", () => {
   test("throws ConflictError when pageComponentIds span multiple pages", async () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx,
         input: {
           title: `${TEST_PREFIX}-update-mixed-pages`,
@@ -390,7 +396,7 @@ describe("deleteMaintenance", () => {
   test("cascades associations", async () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx,
         input: {
           title: `${TEST_PREFIX}-delete`,
@@ -413,12 +419,194 @@ describe("deleteMaintenance", () => {
   });
 });
 
+describe("maintenance updates", () => {
+  test("creates, edits, deletes, synchronizes parent, and audits", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const { maintenance: record } = await createMaintenance({
+        ctx,
+        input: {
+          title: `${TEST_PREFIX}-updates`,
+          message: "initial",
+          ...futureRange(),
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+      const initial = await tx
+        .select()
+        .from(maintenanceUpdate)
+        .where(eq(maintenanceUpdate.maintenanceId, record.id))
+        .get();
+      if (!initial) throw new Error("initial maintenance update not found");
+      expect(initial.message).toBe("initial");
+
+      const older = await addMaintenanceUpdate({
+        ctx,
+        input: {
+          maintenanceId: record.id,
+          message: "backdated",
+          date: new Date(0),
+        },
+      });
+      expect(older.maintenance.message).toBe("initial");
+
+      const newest = await addMaintenanceUpdate({
+        ctx,
+        input: { maintenanceId: record.id, message: "newest" },
+      });
+      expect(newest.maintenance.message).toBe("newest");
+
+      await updateMaintenanceUpdate({
+        ctx,
+        input: { id: newest.maintenanceUpdate.id, message: "edited" },
+      });
+      expect(
+        (await getMaintenance({ ctx, input: { id: record.id } })).message,
+      ).toBe("edited");
+
+      await deleteMaintenanceUpdate({
+        ctx,
+        input: { id: newest.maintenanceUpdate.id },
+      });
+      const full = await getMaintenance({ ctx, input: { id: record.id } });
+      expect(full.message).toBe("initial");
+      expect(full.updates.map((update) => update.id)).toEqual([
+        initial.id,
+        older.maintenanceUpdate.id,
+      ]);
+
+      for (const action of [
+        "maintenance_update.create",
+        "maintenance_update.update",
+        "maintenance_update.delete",
+      ] as const) {
+        await expectAuditRow({
+          workspaceId: teamCtx.workspace.id,
+          action,
+          entityType: "maintenance_update",
+          entityId:
+            action === "maintenance_update.update" ||
+            action === "maintenance_update.delete"
+              ? newest.maintenanceUpdate.id
+              : older.maintenanceUpdate.id,
+          db: tx,
+        });
+      }
+    });
+  });
+
+  test("rejects deleting the last update", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const { maintenance: record } = await createMaintenance({
+        ctx,
+        input: {
+          title: `${TEST_PREFIX}-last-update`,
+          message: "only",
+          ...futureRange(),
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+      const only = await tx
+        .select()
+        .from(maintenanceUpdate)
+        .where(eq(maintenanceUpdate.maintenanceId, record.id))
+        .get();
+      if (!only) throw new Error("initial maintenance update not found");
+
+      await expect(
+        deleteMaintenanceUpdate({ ctx, input: { id: only.id } }),
+      ).rejects.toBeInstanceOf(ConflictError);
+    });
+  });
+
+  test("scopes update rows to the workspace", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const { maintenance: record } = await createMaintenance({
+        ctx,
+        input: {
+          title: `${TEST_PREFIX}-update-scope`,
+          message: "only",
+          ...futureRange(),
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+      const only = await tx
+        .select()
+        .from(maintenanceUpdate)
+        .where(eq(maintenanceUpdate.maintenanceId, record.id))
+        .get();
+      if (!only) throw new Error("initial maintenance update not found");
+
+      await expect(
+        updateMaintenanceUpdate({
+          ctx: { ...freeCtx, db: tx },
+          input: { id: only.id, message: "blocked" },
+        }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+  });
+
+  test("rejects read-only actors for update CRUD", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const { maintenance: record } = await createMaintenance({
+        ctx,
+        input: {
+          title: `${TEST_PREFIX}-updates-read-only`,
+          message: "initial",
+          ...futureRange(),
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+      const only = await tx
+        .select()
+        .from(maintenanceUpdate)
+        .where(eq(maintenanceUpdate.maintenanceId, record.id))
+        .get();
+      if (!only) throw new Error("initial maintenance update not found");
+      const readOnlyCtx = {
+        ...makeApiKeyCtx(teamCtx.workspace, {
+          keyId: "maintenance-update-read",
+          userId: 1,
+          scopes: ["read"],
+        }),
+        db: tx,
+      };
+
+      await expect(
+        addMaintenanceUpdate({
+          ctx: readOnlyCtx,
+          input: { maintenanceId: record.id, message: "blocked" },
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      await expect(
+        updateMaintenanceUpdate({
+          ctx: readOnlyCtx,
+          input: { id: only.id, message: "blocked" },
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      await expect(
+        deleteMaintenanceUpdate({
+          ctx: readOnlyCtx,
+          input: { id: only.id },
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+  });
+});
+
 describe("list / get", () => {
   test("respects workspace isolation", async () => {
     await withTestTransaction(async (tx) => {
       const teamCtxTx = { ...teamCtx, db: tx };
       const freeCtxTx = { ...freeCtx, db: tx };
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx: teamCtxTx,
         input: {
           title: `${TEST_PREFIX}-isolation`,
@@ -449,7 +637,7 @@ describe("list / get", () => {
   test("list returns totalSize and enriched relations", async () => {
     await withTestTransaction(async (tx) => {
       const ctx = { ...teamCtx, db: tx };
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx,
         input: {
           title: `${TEST_PREFIX}-list-enrich`,
@@ -475,7 +663,7 @@ describe("list / get", () => {
 describe("notifyMaintenance", () => {
   test("throws when maintenance belongs to another workspace", async () => {
     await withTestTransaction(async (tx) => {
-      const record = await createMaintenance({
+      const { initialUpdate } = await createMaintenance({
         ctx: { ...teamCtx, db: tx },
         input: {
           title: `${TEST_PREFIX}-notify-cross-ws`,
@@ -489,9 +677,33 @@ describe("notifyMaintenance", () => {
       await expect(
         notifyMaintenance({
           ctx: { ...freeCtx, db: tx },
-          input: { maintenanceId: record.id },
+          input: { maintenanceUpdateId: initialUpdate.id },
         }),
       ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+  });
+
+  test("dispatches the requested maintenance update", async () => {
+    await withTestTransaction(async (tx) => {
+      const { initialUpdate } = await createMaintenance({
+        ctx: { ...teamCtx, db: tx },
+        input: {
+          title: `${TEST_PREFIX}-notify-update`,
+          message: "m",
+          ...futureRange(),
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+
+      await notifyMaintenance({
+        ctx: { ...teamCtx, db: tx },
+        input: { maintenanceUpdateId: initialUpdate.id },
+      });
+
+      expect(subscriptionSpies?.dispatchMaintenanceUpdate.mock.calls).toEqual([
+        [initialUpdate.id],
+      ]);
     });
   });
 });
@@ -506,7 +718,7 @@ describe("slack actor path", () => {
         }),
         db: tx,
       };
-      const record = await createMaintenance({
+      const { maintenance: record } = await createMaintenance({
         ctx,
         input: {
           title: `${TEST_PREFIX}-slack`,

--- a/packages/services/src/maintenance/add-update.ts
+++ b/packages/services/src/maintenance/add-update.ts
@@ -5,10 +5,7 @@ import { requireScope } from "../auth";
 import { type ServiceContext, withTransaction } from "../context";
 import { InternalServiceError } from "../errors";
 import type { Maintenance, MaintenanceUpdate } from "../types";
-import {
-  getMaintenanceInWorkspace,
-  syncMaintenanceMessage,
-} from "./internal";
+import { getMaintenanceInWorkspace, syncMaintenanceMessage } from "./internal";
 import { AddMaintenanceUpdateInput } from "./schemas";
 
 export type AddMaintenanceUpdateResult = {

--- a/packages/services/src/maintenance/add-update.ts
+++ b/packages/services/src/maintenance/add-update.ts
@@ -1,0 +1,64 @@
+import { maintenanceUpdate } from "@openstatus/db/src/schema";
+
+import { emitAudit } from "../audit";
+import { requireScope } from "../auth";
+import { type ServiceContext, withTransaction } from "../context";
+import { InternalServiceError } from "../errors";
+import type { Maintenance, MaintenanceUpdate } from "../types";
+import {
+  getMaintenanceInWorkspace,
+  syncMaintenanceMessage,
+} from "./internal";
+import { AddMaintenanceUpdateInput } from "./schemas";
+
+export type AddMaintenanceUpdateResult = {
+  maintenance: Maintenance;
+  maintenanceUpdate: MaintenanceUpdate;
+};
+
+export async function addMaintenanceUpdate(args: {
+  ctx: ServiceContext;
+  input: AddMaintenanceUpdateInput;
+}): Promise<AddMaintenanceUpdateResult> {
+  const { ctx } = args;
+  requireScope(ctx, "write");
+  const input = AddMaintenanceUpdateInput.parse(args.input);
+
+  return withTransaction(ctx, async (tx) => {
+    const record = await getMaintenanceInWorkspace({
+      tx,
+      id: input.maintenanceId,
+      workspaceId: ctx.workspace.id,
+    });
+
+    const newUpdate = await tx
+      .insert(maintenanceUpdate)
+      .values({
+        maintenanceId: record.id,
+        message: input.message,
+        date: input.date ?? new Date(),
+      })
+      .returning()
+      .get();
+
+    const updatedMaintenance = await syncMaintenanceMessage(tx, record.id);
+    if (!updatedMaintenance) {
+      throw new InternalServiceError(
+        `failed to synchronize maintenance ${record.id}`,
+      );
+    }
+
+    await emitAudit(tx, ctx, {
+      action: "maintenance_update.create",
+      entityType: "maintenance_update",
+      entityId: newUpdate.id,
+      after: newUpdate,
+      metadata: { maintenanceId: record.id },
+    });
+
+    return {
+      maintenance: updatedMaintenance,
+      maintenanceUpdate: newUpdate,
+    };
+  });
+}

--- a/packages/services/src/maintenance/create.ts
+++ b/packages/services/src/maintenance/create.ts
@@ -1,10 +1,10 @@
-import { maintenance } from "@openstatus/db/src/schema";
+import { maintenance, maintenanceUpdate } from "@openstatus/db/src/schema";
 
 import { emitAudit } from "../audit";
 import { requireScope } from "../auth";
 import { type ServiceContext, withTransaction } from "../context";
 import { ConflictError } from "../errors";
-import type { Maintenance } from "../types";
+import type { Maintenance, MaintenanceUpdate } from "../types";
 import {
   assertPageInWorkspace,
   updatePageComponentAssociations,
@@ -12,10 +12,15 @@ import {
 } from "./internal";
 import { CreateMaintenanceInput } from "./schemas";
 
+export type CreateMaintenanceResult = {
+  maintenance: Maintenance;
+  initialUpdate: MaintenanceUpdate;
+};
+
 export async function createMaintenance(args: {
   ctx: ServiceContext;
   input: CreateMaintenanceInput;
-}): Promise<Maintenance> {
+}): Promise<CreateMaintenanceResult> {
   const { ctx } = args;
   requireScope(ctx, "write");
   const input = CreateMaintenanceInput.parse(args.input);
@@ -52,6 +57,16 @@ export async function createMaintenance(args: {
       .returning()
       .get();
 
+    const initialUpdate = await tx
+      .insert(maintenanceUpdate)
+      .values({
+        maintenanceId: record.id,
+        message: input.message,
+        date: record.createdAt ?? input.from,
+      })
+      .returning()
+      .get();
+
     await updatePageComponentAssociations({
       tx,
       maintenanceId: record.id,
@@ -65,6 +80,14 @@ export async function createMaintenance(args: {
       after: record,
     });
 
-    return record;
+    await emitAudit(tx, ctx, {
+      action: "maintenance_update.create",
+      entityType: "maintenance_update",
+      entityId: initialUpdate.id,
+      after: initialUpdate,
+      metadata: { maintenanceId: record.id },
+    });
+
+    return { maintenance: record, initialUpdate };
   });
 }

--- a/packages/services/src/maintenance/delete-update.ts
+++ b/packages/services/src/maintenance/delete-update.ts
@@ -1,0 +1,50 @@
+import { count, eq } from "@openstatus/db";
+import { maintenanceUpdate } from "@openstatus/db/src/schema";
+
+import { emitAudit } from "../audit";
+import { requireScope } from "../auth";
+import { type ServiceContext, withTransaction } from "../context";
+import { ConflictError } from "../errors";
+import {
+  getMaintenanceUpdateInWorkspace,
+  syncMaintenanceMessage,
+} from "./internal";
+import { DeleteMaintenanceUpdateInput } from "./schemas";
+
+export async function deleteMaintenanceUpdate(args: {
+  ctx: ServiceContext;
+  input: DeleteMaintenanceUpdateInput;
+}): Promise<void> {
+  const { ctx } = args;
+  requireScope(ctx, "write");
+  const input = DeleteMaintenanceUpdateInput.parse(args.input);
+
+  await withTransaction(ctx, async (tx) => {
+    const existing = await getMaintenanceUpdateInWorkspace({
+      tx,
+      id: input.id,
+      workspaceId: ctx.workspace.id,
+    });
+    const total = await tx
+      .select({ value: count() })
+      .from(maintenanceUpdate)
+      .where(eq(maintenanceUpdate.maintenanceId, existing.maintenanceId))
+      .get();
+    if ((total?.value ?? 0) <= 1) {
+      throw new ConflictError("A maintenance must have at least one update.");
+    }
+
+    await tx
+      .delete(maintenanceUpdate)
+      .where(eq(maintenanceUpdate.id, existing.id));
+    await syncMaintenanceMessage(tx, existing.maintenanceId);
+
+    await emitAudit(tx, ctx, {
+      action: "maintenance_update.delete",
+      entityType: "maintenance_update",
+      entityId: existing.id,
+      before: existing,
+      metadata: { maintenanceId: existing.maintenanceId },
+    });
+  });
+}

--- a/packages/services/src/maintenance/get-update.ts
+++ b/packages/services/src/maintenance/get-update.ts
@@ -1,6 +1,4 @@
-import { db as defaultDb } from "@openstatus/db";
-
-import type { ServiceContext } from "../context";
+import { type ServiceContext, getReadDb } from "../context";
 import type { MaintenanceUpdate } from "../types";
 import { getMaintenanceUpdateInWorkspace } from "./internal";
 import { GetMaintenanceUpdateInput } from "./schemas";
@@ -12,7 +10,7 @@ export async function getMaintenanceUpdate(args: {
   const { ctx } = args;
   const input = GetMaintenanceUpdateInput.parse(args.input);
   return getMaintenanceUpdateInWorkspace({
-    tx: ctx.db ?? defaultDb,
+    tx: getReadDb(ctx),
     id: input.id,
     workspaceId: ctx.workspace.id,
   });

--- a/packages/services/src/maintenance/get-update.ts
+++ b/packages/services/src/maintenance/get-update.ts
@@ -1,0 +1,19 @@
+import { db as defaultDb } from "@openstatus/db";
+
+import type { ServiceContext } from "../context";
+import type { MaintenanceUpdate } from "../types";
+import { getMaintenanceUpdateInWorkspace } from "./internal";
+import { GetMaintenanceUpdateInput } from "./schemas";
+
+export async function getMaintenanceUpdate(args: {
+  ctx: ServiceContext;
+  input: GetMaintenanceUpdateInput;
+}): Promise<MaintenanceUpdate> {
+  const { ctx } = args;
+  const input = GetMaintenanceUpdateInput.parse(args.input);
+  return getMaintenanceUpdateInWorkspace({
+    tx: ctx.db ?? defaultDb,
+    id: input.id,
+    workspaceId: ctx.workspace.id,
+  });
+}

--- a/packages/services/src/maintenance/index.ts
+++ b/packages/services/src/maintenance/index.ts
@@ -1,5 +1,11 @@
-export { createMaintenance } from "./create";
+export {
+  addMaintenanceUpdate,
+  type AddMaintenanceUpdateResult,
+} from "./add-update";
+export { createMaintenance, type CreateMaintenanceResult } from "./create";
 export { deleteMaintenance } from "./delete";
+export { deleteMaintenanceUpdate } from "./delete-update";
+export { getMaintenanceUpdate } from "./get-update";
 export {
   getMaintenance,
   listMaintenances,
@@ -8,15 +14,20 @@ export {
 } from "./list";
 export { notifyMaintenance } from "./notify";
 export { updateMaintenance } from "./update";
+export { updateMaintenanceUpdate } from "./update-update";
 
 export {
+  AddMaintenanceUpdateInput,
   CreateMaintenanceInput,
   DeleteMaintenanceInput,
+  DeleteMaintenanceUpdateInput,
   GetMaintenanceInput,
+  GetMaintenanceUpdateInput,
   ListMaintenancesInput,
   type MaintenanceListPeriod,
   maintenanceListPeriodSchema,
   maintenanceListPeriods,
   NotifyMaintenanceInput,
   UpdateMaintenanceInput,
+  UpdateMaintenanceUpdateInput,
 } from "./schemas";

--- a/packages/services/src/maintenance/internal.ts
+++ b/packages/services/src/maintenance/internal.ts
@@ -1,6 +1,7 @@
-import { and, eq, inArray } from "@openstatus/db";
+import { and, desc, eq, inArray } from "@openstatus/db";
 import {
   maintenance,
+  maintenanceUpdate,
   maintenancesToPageComponents,
   page,
   pageComponent,
@@ -114,4 +115,55 @@ export async function getMaintenanceInWorkspace(args: {
     .get();
   if (!row) throw new NotFoundError("maintenance", id);
   return row;
+}
+
+export async function getMaintenanceUpdateInWorkspace(args: {
+  tx: DB;
+  id: number;
+  workspaceId: number;
+}) {
+  const { tx, id, workspaceId } = args;
+  const row = await tx
+    .select({ update: maintenanceUpdate })
+    .from(maintenanceUpdate)
+    .innerJoin(
+      maintenance,
+      eq(maintenance.id, maintenanceUpdate.maintenanceId),
+    )
+    .where(
+      and(
+        eq(maintenanceUpdate.id, id),
+        eq(maintenance.workspaceId, workspaceId),
+      ),
+    )
+    .get();
+  if (!row) throw new NotFoundError("maintenance_update", id);
+  return row.update;
+}
+
+export async function syncMaintenanceMessage(
+  tx: DB,
+  maintenanceId: number,
+) {
+  const latest = await getLatestMaintenanceUpdate(tx, maintenanceId);
+
+  if (!latest) {
+    throw new ConflictError("A maintenance must have at least one update.");
+  }
+
+  return tx
+    .update(maintenance)
+    .set({ message: latest.message, updatedAt: new Date() })
+    .where(eq(maintenance.id, maintenanceId))
+    .returning()
+    .get();
+}
+
+export function getLatestMaintenanceUpdate(tx: DB, maintenanceId: number) {
+  return tx
+    .select()
+    .from(maintenanceUpdate)
+    .where(eq(maintenanceUpdate.maintenanceId, maintenanceId))
+    .orderBy(desc(maintenanceUpdate.date), desc(maintenanceUpdate.id))
+    .get();
 }

--- a/packages/services/src/maintenance/internal.ts
+++ b/packages/services/src/maintenance/internal.ts
@@ -126,10 +126,7 @@ export async function getMaintenanceUpdateInWorkspace(args: {
   const row = await tx
     .select({ update: maintenanceUpdate })
     .from(maintenanceUpdate)
-    .innerJoin(
-      maintenance,
-      eq(maintenance.id, maintenanceUpdate.maintenanceId),
-    )
+    .innerJoin(maintenance, eq(maintenance.id, maintenanceUpdate.maintenanceId))
     .where(
       and(
         eq(maintenanceUpdate.id, id),
@@ -141,10 +138,7 @@ export async function getMaintenanceUpdateInWorkspace(args: {
   return row.update;
 }
 
-export async function syncMaintenanceMessage(
-  tx: DB,
-  maintenanceId: number,
-) {
+export async function syncMaintenanceMessage(tx: DB, maintenanceId: number) {
   const latest = await getLatestMaintenanceUpdate(tx, maintenanceId);
 
   if (!latest) {

--- a/packages/services/src/maintenance/list.ts
+++ b/packages/services/src/maintenance/list.ts
@@ -11,13 +11,14 @@ import {
 } from "@openstatus/db";
 import {
   maintenance,
+  maintenanceUpdate,
   maintenancesToPageComponents,
   pageComponent,
   selectPageComponentSchema,
 } from "@openstatus/db/src/schema";
 
 import type { DB, ServiceContext } from "../context";
-import type { Maintenance, PageComponent } from "../types";
+import type { Maintenance, MaintenanceUpdate, PageComponent } from "../types";
 import { getMaintenanceInWorkspace } from "./internal";
 import {
   GetMaintenanceInput,
@@ -39,6 +40,7 @@ function periodToSince(period: MaintenanceListPeriod): Date {
 }
 
 export type MaintenanceWithRelations = Maintenance & {
+  updates: MaintenanceUpdate[];
   pageComponents: PageComponent[];
   pageComponentIds: number[];
 };
@@ -59,6 +61,19 @@ async function enrichMaintenancesBatch(
 ): Promise<MaintenanceWithRelations[]> {
   if (rows.length === 0) return [];
   const ids = rows.map((r) => r.id);
+
+  const allUpdates = await db
+    .select()
+    .from(maintenanceUpdate)
+    .where(inArray(maintenanceUpdate.maintenanceId, ids))
+    .orderBy(desc(maintenanceUpdate.date), desc(maintenanceUpdate.id))
+    .all();
+  const updatesByMaintenance = new Map<number, MaintenanceUpdate[]>();
+  for (const update of allUpdates) {
+    const existing = updatesByMaintenance.get(update.maintenanceId);
+    if (existing) existing.push(update);
+    else updatesByMaintenance.set(update.maintenanceId, [update]);
+  }
 
   // Explicit column selection (not `select()`) keeps the row shape in our
   // hands instead of relying on drizzle's auto-derived `row.<table_name>`
@@ -89,6 +104,7 @@ async function enrichMaintenancesBatch(
     const components = componentsByMaintenance.get(r.id) ?? [];
     return {
       ...r,
+      updates: updatesByMaintenance.get(r.id) ?? [],
       pageComponents: components,
       pageComponentIds: components.map((c) => c.id),
     };

--- a/packages/services/src/maintenance/notify.ts
+++ b/packages/services/src/maintenance/notify.ts
@@ -1,5 +1,5 @@
 import { db as defaultDb, eq } from "@openstatus/db";
-import { maintenance } from "@openstatus/db/src/schema";
+import { maintenance, maintenanceUpdate } from "@openstatus/db/src/schema";
 import { dispatchMaintenanceUpdate } from "@openstatus/subscriptions";
 
 import { requireScope } from "../auth";
@@ -8,12 +8,13 @@ import { ForbiddenError, NotFoundError } from "../errors";
 import { NotifyMaintenanceInput } from "./schemas";
 
 /**
- * Dispatch subscriber notifications for a maintenance. Separate from the
+ * Dispatch subscriber notifications for a specific maintenance update.
+ * Separate from the
  * create/update mutations because the dashboard runs on Edge and cannot
  * fire-and-forget — callers invoke this as a second awaited call.
  *
  * Enforces:
- *   - Workspace owns the target maintenance.
+ *   - Workspace owns the target update (via its parent maintenance).
  *   - Plan has `status-subscribers` enabled — otherwise no-op.
  */
 export async function notifyMaintenance(args: {
@@ -26,21 +27,27 @@ export async function notifyMaintenance(args: {
   const db = ctx.db ?? defaultDb;
 
   const row = await db
-    .select({ id: maintenance.id, workspaceId: maintenance.workspaceId })
-    .from(maintenance)
-    .where(eq(maintenance.id, input.maintenanceId))
+    .select({
+      updateId: maintenanceUpdate.id,
+      maintenanceWorkspaceId: maintenance.workspaceId,
+    })
+    .from(maintenanceUpdate)
+    .innerJoin(maintenance, eq(maintenanceUpdate.maintenanceId, maintenance.id))
+    .where(eq(maintenanceUpdate.id, input.maintenanceUpdateId))
     .get();
 
   if (!row) {
-    throw new NotFoundError("maintenance", input.maintenanceId);
+    throw new NotFoundError("maintenance_update", input.maintenanceUpdateId);
   }
-  if (row.workspaceId !== ctx.workspace.id) {
-    throw new ForbiddenError("Maintenance does not belong to this workspace.");
+  if (row.maintenanceWorkspaceId !== ctx.workspace.id) {
+    throw new ForbiddenError(
+      "Maintenance update does not belong to this workspace.",
+    );
   }
 
   if (!ctx.workspace.limits["status-subscribers"]) {
     return;
   }
 
-  await dispatchMaintenanceUpdate(input.maintenanceId);
+  await dispatchMaintenanceUpdate(input.maintenanceUpdateId);
 }

--- a/packages/services/src/maintenance/notify.ts
+++ b/packages/services/src/maintenance/notify.ts
@@ -15,12 +15,14 @@ import { NotifyMaintenanceInput } from "./schemas";
  *
  * Enforces:
  *   - Workspace owns the target update (via its parent maintenance).
- *   - Plan has `status-subscribers` enabled — otherwise no-op.
+ *   - Plan has `status-subscribers` enabled — otherwise returns false.
+ *
+ * Returns true only when a dispatch actually ran.
  */
 export async function notifyMaintenance(args: {
   ctx: ServiceContext;
   input: NotifyMaintenanceInput;
-}): Promise<void> {
+}): Promise<boolean> {
   const { ctx } = args;
   requireScope(ctx, "write");
   const input = NotifyMaintenanceInput.parse(args.input);
@@ -46,8 +48,9 @@ export async function notifyMaintenance(args: {
   }
 
   if (!ctx.workspace.limits["status-subscribers"]) {
-    return;
+    return false;
   }
 
   await dispatchMaintenanceUpdate(input.maintenanceUpdateId);
+  return true;
 }

--- a/packages/services/src/maintenance/schemas.ts
+++ b/packages/services/src/maintenance/schemas.ts
@@ -36,6 +36,38 @@ export const UpdateMaintenanceInput = z.object({
 });
 export type UpdateMaintenanceInput = z.infer<typeof UpdateMaintenanceInput>;
 
+export const AddMaintenanceUpdateInput = z.object({
+  maintenanceId: z.number().int(),
+  message: z.string().min(1),
+  date: z.coerce.date().optional(),
+});
+export type AddMaintenanceUpdateInput = z.infer<
+  typeof AddMaintenanceUpdateInput
+>;
+
+export const UpdateMaintenanceUpdateInput = z.object({
+  id: z.number().int(),
+  message: z.string().min(1).optional(),
+  date: z.coerce.date().optional(),
+});
+export type UpdateMaintenanceUpdateInput = z.infer<
+  typeof UpdateMaintenanceUpdateInput
+>;
+
+export const DeleteMaintenanceUpdateInput = z.object({
+  id: z.number().int(),
+});
+export type DeleteMaintenanceUpdateInput = z.infer<
+  typeof DeleteMaintenanceUpdateInput
+>;
+
+export const GetMaintenanceUpdateInput = z.object({
+  id: z.number().int(),
+});
+export type GetMaintenanceUpdateInput = z.infer<
+  typeof GetMaintenanceUpdateInput
+>;
+
 export const DeleteMaintenanceInput = z.object({ id: z.number().int() });
 export type DeleteMaintenanceInput = z.infer<typeof DeleteMaintenanceInput>;
 
@@ -54,6 +86,6 @@ export const ListMaintenancesInput = z.object({
 export type ListMaintenancesInput = z.infer<typeof ListMaintenancesInput>;
 
 export const NotifyMaintenanceInput = z.object({
-  maintenanceId: z.number().int(),
+  maintenanceUpdateId: z.number().int(),
 });
 export type NotifyMaintenanceInput = z.infer<typeof NotifyMaintenanceInput>;

--- a/packages/services/src/maintenance/schemas.ts
+++ b/packages/services/src/maintenance/schemas.ts
@@ -45,11 +45,15 @@ export type AddMaintenanceUpdateInput = z.infer<
   typeof AddMaintenanceUpdateInput
 >;
 
-export const UpdateMaintenanceUpdateInput = z.object({
-  id: z.number().int(),
-  message: z.string().min(1).optional(),
-  date: z.coerce.date().optional(),
-});
+export const UpdateMaintenanceUpdateInput = z
+  .object({
+    id: z.number().int(),
+    message: z.string().min(1).optional(),
+    date: z.coerce.date().optional(),
+  })
+  .refine((input) => input.message !== undefined || input.date !== undefined, {
+    message: "At least one field must be provided.",
+  });
 export type UpdateMaintenanceUpdateInput = z.infer<
   typeof UpdateMaintenanceUpdateInput
 >;

--- a/packages/services/src/maintenance/update-update.ts
+++ b/packages/services/src/maintenance/update-update.ts
@@ -1,0 +1,59 @@
+import { eq } from "@openstatus/db";
+import { maintenanceUpdate } from "@openstatus/db/src/schema";
+
+import { emitAudit } from "../audit";
+import { requireScope } from "../auth";
+import { type ServiceContext, withTransaction } from "../context";
+import { InternalServiceError } from "../errors";
+import type { MaintenanceUpdate } from "../types";
+import {
+  getMaintenanceUpdateInWorkspace,
+  syncMaintenanceMessage,
+} from "./internal";
+import { UpdateMaintenanceUpdateInput } from "./schemas";
+
+export async function updateMaintenanceUpdate(args: {
+  ctx: ServiceContext;
+  input: UpdateMaintenanceUpdateInput;
+}): Promise<MaintenanceUpdate> {
+  const { ctx } = args;
+  requireScope(ctx, "write");
+  const input = UpdateMaintenanceUpdateInput.parse(args.input);
+
+  return withTransaction(ctx, async (tx) => {
+    const existing = await getMaintenanceUpdateInWorkspace({
+      tx,
+      id: input.id,
+      workspaceId: ctx.workspace.id,
+    });
+
+    const values: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.message !== undefined) values.message = input.message;
+    if (input.date !== undefined) values.date = input.date;
+
+    const updated = await tx
+      .update(maintenanceUpdate)
+      .set(values)
+      .where(eq(maintenanceUpdate.id, existing.id))
+      .returning()
+      .get();
+    if (!updated) {
+      throw new InternalServiceError(
+        `failed to update maintenance update ${existing.id}`,
+      );
+    }
+
+    await syncMaintenanceMessage(tx, existing.maintenanceId);
+
+    await emitAudit(tx, ctx, {
+      action: "maintenance_update.update",
+      entityType: "maintenance_update",
+      entityId: updated.id,
+      before: existing,
+      after: updated,
+      metadata: { maintenanceId: existing.maintenanceId },
+    });
+
+    return updated;
+  });
+}

--- a/packages/services/src/maintenance/update.ts
+++ b/packages/services/src/maintenance/update.ts
@@ -7,11 +7,13 @@ import { type ServiceContext, withTransaction } from "../context";
 import { ConflictError, InternalServiceError } from "../errors";
 import type { Maintenance } from "../types";
 import {
+  getLatestMaintenanceUpdate,
   getMaintenanceInWorkspace,
   updatePageComponentAssociations,
   validatePageComponentIds,
 } from "./internal";
 import { UpdateMaintenanceInput } from "./schemas";
+import { updateMaintenanceUpdate } from "./update-update";
 
 export async function updateMaintenance(args: {
   ctx: ServiceContext;
@@ -38,9 +40,21 @@ export async function updateMaintenance(args: {
 
     const updateValues: Record<string, unknown> = { updatedAt: new Date() };
     if (input.title !== undefined) updateValues.title = input.title;
-    if (input.message !== undefined) updateValues.message = input.message;
     if (input.from !== undefined) updateValues.from = input.from;
     if (input.to !== undefined) updateValues.to = input.to;
+
+    if (input.message !== undefined) {
+      const latest = await getLatestMaintenanceUpdate(tx, existing.id);
+      if (!latest) {
+        throw new InternalServiceError(
+          `maintenance ${existing.id} has no updates`,
+        );
+      }
+      await updateMaintenanceUpdate({
+        ctx: { ...ctx, db: tx },
+        input: { id: latest.id, message: input.message },
+      });
+    }
 
     if (input.pageComponentIds !== undefined) {
       const validated = await validatePageComponentIds({

--- a/packages/services/src/page/get-content.ts
+++ b/packages/services/src/page/get-content.ts
@@ -2,6 +2,7 @@ import { and, db as defaultDb, desc, eq, inArray } from "@openstatus/db";
 import {
   type PageComponentImpact,
   maintenance,
+  maintenanceUpdate,
   maintenancesToPageComponents,
   pageComponent,
   pageComponentGroup,
@@ -18,6 +19,7 @@ type GroupRow = typeof pageComponentGroup.$inferSelect;
 type ReportRow = typeof statusReport.$inferSelect;
 type UpdateRow = typeof statusReportUpdate.$inferSelect;
 type MaintenanceRow = typeof maintenance.$inferSelect;
+type MaintenanceUpdateRow = typeof maintenanceUpdate.$inferSelect;
 
 export type StatusReportContent = ReportRow & {
   pageComponentIds: number[];
@@ -33,6 +35,7 @@ export type StatusReportContent = ReportRow & {
 
 export type MaintenanceContent = MaintenanceRow & {
   pageComponentIds: number[];
+  maintenanceUpdates: MaintenanceUpdateRow[];
 };
 
 export type StatusPageContent = {
@@ -155,22 +158,36 @@ export async function getStatusPageContent(args: {
   }));
 
   const maintenanceIds = pageMaintenances.map((m) => m.id);
-  const maintenanceComponents =
+  const [maintenanceComponents, maintenanceUpdates] = await Promise.all([
     maintenanceIds.length > 0
-      ? await db
+      ? db
           .select()
           .from(maintenancesToPageComponents)
           .where(
             inArray(maintenancesToPageComponents.maintenanceId, maintenanceIds),
           )
           .all()
-      : [];
+      : Promise.resolve(
+          [] as (typeof maintenancesToPageComponents.$inferSelect)[],
+        ),
+    maintenanceIds.length > 0
+      ? db
+          .select()
+          .from(maintenanceUpdate)
+          .where(inArray(maintenanceUpdate.maintenanceId, maintenanceIds))
+          .orderBy(desc(maintenanceUpdate.date), desc(maintenanceUpdate.id))
+          .all()
+      : Promise.resolve([] as MaintenanceUpdateRow[]),
+  ]);
 
   const maintenances: MaintenanceContent[] = pageMaintenances.map((m) => ({
     ...m,
     pageComponentIds: maintenanceComponents
       .filter((mc) => mc.maintenanceId === m.id)
       .map((mc) => mc.pageComponentId),
+    maintenanceUpdates: maintenanceUpdates.filter(
+      (u) => u.maintenanceId === m.id,
+    ),
   }));
 
   return { components, groups, statusReports, maintenances };

--- a/packages/services/src/types.ts
+++ b/packages/services/src/types.ts
@@ -22,7 +22,10 @@ export type {
 
 export type { Page, PageComponent } from "@openstatus/db/src/schema";
 
-export type { Maintenance } from "@openstatus/db/src/schema";
+export type {
+  Maintenance,
+  MaintenanceUpdate,
+} from "@openstatus/db/src/schema";
 
 export type { Incident, Monitor } from "@openstatus/db/src/schema";
 

--- a/packages/services/src/types.ts
+++ b/packages/services/src/types.ts
@@ -22,10 +22,7 @@ export type {
 
 export type { Page, PageComponent } from "@openstatus/db/src/schema";
 
-export type {
-  Maintenance,
-  MaintenanceUpdate,
-} from "@openstatus/db/src/schema";
+export type { Maintenance, MaintenanceUpdate } from "@openstatus/db/src/schema";
 
 export type { Incident, Monitor } from "@openstatus/db/src/schema";
 

--- a/packages/subscriptions/src/channels/email.test.ts
+++ b/packages/subscriptions/src/channels/email.test.ts
@@ -158,7 +158,7 @@ describe("sendEmailNotifications", () => {
     expect(args.idempotencyKey).toMatch(/^status-report-update:77:[0-9a-z]+$/);
   });
 
-  test("falls back to a page-update key when there is no update id (maintenance)", async () => {
+  test("falls back to a page-update key when there is no update id", async () => {
     const sub = makeSub();
     await sendEmailNotifications(
       [sub],

--- a/packages/subscriptions/src/channels/email.ts
+++ b/packages/subscriptions/src/channels/email.ts
@@ -24,9 +24,7 @@ export async function validateEmailConfig(config: unknown) {
   return { valid: email.success, error: email.error?.message };
 }
 
-// Stable per status-report update / maintenance so Resend dedupes the email
-// retry path. Status reports key off the specific update; maintenance has no
-// update row, so fall back to its id + status.
+// Stable per entity update so Resend dedupes the email retry path.
 function idempotencyKeyFor(pageUpdate: PageUpdate): string {
   return pageUpdate.updateId != null
     ? `status-report-update:${pageUpdate.updateId}`

--- a/packages/subscriptions/src/dispatcher.test.ts
+++ b/packages/subscriptions/src/dispatcher.test.ts
@@ -1,6 +1,9 @@
 import "./test-preload.ts";
 import { db, eq } from "@openstatus/db";
 import {
+  maintenance,
+  maintenanceUpdate,
+  maintenancesToPageComponents,
   pageSubscriber,
   pageSubscriberToPageComponent,
 } from "@openstatus/db/src/schema";
@@ -21,7 +24,7 @@ import {
 } from "@std/testing/bdd";
 import { assertSpyCalls, type Stub, stub } from "@std/testing/mock";
 
-import { dispatchPageUpdate } from "./dispatcher";
+import { dispatchMaintenanceUpdate, dispatchPageUpdate } from "./dispatcher";
 import type { PageUpdate } from "./types";
 
 // RESEND_API_KEY is set in test-preload.ts (see bunfig.toml) so @openstatus/emails
@@ -33,7 +36,9 @@ let rejectNextSend: Error | null = null;
 // Built in `beforeAll` — a private page keeps the subscriber set this suite
 // dispatches to independent of anything else running against the database.
 let PAGE_ID: number;
+let WORKSPACE_ID: number;
 let COMPONENT_1: number;
+let COMPONENT_1_NAME: string;
 let COMPONENT_2: number;
 
 const EMAILS = {
@@ -69,8 +74,11 @@ async function cleanAll() {
 
 beforeAll(async () => {
   const { workspace } = await createTestWorkspace();
+  WORKSPACE_ID = workspace.id;
   PAGE_ID = (await createPage(workspace.id)).id;
-  COMPONENT_1 = (await createPageComponent(workspace.id, PAGE_ID)).id;
+  const component1 = await createPageComponent(workspace.id, PAGE_ID);
+  COMPONENT_1 = component1.id;
+  COMPONENT_1_NAME = component1.name;
   COMPONENT_2 = (await createPageComponent(workspace.id, PAGE_ID, { order: 1 }))
     .id;
 
@@ -224,5 +232,56 @@ describe("dispatchPageUpdate - edge cases", () => {
     await expect(
       dispatchPageUpdate(makePageUpdate({ pageComponentIds: [] })),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("dispatchMaintenanceUpdate", () => {
+  test("dispatches the selected update with parent schedule and components", async () => {
+    const startsAt = new Date("2026-08-10T10:00:00.000Z");
+    const endsAt = new Date("2026-08-10T11:00:00.000Z");
+    const occurredAt = new Date("2026-08-07T14:00:00.000Z");
+    const record = await db
+      .insert(maintenance)
+      .values({
+        workspaceId: WORKSPACE_ID,
+        pageId: PAGE_ID,
+        title: "Database maintenance",
+        message: "parent message",
+        from: startsAt,
+        to: endsAt,
+      })
+      .returning()
+      .get();
+
+    try {
+      await db
+        .insert(maintenancesToPageComponents)
+        .values({
+          maintenanceId: record.id,
+          pageComponentId: COMPONENT_1,
+        })
+        .run();
+      const update = await db
+        .insert(maintenanceUpdate)
+        .values({
+          maintenanceId: record.id,
+          message: "specific update message",
+          date: occurredAt,
+        })
+        .returning()
+        .get();
+
+      await dispatchMaintenanceUpdate(update.id);
+
+      const args = sendStatusReportUpdateMock.calls[0].args[0];
+      expect(args.message).toBe("specific update message");
+      expect(args.date).toBe(occurredAt.toISOString());
+      expect(args.pageComponents).toContain(COMPONENT_1_NAME);
+      expect(args.idempotencyKey).toMatch(
+        new RegExp(`^status-report-update:${update.id}:`),
+      );
+    } finally {
+      await db.delete(maintenance).where(eq(maintenance.id, record.id));
+    }
   });
 });

--- a/packages/subscriptions/src/dispatcher.ts
+++ b/packages/subscriptions/src/dispatcher.ts
@@ -1,6 +1,6 @@
 import { and, db, eq, isNotNull, isNull } from "@openstatus/db";
 import {
-  maintenance,
+  maintenanceUpdate,
   page,
   pageSubscriber,
   statusReportUpdate,
@@ -81,42 +81,46 @@ export async function dispatchStatusReportUpdate(statusReportUpdateId: number) {
 /**
  * Dispatch notifications for a maintenance update
  */
-export async function dispatchMaintenanceUpdate(maintenanceId: number) {
-  const maintenanceWithComponents = await db.query.maintenance.findFirst({
-    where: eq(maintenance.id, maintenanceId),
+export async function dispatchMaintenanceUpdate(maintenanceUpdateId: number) {
+  const update = await db.query.maintenanceUpdate.findFirst({
+    where: eq(maintenanceUpdate.id, maintenanceUpdateId),
     with: {
-      maintenancesToPageComponents: {
-        with: { pageComponent: true },
+      maintenance: {
+        with: {
+          maintenancesToPageComponents: {
+            with: { pageComponent: true },
+          },
+        },
       },
     },
   });
 
-  if (!maintenanceWithComponents) {
-    console.error(`Maintenance ${maintenanceId} not found`);
+  if (!update?.maintenance) {
+    console.error(`Maintenance update ${maintenanceUpdateId} not found`);
     return;
   }
 
-  if (!maintenanceWithComponents.pageId) {
-    console.error(`Maintenance ${maintenanceId} has no page ID`);
+  if (!update.maintenance.pageId) {
+    console.error(`Maintenance ${update.maintenance.id} has no page ID`);
     return;
   }
 
-  const pageComponents =
-    maintenanceWithComponents.maintenancesToPageComponents.map(
-      (i) => i.pageComponent,
-    );
+  const pageComponents = update.maintenance.maintenancesToPageComponents.map(
+    (i) => i.pageComponent,
+  );
 
   await dispatchPageUpdate({
-    id: maintenanceWithComponents.id,
-    pageId: maintenanceWithComponents.pageId,
-    title: maintenanceWithComponents.title,
+    id: update.maintenance.id,
+    pageId: update.maintenance.pageId,
+    title: update.maintenance.title,
     status: "maintenance",
-    message: maintenanceWithComponents.message,
+    message: update.message,
     pageComponentIds: pageComponents.map((c) => c.id),
     pageComponents: pageComponents.map((c) => c.name),
-    date: `${maintenanceWithComponents.from.toISOString()} - ${maintenanceWithComponents.to.toISOString()}`,
-    startsAt: maintenanceWithComponents.from.toISOString(),
-    endsAt: maintenanceWithComponents.to.toISOString(),
+    date: update.date.toISOString(),
+    updateId: update.id,
+    startsAt: update.maintenance.from.toISOString(),
+    endsAt: update.maintenance.to.toISOString(),
     pageComponentsWithId: pageComponents.map((c) => ({
       id: c.id,
       name: c.name,

--- a/packages/subscriptions/src/types.ts
+++ b/packages/subscriptions/src/types.ts
@@ -44,7 +44,7 @@ export interface PageUpdate {
   // Optional fields consumed by the prepared (staged) generic webhook payload.
   // Populated by the matching dispatcher; ignored by email/Slack/Discord
   // builders, which key off the fields above.
-  updateId?: number; // statusReportUpdate.id (status reports only)
+  updateId?: number; // entity-specific update row id
   pageComponentsWithId?: { id: number; name: string }[];
   // Current impact per component as of this update (not the raw delta).
   componentsWithImpact?: {

--- a/packages/ui/src/components/blocks/status-events.tsx
+++ b/packages/ui/src/components/blocks/status-events.tsx
@@ -651,6 +651,10 @@ interface StatusMaintenanceUpdate {
   message: string;
   from: Date;
   to: Date;
+  maintenanceUpdates?: {
+    date: Date;
+    message: string;
+  }[];
 }
 
 /**
@@ -697,52 +701,74 @@ export function StatusEventTimelineMaintenance({
     maintenance.from,
     maintenance.to,
   );
+  const updates = [...(maintenance.maintenanceUpdates ?? [])].sort(
+    (a, b) => b.date.getTime() - a.date.getTime(),
+  );
+  const entries =
+    updates.length > 0
+      ? updates
+      : [{ date: maintenance.from, message: maintenance.message }];
+
   return (
     <div
       data-slot="status-event-timeline-maintenance"
       data-variant="maintenance"
-      className="group"
+      className="text-muted-foreground group text-sm"
     >
-      <div className="flex flex-row items-center justify-between gap-2">
-        <div className="flex flex-row gap-4">
-          {withDot ? (
-            <div className="flex flex-col">
-              <div className="flex h-5 flex-col items-center justify-center">
-                <StatusEventTimelineDot />
+      <StatusEventTimelineTitle>
+        <span>{maintenance.title}</span>{" "}
+        <span className="text-muted-foreground/70">·</span>{" "}
+        <span className="text-muted-foreground font-mono text-xs">
+          <StatusTimestamp date={maintenance.from} variant="rich" asChild>
+            <span>{from}</span>
+          </StatusTimestamp>
+          {" - "}
+          <StatusTimestamp date={maintenance.to} variant="rich" asChild>
+            <span>{to}</span>
+          </StatusTimestamp>
+        </span>{" "}
+        {duration ? (
+          <span className="text-muted-foreground/70 font-mono text-xs">
+            {labels.durationFor(duration)}
+          </span>
+        ) : null}
+      </StatusEventTimelineTitle>
+      <div className="mt-2">
+        {entries.map((update, index) => (
+          <div
+            key={`${update.date.getTime()}-${index}`}
+            className="flex flex-row gap-4"
+          >
+            {withDot ? (
+              <div className="flex flex-col">
+                <div className="flex h-5 flex-col items-center justify-center">
+                  <StatusEventTimelineDot />
+                </div>
+                {index !== entries.length - 1 ? (
+                  <StatusEventTimelineSeparator />
+                ) : null}
               </div>
-            </div>
-          ) : null}
-          {/* NOTE: is always last, no need for className="mb-2" */}
-          <div>
-            <StatusEventTimelineTitle>
-              <span>{maintenance.title}</span>{" "}
-              <span className="text-muted-foreground/70">·</span>{" "}
-              <span className="text-muted-foreground font-mono text-xs">
-                <StatusTimestamp date={maintenance.from} variant="rich" asChild>
-                  <span>{from}</span>
-                </StatusTimestamp>
-                {" - "}
-                <StatusTimestamp date={maintenance.to} variant="rich" asChild>
-                  <span>{to}</span>
-                </StatusTimestamp>
-              </span>{" "}
-              {duration ? (
-                <span className="text-muted-foreground/70 font-mono text-xs">
-                  {labels.durationFor(duration)}
+            ) : null}
+            <div className={cn(index === entries.length - 1 ? "mb-0" : "mb-2")}>
+              <StatusEventTimelineTitle>
+                <span className="text-muted-foreground font-mono text-xs">
+                  <StatusTimestamp date={update.date} variant="rich" asChild>
+                    <span>{labels.formatDateTime(update.date)}</span>
+                  </StatusTimestamp>
                 </span>
-              ) : null}
-            </StatusEventTimelineTitle>
-            <StatusEventTimelineMessage>
-              {maintenance.message.trim() === "" ? (
-                <span className="text-muted-foreground/70">-</span>
-              ) : renderMessage ? (
-                renderMessage(maintenance.message)
-              ) : (
-                maintenance.message
-              )}
-            </StatusEventTimelineMessage>
+              </StatusEventTimelineTitle>
+              <StatusEventTimelineMessage>
+                {update.message.trim() === "" ? (
+                  <span className="text-muted-foreground/70">-</span>
+                ) : renderMessage ? (
+                  renderMessage(update.message)
+                ) : (
+                  update.message
+                )}
+              </StatusEventTimelineMessage>
+            </div>
           </div>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/packages/ui/src/components/blocks/status-feed.tsx
+++ b/packages/ui/src/components/blocks/status-feed.tsx
@@ -277,6 +277,7 @@ export function StatusFeed({
                   maintenance={{
                     title: maintenance.title,
                     message: maintenance.message,
+                    maintenanceUpdates: maintenance.maintenanceUpdates,
                     from: maintenance.from,
                     to: maintenance.to,
                   }}

--- a/packages/ui/src/components/blocks/status.types.ts
+++ b/packages/ui/src/components/blocks/status.types.ts
@@ -36,6 +36,10 @@ export interface Maintenance {
   title: string;
   affected: string[];
   message: string;
+  maintenanceUpdates?: {
+    date: Date;
+    message: string;
+  }[];
   from: Date;
   to: Date;
 }


### PR DESCRIPTION
## Summary
- Add chronological maintenance updates (create/edit/delete) across services, tRPC, REST, RPC/MCP, and the dashboard UI
- Surface updates on public status-page feeds (markdown/JSON) and in subscriber email notifications
- Include DB migration, OpenAPI/proto definitions, agent tools, and audit logging for the new verbs

## Test plan
- [ ] Create a maintenance and add/edit/delete updates from the dashboard detail page
- [ ] Verify updates appear on the public status page feed (JSON + markdown)
- [ ] Confirm subscriber notifications include maintenance update content
- [ ] Exercise REST `/v1/maintenance-updates` and RPC/MCP tools with read/write scopes
- [ ] Run maintenance service and API tests (`packages/services`, `packages/api`, `apps/server`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

