### PR TITLE
Add SSRF protection to monitor URL validation

### DIFF
--- a/apps/server/src/routes/rpc/handlers/monitor/__tests__/monitor.test.ts
+++ b/apps/server/src/routes/rpc/handlers/monitor/__tests__/monitor.test.ts
@@ -1361,6 +1361,7 @@ describe("MonitorService - private and internal URLs", () => {
             name: `${TEST_PREFIX}-ssrf`,
             url,
             periodicity: "PERIODICITY_5M",
+            method: "HTTP_METHOD_GET",
           },
         },
         { "x-openstatus-key": "1" },

--- a/apps/server/src/routes/rpc/handlers/monitor/__tests__/monitor.test.ts
+++ b/apps/server/src/routes/rpc/handlers/monitor/__tests__/monitor.test.ts
@@ -1343,6 +1343,96 @@ describe("MonitorService.UpdateDNSMonitor", () => {
   });
 });
 
+describe("MonitorService - private and internal URLs", () => {
+  // Valid URIs, so protovalidate passes them through to the service guard.
+  const BLOCKED = [
+    "http://localhost:3000",
+    "http://127.0.0.1/health",
+    "http://192.168.1.10/",
+    "http://169.254.169.254/latest/meta-data/",
+  ];
+
+  for (const url of BLOCKED) {
+    test(`CreateHTTPMonitor rejects ${url}`, async () => {
+      const res = await connectRequest(
+        "CreateHTTPMonitor",
+        {
+          monitor: {
+            name: `${TEST_PREFIX}-ssrf`,
+            url,
+            periodicity: "PERIODICITY_5M",
+          },
+        },
+        { "x-openstatus-key": "1" },
+      );
+
+      expect(res.status).toBe(400);
+
+      const data = await res.json();
+      expect(data.message).toContain("private or internal");
+
+      const leaked = await db
+        .select()
+        .from(monitor)
+        .where(and(eq(monitor.workspaceId, 1), eq(monitor.url, url)))
+        .get();
+      expect(leaked).toBeUndefined();
+    });
+  }
+
+  test("UpdateHTTPMonitor rejects a private URL and leaves the stored one intact", async () => {
+    const before = await db
+      .select()
+      .from(monitor)
+      .where(eq(monitor.id, testHttpMonitorId))
+      .get();
+
+    const res = await connectRequest(
+      "UpdateHTTPMonitor",
+      {
+        id: String(testHttpMonitorId),
+        monitor: { url: "http://127.0.0.1:8080" },
+      },
+      { "x-openstatus-key": "1" },
+    );
+
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.message).toContain("private or internal");
+
+    const after = await db
+      .select()
+      .from(monitor)
+      .where(eq(monitor.id, testHttpMonitorId))
+      .get();
+    expect(after?.url).toBe(before?.url);
+  });
+
+  test("CreateTCPMonitor accepts a private target", async () => {
+    const res = await connectRequest(
+      "CreateTCPMonitor",
+      {
+        monitor: {
+          name: `${TEST_PREFIX}-ssrf-tcp`,
+          uri: "192.168.1.10:8080",
+          periodicity: "PERIODICITY_10M",
+        },
+      },
+      { "x-openstatus-key": "1" },
+    );
+
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.monitor.uri).toBe("192.168.1.10:8080");
+
+    if (data.monitor.id) {
+      await db.delete(monitor).where(eq(monitor.id, Number(data.monitor.id)));
+    }
+  });
+});
+
 describe("MonitorService.TriggerMonitor", () => {
   test("returns 404 for non-existent monitor", async () => {
     const res = await connectRequest(

--- a/apps/server/src/routes/v1/check/http/post.test.ts
+++ b/apps/server/src/routes/v1/check/http/post.test.ts
@@ -79,6 +79,30 @@ test("Create a single check  ", async () => {
   });
 });
 
+for (const url of [
+  "http://localhost:3000",
+  "http://127.0.0.1/health",
+  "http://192.168.1.10/",
+  "http://169.254.169.254/latest/meta-data/",
+]) {
+  test(`rejects a check against ${url} without probing it`, async () => {
+    const res = await app.request("/v1/check/http", {
+      method: "POST",
+      headers: {
+        "x-openstatus-key": "1",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ url, regions: ["ams"], method: "GET" }),
+    });
+
+    expect(res.status).toBe(400);
+    // Pin the reason so a schema change can't turn this into a passing
+    // test that never reaches the guard.
+    expect((await res.json()).message).toContain("private or internal");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+}
+
 test("Create a multiple check", async () => {
   const data = {
     url: "https://www.openstatus.dev",

--- a/apps/server/src/routes/v1/check/http/post.ts
+++ b/apps/server/src/routes/v1/check/http/post.ts
@@ -7,6 +7,7 @@ import percentile from "percentile";
 import { env } from "@/env";
 import { openApiErrorResponses } from "@/libs/errors";
 
+import { assertSafeMonitorUrl } from "../../monitors/utils";
 import type { checkApi } from "../index";
 
 const logger = getLogger("api-server");
@@ -53,6 +54,9 @@ export function registerHTTPPostCheck(api: typeof checkApi) {
     const input = c.req.valid("json");
 
     const { headers, regions, runCount, aggregated, ...rest } = data;
+
+    // Guard before the insert so a rejected target leaves no `check` row.
+    assertSafeMonitorUrl({ jobType: "http", url: data.url });
 
     const newCheck = await db
       .insert(check)

--- a/apps/server/src/routes/v1/monitors/post.ts
+++ b/apps/server/src/routes/v1/monitors/post.ts
@@ -9,7 +9,7 @@ import { trackMiddleware } from "@/libs/middlewares";
 
 import type { monitorsApi } from "./index";
 import { MonitorSchema } from "./schema";
-import { getAssertions } from "./utils";
+import { assertSafeMonitorUrl, getAssertions } from "./utils";
 
 const postRoute = createRoute({
   method: "post",
@@ -92,6 +92,13 @@ export function registerPostMonitor(api: typeof monitorsApi) {
           "Invalid jobType, currently only 'http' and 'tcp' are supported",
       });
     }
+
+    // `jobType` is nullable on the wire; the column defaults to "http".
+    await assertSafeMonitorUrl({
+      workspaceId,
+      jobType: input.jobType ?? "http",
+      url: input.url,
+    });
 
     const { headers, regions, assertions, ...rest } = input;
 

--- a/apps/server/src/routes/v1/monitors/post.ts
+++ b/apps/server/src/routes/v1/monitors/post.ts
@@ -94,11 +94,7 @@ export function registerPostMonitor(api: typeof monitorsApi) {
     }
 
     // `jobType` is nullable on the wire; the column defaults to "http".
-    await assertSafeMonitorUrl({
-      workspaceId,
-      jobType: input.jobType ?? "http",
-      url: input.url,
-    });
+    assertSafeMonitorUrl({ jobType: input.jobType ?? "http", url: input.url });
 
     const { headers, regions, assertions, ...rest } = input;
 

--- a/apps/server/src/routes/v1/monitors/post_http.ts
+++ b/apps/server/src/routes/v1/monitors/post_http.ts
@@ -9,7 +9,7 @@ import { trackMiddleware } from "@/libs/middlewares";
 
 import type { monitorsApi } from "./index";
 import { HTTPMonitorSchema, MonitorSchema } from "./schema";
-import { getAssertionNew } from "./utils";
+import { assertSafeMonitorUrl, getAssertionNew } from "./utils";
 
 const postRoute = createRoute({
   method: "post",
@@ -84,6 +84,12 @@ export function registerPostMonitorHTTP(api: typeof monitorsApi) {
         });
       }
     }
+
+    await assertSafeMonitorUrl({
+      workspaceId,
+      jobType: "http",
+      url: input.request.url,
+    });
 
     const { request, regions, assertions, openTelemetry, ...rest } = input;
 

--- a/apps/server/src/routes/v1/monitors/post_http.ts
+++ b/apps/server/src/routes/v1/monitors/post_http.ts
@@ -85,11 +85,7 @@ export function registerPostMonitorHTTP(api: typeof monitorsApi) {
       }
     }
 
-    await assertSafeMonitorUrl({
-      workspaceId,
-      jobType: "http",
-      url: input.request.url,
-    });
+    assertSafeMonitorUrl({ jobType: "http", url: input.request.url });
 
     const { request, regions, assertions, openTelemetry, ...rest } = input;
 

--- a/apps/server/src/routes/v1/monitors/put.ts
+++ b/apps/server/src/routes/v1/monitors/put.ts
@@ -9,7 +9,7 @@ import { trackMiddleware } from "@/libs/middlewares";
 
 import type { monitorsApi } from "./index";
 import { MonitorSchema, ParamsSchema } from "./schema";
-import { getAssertions } from "./utils";
+import { assertSafeMonitorUrl, getAssertions } from "./utils";
 
 const putRoute = createRoute({
   method: "put",
@@ -97,6 +97,15 @@ export function registerPutMonitor(api: typeof monitorsApi) {
         code: "BAD_REQUEST",
         message:
           "Cannot change jobType. Please delete and create a new monitor instead.",
+      });
+    }
+
+    if (input.url !== undefined) {
+      await assertSafeMonitorUrl({
+        workspaceId,
+        monitorId: _monitor.id,
+        jobType: _monitor.jobType,
+        url: input.url,
       });
     }
 

--- a/apps/server/src/routes/v1/monitors/put.ts
+++ b/apps/server/src/routes/v1/monitors/put.ts
@@ -101,12 +101,7 @@ export function registerPutMonitor(api: typeof monitorsApi) {
     }
 
     if (input.url !== undefined) {
-      await assertSafeMonitorUrl({
-        workspaceId,
-        monitorId: _monitor.id,
-        jobType: _monitor.jobType,
-        url: input.url,
-      });
+      assertSafeMonitorUrl({ jobType: _monitor.jobType, url: input.url });
     }
 
     const { headers, regions, assertions, ...rest } = input;

--- a/apps/server/src/routes/v1/monitors/put_http.ts
+++ b/apps/server/src/routes/v1/monitors/put_http.ts
@@ -9,7 +9,7 @@ import { trackMiddleware } from "@/libs/middlewares";
 
 import type { monitorsApi } from "./index";
 import { HTTPMonitorSchema, MonitorSchema, ParamsSchema } from "./schema";
-import { getAssertionNew } from "./utils";
+import { assertSafeMonitorUrl, getAssertionNew } from "./utils";
 
 const putRoute = createRoute({
   method: "put",
@@ -91,6 +91,13 @@ export function registerPutHTTPMonitor(api: typeof monitorsApi) {
         message: `Monitor ${id} not found`,
       });
     }
+
+    await assertSafeMonitorUrl({
+      workspaceId,
+      monitorId: _monitor.id,
+      jobType: "http",
+      url: input.request.url,
+    });
 
     const { request, regions, assertions, openTelemetry, ...rest } = input;
 

--- a/apps/server/src/routes/v1/monitors/put_http.ts
+++ b/apps/server/src/routes/v1/monitors/put_http.ts
@@ -92,12 +92,7 @@ export function registerPutHTTPMonitor(api: typeof monitorsApi) {
       });
     }
 
-    await assertSafeMonitorUrl({
-      workspaceId,
-      monitorId: _monitor.id,
-      jobType: "http",
-      url: input.request.url,
-    });
+    assertSafeMonitorUrl({ jobType: "http", url: input.request.url });
 
     const { request, regions, assertions, openTelemetry, ...rest } = input;
 

--- a/apps/server/src/routes/v1/monitors/utils.ts
+++ b/apps/server/src/routes/v1/monitors/utils.ts
@@ -4,7 +4,6 @@ import {
   StatusAssertion,
   TextBodyAssertion,
 } from "@openstatus/assertions";
-import { db } from "@openstatus/db";
 import { ServiceError } from "@openstatus/services";
 import { assertMonitorUrlSafe } from "@openstatus/services/monitor";
 import type { z } from "zod";
@@ -17,14 +16,12 @@ import type { assertion, assertionsSchema } from "./schema";
  * These routes write to the DB directly instead of going through
  * `@openstatus/services`, so the SSRF guard has to be invoked by hand.
  */
-export async function assertSafeMonitorUrl(args: {
-  workspaceId: number;
+export function assertSafeMonitorUrl(args: {
   jobType: string;
   url: string;
-  monitorId?: number;
-}): Promise<void> {
+}): void {
   try {
-    await assertMonitorUrlSafe({ tx: db, ...args });
+    assertMonitorUrlSafe(args);
   } catch (err) {
     if (err instanceof ServiceError) {
       throw new OpenStatusApiError({

--- a/apps/server/src/routes/v1/monitors/utils.ts
+++ b/apps/server/src/routes/v1/monitors/utils.ts
@@ -4,9 +4,37 @@ import {
   StatusAssertion,
   TextBodyAssertion,
 } from "@openstatus/assertions";
+import { db } from "@openstatus/db";
+import { ServiceError } from "@openstatus/services";
+import { assertMonitorUrlSafe } from "@openstatus/services/monitor";
 import type { z } from "zod";
 
+import { OpenStatusApiError } from "@/libs/errors";
+
 import type { assertion, assertionsSchema } from "./schema";
+
+/**
+ * These routes write to the DB directly instead of going through
+ * `@openstatus/services`, so the SSRF guard has to be invoked by hand.
+ */
+export async function assertSafeMonitorUrl(args: {
+  workspaceId: number;
+  jobType: string;
+  url: string;
+  monitorId?: number;
+}): Promise<void> {
+  try {
+    await assertMonitorUrlSafe({ tx: db, ...args });
+  } catch (err) {
+    if (err instanceof ServiceError) {
+      throw new OpenStatusApiError({
+        code: "BAD_REQUEST",
+        message: err.message,
+      });
+    }
+    throw err;
+  }
+}
 
 export const getAssertions = (
   assertions: z.infer<typeof assertion>[],

--- a/packages/services/src/monitor/__tests__/url-safety.test.ts
+++ b/packages/services/src/monitor/__tests__/url-safety.test.ts
@@ -1,0 +1,157 @@
+import {
+  privateLocation,
+  privateLocationToMonitors,
+  selectWorkspaceSchema,
+} from "@openstatus/db/src/schema";
+import { createWorkspace } from "@openstatus/db/src/test/factories";
+import { expect } from "@std/expect";
+import { beforeAll, describe, test } from "@std/testing/bdd";
+
+import { makeUserCtx, withTestTransaction } from "../../../test/helpers";
+import type { ServiceContext } from "../../context";
+import { ValidationError } from "../../errors";
+import { createMonitor } from "../create";
+import { updateMonitorConfig, updateMonitorGeneral } from "../update";
+
+const TEST_PREFIX = "svc-monitor-url-safety";
+
+let ctx: ServiceContext;
+
+beforeAll(async () => {
+  const ws = selectWorkspaceSchema.parse(await createWorkspace());
+  ctx = makeUserCtx(ws, { userId: 1 });
+});
+
+const BLOCKED = [
+  "http://localhost:3000",
+  "http://127.0.0.1/health",
+  "http://192.168.1.10/",
+  "http://10.0.0.1/",
+  "http://172.16.0.1/",
+  "http://169.254.169.254/latest/meta-data/",
+  "http://metadata.google.internal/",
+  "http://[::1]/",
+  "http://[::ffff:7f00:1]/",
+];
+
+function httpInput(url: string) {
+  return {
+    name: `${TEST_PREFIX}-monitor`,
+    jobType: "http" as const,
+    url,
+    method: "GET" as const,
+    headers: [],
+    assertions: [],
+    active: false,
+  };
+}
+
+describe("monitor url SSRF guard", () => {
+  test("createMonitor rejects private and internal http targets", async () => {
+    for (const url of BLOCKED) {
+      await withTestTransaction(async (tx) => {
+        await expect(
+          createMonitor({ ctx: { ...ctx, db: tx }, input: httpInput(url) }),
+        ).rejects.toThrow(ValidationError);
+      });
+    }
+  });
+
+  test("createMonitor allows public http targets", async () => {
+    await withTestTransaction(async (tx) => {
+      const row = await createMonitor({
+        ctx: { ...ctx, db: tx },
+        input: httpInput("https://example.com/health"),
+      });
+      expect(row.url).toBe("https://example.com/health");
+    });
+  });
+
+  test("tcp and dns monitors are not url-checked", async () => {
+    await withTestTransaction(async (tx) => {
+      const tcp = await createMonitor({
+        ctx: { ...ctx, db: tx },
+        input: { ...httpInput("127.0.0.1:8080"), jobType: "tcp" },
+      });
+      expect(tcp.url).toBe("127.0.0.1:8080");
+
+      const dns = await createMonitor({
+        ctx: { ...ctx, db: tx },
+        input: { ...httpInput("localhost"), jobType: "dns" },
+      });
+      expect(dns.url).toBe("localhost");
+    });
+  });
+
+  test("updateMonitorGeneral rejects a private target", async () => {
+    await withTestTransaction(async (tx) => {
+      const created = await createMonitor({
+        ctx: { ...ctx, db: tx },
+        input: httpInput("https://example.com"),
+      });
+
+      await expect(
+        updateMonitorGeneral({
+          ctx: { ...ctx, db: tx },
+          input: {
+            id: created.id,
+            name: created.name,
+            jobType: "http",
+            url: "http://127.0.0.1:8080",
+            method: "GET",
+            headers: [],
+            assertions: [],
+            active: false,
+          },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  test("updateMonitorConfig rejects a private target using the stored jobType", async () => {
+    await withTestTransaction(async (tx) => {
+      const created = await createMonitor({
+        ctx: { ...ctx, db: tx },
+        input: httpInput("https://example.com"),
+      });
+
+      await expect(
+        updateMonitorConfig({
+          ctx: { ...ctx, db: tx },
+          input: { id: created.id, url: "http://localhost:3000" },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  test("a monitor attached to a private location may target an internal host", async () => {
+    await withTestTransaction(async (tx) => {
+      const created = await createMonitor({
+        ctx: { ...ctx, db: tx },
+        input: httpInput("https://example.com"),
+      });
+
+      const location = await tx
+        .insert(privateLocation)
+        .values({
+          name: `${TEST_PREFIX}-location`,
+          token: `${TEST_PREFIX}-token`,
+          workspaceId: ctx.workspace.id,
+        })
+        .returning()
+        .get();
+
+      await tx.insert(privateLocationToMonitors).values({
+        privateLocationId: location.id,
+        monitorId: created.id,
+      });
+
+      const updated = await updateMonitorConfig({
+        ctx: { ...ctx, db: tx },
+        input: { id: created.id, url: "http://10.0.0.5:8080/health" },
+      });
+
+      expect(updated.url).toBe("http://10.0.0.5:8080/health");
+    });
+  });
+});

--- a/packages/services/src/monitor/__tests__/url-safety.test.ts
+++ b/packages/services/src/monitor/__tests__/url-safety.test.ts
@@ -1,8 +1,4 @@
-import {
-  privateLocation,
-  privateLocationToMonitors,
-  selectWorkspaceSchema,
-} from "@openstatus/db/src/schema";
+import { selectWorkspaceSchema } from "@openstatus/db/src/schema";
 import { createWorkspace } from "@openstatus/db/src/test/factories";
 import { expect } from "@std/expect";
 import { beforeAll, describe, test } from "@std/testing/bdd";
@@ -124,34 +120,19 @@ describe("monitor url SSRF guard", () => {
     });
   });
 
-  test("a monitor attached to a private location may target an internal host", async () => {
+  test("updateMonitorConfig leaves tcp urls alone", async () => {
     await withTestTransaction(async (tx) => {
       const created = await createMonitor({
         ctx: { ...ctx, db: tx },
-        input: httpInput("https://example.com"),
-      });
-
-      const location = await tx
-        .insert(privateLocation)
-        .values({
-          name: `${TEST_PREFIX}-location`,
-          token: `${TEST_PREFIX}-token`,
-          workspaceId: ctx.workspace.id,
-        })
-        .returning()
-        .get();
-
-      await tx.insert(privateLocationToMonitors).values({
-        privateLocationId: location.id,
-        monitorId: created.id,
+        input: { ...httpInput("example.com:443"), jobType: "tcp" },
       });
 
       const updated = await updateMonitorConfig({
         ctx: { ...ctx, db: tx },
-        input: { id: created.id, url: "http://10.0.0.5:8080/health" },
+        input: { id: created.id, url: "10.0.0.5:8080" },
       });
 
-      expect(updated.url).toBe("http://10.0.0.5:8080/health");
+      expect(updated.url).toBe("10.0.0.5:8080");
     });
   });
 });

--- a/packages/services/src/monitor/create.ts
+++ b/packages/services/src/monitor/create.ts
@@ -11,6 +11,7 @@ import {
   serialiseAssertions,
 } from "./internal";
 import { CreateMonitorInput } from "./schemas";
+import { assertMonitorUrlSafe } from "./url-safety";
 
 export async function createMonitor(args: {
   ctx: ServiceContext;
@@ -21,6 +22,15 @@ export async function createMonitor(args: {
   const input = CreateMonitorInput.parse(args.input);
 
   return withTransaction(ctx, async (tx) => {
+    // No monitor id yet, so no private-location exemption is possible here —
+    // attach the location first, then point the monitor at the internal host.
+    await assertMonitorUrlSafe({
+      tx,
+      workspaceId: ctx.workspace.id,
+      jobType: input.jobType,
+      url: input.url,
+    });
+
     await assertWithinLimit({
       tx,
       workspaceId: ctx.workspace.id,

--- a/packages/services/src/monitor/create.ts
+++ b/packages/services/src/monitor/create.ts
@@ -21,16 +21,9 @@ export async function createMonitor(args: {
   requireScope(ctx, "write");
   const input = CreateMonitorInput.parse(args.input);
 
-  return withTransaction(ctx, async (tx) => {
-    // No monitor id yet, so no private-location exemption is possible here —
-    // attach the location first, then point the monitor at the internal host.
-    await assertMonitorUrlSafe({
-      tx,
-      workspaceId: ctx.workspace.id,
-      jobType: input.jobType,
-      url: input.url,
-    });
+  assertMonitorUrlSafe({ jobType: input.jobType, url: input.url });
 
+  return withTransaction(ctx, async (tx) => {
     await assertWithinLimit({
       tx,
       workspaceId: ctx.workspace.id,

--- a/packages/services/src/monitor/index.ts
+++ b/packages/services/src/monitor/index.ts
@@ -39,6 +39,7 @@ export {
   streamMonitorPreview,
 } from "./stream-monitor-preview";
 export { triggerMonitorRun, type TriggerMonitorResult } from "./trigger";
+export { assertMonitorUrlSafe } from "./url-safety";
 export {
   bulkUpdateMonitors,
   updateMonitorConfig,

--- a/packages/services/src/monitor/update.ts
+++ b/packages/services/src/monitor/update.ts
@@ -20,6 +20,7 @@ import {
   UpdateMonitorResponseTimeInput,
   UpdateMonitorRetryInput,
 } from "./schemas";
+import { assertMonitorUrlSafe } from "./url-safety";
 
 /**
  * Apply a whole-object patch in a single UPDATE. `undefined` fields are
@@ -39,6 +40,17 @@ export async function updateMonitorConfig(args: {
       id: input.id,
       workspaceId: ctx.workspace.id,
     });
+
+    if (input.url !== undefined) {
+      // `jobType` is absent from this patch, so the stored type decides.
+      await assertMonitorUrlSafe({
+        tx,
+        workspaceId: ctx.workspace.id,
+        monitorId: existing.id,
+        jobType: existing.jobType,
+        url: input.url,
+      });
+    }
 
     const values: Record<string, unknown> = { updatedAt: new Date() };
     if (input.name !== undefined) values.name = input.name;
@@ -109,6 +121,14 @@ export async function updateMonitorGeneral(args: {
       tx,
       id: input.id,
       workspaceId: ctx.workspace.id,
+    });
+
+    await assertMonitorUrlSafe({
+      tx,
+      workspaceId: ctx.workspace.id,
+      monitorId: existing.id,
+      jobType: input.jobType,
+      url: input.url,
     });
 
     const updated = await tx

--- a/packages/services/src/monitor/update.ts
+++ b/packages/services/src/monitor/update.ts
@@ -43,13 +43,7 @@ export async function updateMonitorConfig(args: {
 
     if (input.url !== undefined) {
       // `jobType` is absent from this patch, so the stored type decides.
-      await assertMonitorUrlSafe({
-        tx,
-        workspaceId: ctx.workspace.id,
-        monitorId: existing.id,
-        jobType: existing.jobType,
-        url: input.url,
-      });
+      assertMonitorUrlSafe({ jobType: existing.jobType, url: input.url });
     }
 
     const values: Record<string, unknown> = { updatedAt: new Date() };
@@ -115,20 +109,13 @@ export async function updateMonitorGeneral(args: {
   const { ctx } = args;
   requireScope(ctx, "write");
   const input = UpdateMonitorGeneralInput.parse(args.input);
+  assertMonitorUrlSafe({ jobType: input.jobType, url: input.url });
 
   return withTransaction(ctx, async (tx) => {
     const existing = await getMonitorInWorkspace({
       tx,
       id: input.id,
       workspaceId: ctx.workspace.id,
-    });
-
-    await assertMonitorUrlSafe({
-      tx,
-      workspaceId: ctx.workspace.id,
-      monitorId: existing.id,
-      jobType: input.jobType,
-      url: input.url,
     });
 
     const updated = await tx

--- a/packages/services/src/monitor/url-safety.ts
+++ b/packages/services/src/monitor/url-safety.ts
@@ -1,0 +1,73 @@
+import { and, eq, isNull } from "@openstatus/db";
+import {
+  monitor,
+  privateLocation,
+  privateLocationToMonitors,
+} from "@openstatus/db/src/schema";
+import { assertSafeUrlSync } from "@openstatus/utils";
+
+import type { DB } from "../context";
+import { ValidationError } from "../errors";
+
+async function hasPrivateLocation(args: {
+  tx: DB;
+  workspaceId: number;
+  monitorId: number;
+}): Promise<boolean> {
+  const { tx, workspaceId, monitorId } = args;
+  const row = await tx
+    .select({ id: privateLocationToMonitors.privateLocationId })
+    .from(privateLocationToMonitors)
+    .innerJoin(
+      privateLocation,
+      eq(privateLocationToMonitors.privateLocationId, privateLocation.id),
+    )
+    .innerJoin(monitor, eq(privateLocationToMonitors.monitorId, monitor.id))
+    .where(
+      and(
+        eq(privateLocationToMonitors.monitorId, monitorId),
+        eq(privateLocation.workspaceId, workspaceId),
+        eq(monitor.workspaceId, workspaceId),
+        isNull(privateLocationToMonitors.deletedAt),
+        isNull(monitor.deletedAt),
+      ),
+    )
+    .get();
+  return row !== undefined;
+}
+
+/**
+ * Reject monitor URLs pointing at private/internal infrastructure.
+ *
+ * Only `http` is checked: TCP takes `host:port` and DNS a bare hostname,
+ * neither of which parses as a URL, and TCP documents private targets as a
+ * supported input. Monitors attached to a private location are exempt — those
+ * probes run inside the customer's own network, where an internal target is
+ * the whole point.
+ */
+export async function assertMonitorUrlSafe(args: {
+  tx: DB;
+  workspaceId: number;
+  jobType: string;
+  url: string;
+  monitorId?: number;
+}): Promise<void> {
+  const { tx, workspaceId, jobType, url, monitorId } = args;
+  if (jobType !== "http") return;
+
+  if (
+    monitorId !== undefined &&
+    (await hasPrivateLocation({ tx, workspaceId, monitorId }))
+  ) {
+    return;
+  }
+
+  try {
+    assertSafeUrlSync(url);
+  } catch (err) {
+    throw new ValidationError(
+      err instanceof Error ? err.message : "Invalid URL",
+      err,
+    );
+  }
+}

--- a/packages/services/src/monitor/url-safety.ts
+++ b/packages/services/src/monitor/url-safety.ts
@@ -1,69 +1,22 @@
-import { and, eq, isNull } from "@openstatus/db";
-import {
-  monitor,
-  privateLocation,
-  privateLocationToMonitors,
-} from "@openstatus/db/src/schema";
 import { assertSafeUrlSync } from "@openstatus/utils";
 
-import type { DB } from "../context";
 import { ValidationError } from "../errors";
-
-async function hasPrivateLocation(args: {
-  tx: DB;
-  workspaceId: number;
-  monitorId: number;
-}): Promise<boolean> {
-  const { tx, workspaceId, monitorId } = args;
-  const row = await tx
-    .select({ id: privateLocationToMonitors.privateLocationId })
-    .from(privateLocationToMonitors)
-    .innerJoin(
-      privateLocation,
-      eq(privateLocationToMonitors.privateLocationId, privateLocation.id),
-    )
-    .innerJoin(monitor, eq(privateLocationToMonitors.monitorId, monitor.id))
-    .where(
-      and(
-        eq(privateLocationToMonitors.monitorId, monitorId),
-        eq(privateLocation.workspaceId, workspaceId),
-        eq(monitor.workspaceId, workspaceId),
-        isNull(privateLocationToMonitors.deletedAt),
-        isNull(monitor.deletedAt),
-      ),
-    )
-    .get();
-  return row !== undefined;
-}
 
 /**
  * Reject monitor URLs pointing at private/internal infrastructure.
  *
  * Only `http` is checked: TCP takes `host:port` and DNS a bare hostname,
  * neither of which parses as a URL, and TCP documents private targets as a
- * supported input. Monitors attached to a private location are exempt — those
- * probes run inside the customer's own network, where an internal target is
- * the whole point.
+ * supported input.
  */
-export async function assertMonitorUrlSafe(args: {
-  tx: DB;
-  workspaceId: number;
+export function assertMonitorUrlSafe(args: {
   jobType: string;
   url: string;
-  monitorId?: number;
-}): Promise<void> {
-  const { tx, workspaceId, jobType, url, monitorId } = args;
-  if (jobType !== "http") return;
-
-  if (
-    monitorId !== undefined &&
-    (await hasPrivateLocation({ tx, workspaceId, monitorId }))
-  ) {
-    return;
-  }
+}): void {
+  if (args.jobType !== "http") return;
 
   try {
-    assertSafeUrlSync(url);
+    assertSafeUrlSync(args.url);
   } catch (err) {
     throw new ValidationError(
       err instanceof Error ? err.message : "Invalid URL",


### PR DESCRIPTION
## Summary

Adds Server-Side Request Forgery (SSRF) protection to monitor creation and updates by validating that HTTP monitor URLs do not target private or internal infrastructure (localhost, private IP ranges, cloud metadata endpoints, etc.).

## Changes

- **New module `packages/services/src/monitor/url-safety.ts`**: Exports `assertMonitorUrlSafe()` which validates HTTP monitor URLs against a blocklist of private/internal targets. Only HTTP monitors are checked; TCP and DNS monitors accept any input as documented.

- **Service layer integration**: 
  - `createMonitor()` now validates URLs before persisting
  - `updateMonitorGeneral()` validates the full input including jobType
  - `updateMonitorConfig()` validates URLs using the stored jobType (since jobType is not provided in partial updates)

- **API route integration**: Added `assertSafeMonitorUrl()` helper in `apps/server/src/routes/v1/monitors/utils.ts` to invoke the service-layer guard in routes that write directly to the database (POST/PUT monitor endpoints). This ensures protection across all entry points.

- **Comprehensive test coverage**: New test suite in `packages/services/src/monitor/__tests__/url-safety.test.ts` validates:
  - Rejection of blocked URLs (localhost, 127.0.0.1, private IP ranges, cloud metadata endpoints, IPv6 loopback)
  - Acceptance of public URLs
  - TCP/DNS monitors bypass URL validation
  - Both create and update operations enforce the guard

## Implementation Details

- Delegates actual URL validation to `@openstatus/utils.assertSafeUrlSync()` and wraps errors as `ValidationError`
- Only applies to `jobType: "http"` — TCP and DNS monitors are not URL-checked since they use different input formats (host:port and bare hostname respectively)
- Follows the services pattern: validation happens in the service layer, with manual invocation in API routes that bypass services

https://claude.ai/code/session_017KkPULrJ15gRP4TUoxVmFD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

