### PR TITLE
docs: server and db scripts run on Deno, not Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ ghcr.io/openstatushq/openstatus-checker:latest
 - [Node.js](https://nodejs.org/en/) >= 20.0.0
 - [pnpm](https://pnpm.io/) >= 10.26.0
 - [Bun](https://bun.sh/)
+- [Deno](https://deno.com/)
 - [Turso CLI](https://docs.turso.tech/quickstart).
 
 #### Dashboard

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -7,6 +7,7 @@
 - [Node.js](https://nodejs.org/en/) >= 20.0.0 — runtime
 - [pnpm](https://pnpm.io/) >= 8 — monorepo package manager (see root `package.json` for pinned version)
 - [Deno](https://deno.com/) — runs the db env/migrate/seed scripts in `packages/db`
+- [Bun](https://bun.sh/) — optional, used by the utility scripts in `src/scripts`
 - [Turso CLI](https://docs.turso.tech/quickstart) — starts the local libSQL server via `pnpm --filter '@openstatus/db' dev`
 
 ### Environment

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -6,7 +6,7 @@
 
 - [Node.js](https://nodejs.org/en/) >= 20.0.0 — runtime
 - [pnpm](https://pnpm.io/) >= 8 — monorepo package manager (see root `package.json` for pinned version)
-- [Bun](https://bun.sh/) — runs the db env/migrate/seed scripts in `packages/db`
+- [Deno](https://deno.com/) — runs the db env/migrate/seed scripts in `packages/db`
 - [Turso CLI](https://docs.turso.tech/quickstart) — starts the local libSQL server via `pnpm --filter '@openstatus/db' dev`
 
 ### Environment

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -2,7 +2,7 @@
 
 ## Tech
 
-- Bun
+- Deno
 - HonoJS
 
 ## Deploy

--- a/apps/workflows/README.md
+++ b/apps/workflows/README.md
@@ -5,13 +5,13 @@
 To install dependencies:
 
 ```sh
-bun install
+pnpm install
 ```
 
 To run:
 
 ```sh
-bun run dev
+pnpm dev
 ```
 
 open <http://localhost:3000>


### PR DESCRIPTION
Two small corrections after the Bun-to-Deno migration:

- `apps/server/README.md` lists Bun under Tech, but the server runs entirely on Deno now — every script in `apps/server/package.json` is `deno run`/`deno test`, and the Dockerfile builds from `denoland/deno` and ships a `deno compile` binary.
- `apps/dashboard/README.md` says Bun runs the db env/migrate/seed scripts, but all of `packages/db`'s scripts are `deno run` too.

Left the root README's Bun requirement alone since Bun is still genuinely used there (root `env` script and `apps/screenshot-service`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

