### PR TITLE
Redirect root path to overview in dashboard

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -40,6 +40,11 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
+        source: "/",
+        destination: "/overview",
+        permanent: false,
+      },
+      {
         source: "/private-locations",
         destination: "/settings/private-locations",
         permanent: false,


### PR DESCRIPTION
## Summary
Add a redirect from the dashboard root path (`/`) to `/overview` to provide a better default landing page for users accessing the dashboard.

## Changes
- Added a new redirect rule in `apps/dashboard/next.config.ts` that routes requests to `/` to `/overview`
- Set `permanent: false` to allow for future changes to the default landing page without breaking bookmarks

## Implementation Details
- The redirect is configured as a non-permanent (307) redirect, which is appropriate for a default navigation path that may change in the future
- This follows the existing redirect pattern in the config for other deprecated routes

https://claude.ai/code/session_01Ff4duwZ4umJhwnLkRyYx23

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

