### PR TITLE
fix: send subscriber verification in signup service

### DIFF
--- a/apps/server/src/routes/rpc/handlers/status-page/__tests__/status-page.test.ts
+++ b/apps/server/src/routes/rpc/handlers/status-page/__tests__/status-page.test.ts
@@ -2339,7 +2339,7 @@ describe("StatusPageService.SubscribeToPage", () => {
     expect(res.status).toBe(403);
   });
 
-  test("returns subscriber even if email sending fails", async () => {
+  test("returns an error if email sending fails", async () => {
     subscriptionSpies.sendVerification.mockImplementationOnce(() => {
       throw new Error("Resend API failure");
     });
@@ -2353,19 +2353,15 @@ describe("StatusPageService.SubscribeToPage", () => {
       { "x-openstatus-key": "1" },
     );
 
-    expect(res.status).toBe(200);
-
-    const data = await res.json();
-    expect(data).toHaveProperty("subscriber");
-    expect(data.subscriber.email).toBe(`${TEST_PREFIX}-emailfail@example.com`);
+    expect(res.status).toBe(500);
 
     // Clean up
     await db
       .delete(pageSubscriber)
-      .where(eq(pageSubscriber.id, Number(data.subscriber.id)));
+      .where(eq(pageSubscriber.email, `${TEST_PREFIX}-emailfail@example.com`));
   });
 
-  test("re-subscribing a pending subscriber re-sends verification email", async () => {
+  test("re-subscribing a pending subscriber does not re-send verification", async () => {
     // First subscribe
     const res1 = await connectRequest(
       "SubscribeToPage",
@@ -2388,14 +2384,13 @@ describe("StatusPageService.SubscribeToPage", () => {
       },
       { "x-openstatus-key": "1" },
     );
-    expect(res2.status).toBe(200);
-    expect(subscriptionSpies.sendVerification).toHaveBeenCalledTimes(1);
+    expect(res2.status).toBe(400);
+    expect(subscriptionSpies.sendVerification).not.toHaveBeenCalled();
 
     // Clean up
-    const data = await res2.json();
     await db
       .delete(pageSubscriber)
-      .where(eq(pageSubscriber.id, Number(data.subscriber.id)));
+      .where(eq(pageSubscriber.email, `${TEST_PREFIX}-resend@example.com`));
   });
 });
 

--- a/apps/server/src/routes/rpc/handlers/status-page/index.ts
+++ b/apps/server/src/routes/rpc/handlers/status-page/index.ts
@@ -70,10 +70,9 @@ import {
 } from "@openstatus/services/page-component-group";
 import {
   createPageSubscriber,
+  subscribeSelfSignupSubscriber,
   unsubscribePageSubscriber,
-  upsertSelfSignupSubscriber,
 } from "@openstatus/services/page-subscriber";
-import { getChannel } from "@openstatus/subscriptions";
 import {
   THEME_KEYS,
   type ThemeKey,
@@ -1297,49 +1296,27 @@ export const statusPageServiceImpl: ServiceImpl<typeof StatusPageService> = {
       throw statusPageNotFoundError(req.pageId);
     }
 
-    const result = await upsertSelfSignupSubscriber({
-      input: {
-        email: req.email,
-        pageId: pageData.id,
-      },
-    });
+    const email = req.email.toLowerCase();
+    try {
+      await subscribeSelfSignupSubscriber({
+        input: { email, pageId: pageData.id },
+        allowAccepted: true,
+      });
+    } catch (error) {
+      toConnectError(error);
+    }
 
-    const row = await db
-      .select()
-      .from(pageSubscriber)
-      .where(eq(pageSubscriber.id, result.id))
-      .get();
+    const row = await db.query.pageSubscriber.findFirst({
+      where: and(
+        eq(pageSubscriber.email, email),
+        eq(pageSubscriber.pageId, pageData.id),
+        eq(pageSubscriber.channelType, "email"),
+        isNull(pageSubscriber.unsubscribedAt),
+      ),
+    });
 
     if (!row) {
       throw subscriberCreateFailedError();
-    }
-
-    if (!result.acceptedAt) {
-      const verifyUrl = pageData.customDomain
-        ? `https://${pageData.customDomain}/verify/${result.token}`
-        : `https://${pageData.slug}.openstatus.dev/verify/${result.token}`;
-
-      const channel = getChannel("email");
-      if (channel?.sendVerification) {
-        try {
-          await channel.sendVerification(
-            {
-              id: result.id,
-              pageId: pageData.id,
-              pageName: pageData.title,
-              pageSlug: pageData.slug,
-              customDomain: pageData.customDomain,
-              componentIds: [],
-              channelType: "email",
-              email: result.email,
-              token: result.token ?? undefined,
-            },
-            verifyUrl,
-          );
-        } catch (err) {
-          console.error("Failed to send verification email:", err);
-        }
-      }
     }
 
     return {

--- a/apps/status-page/src/components/nav/header.tsx
+++ b/apps/status-page/src/components/nav/header.tsx
@@ -23,12 +23,10 @@ import {
 } from "@openstatus/ui/components/ui/sheet";
 import { cn } from "@openstatus/ui/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { isTRPCClientError } from "@trpc/client";
 import { useExtracted } from "next-intl";
 import NextLink from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useState } from "react";
-import { toast } from "sonner";
 
 import { usePathnamePrefix } from "../../hooks/use-pathname-prefix";
 import { useTRPC } from "../../lib/trpc/client";
@@ -94,28 +92,8 @@ export function Header({
   });
   const prefix = usePathnamePrefix();
 
-  const sendPageSubscriptionMutation = useMutation(
-    trpc.emailRouter.sendPageSubscriptionVerification.mutationOptions({}),
-  );
-
   const subscribeMutation = useMutation(
-    trpc.statusPage.subscribe.mutationOptions({
-      onSuccess: (data) => {
-        if (!data?.id || !data?.token) return;
-        sendPageSubscriptionMutation.mutate(
-          { id: data.id, token: data.token },
-          {
-            onError: (error) => {
-              if (isTRPCClientError(error)) {
-                toast.error(error.message);
-              } else {
-                toast.error(t("Failed to subscribe"));
-              }
-            },
-          },
-        );
-      },
-    }),
+    trpc.statusPage.subscribe.mutationOptions({}),
   );
 
   return (

--- a/packages/api/src/router/email/index.ts
+++ b/packages/api/src/router/email/index.ts
@@ -1,124 +1,14 @@
 import { and, eq } from "@openstatus/db";
-import {
-  invitation,
-  pageSubscriber,
-  selectWorkspaceSchema,
-} from "@openstatus/db/src/schema";
+import { invitation } from "@openstatus/db/src/schema";
 import { EmailClient } from "@openstatus/emails";
-import { getChannel } from "@openstatus/subscriptions";
-import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import { env } from "../../env";
-import {
-  createTRPCRouter,
-  protectedProcedure,
-  publicProcedure,
-} from "../../trpc";
+import { createTRPCRouter, protectedProcedure } from "../../trpc";
 
 const emailClient = new EmailClient({ apiKey: env.RESEND_API_KEY });
 
 export const emailRouter = createTRPCRouter({
-  /**
-   * PUBLIC: Send verification email for a new page subscription
-   * Called after upsert to trigger the verification flow
-   */
-  sendPageSubscriptionVerification: publicProcedure
-    .input(
-      z.object({
-        id: z.number().int().positive(),
-        token: z.uuid(),
-      }),
-    )
-    .mutation(async (opts) => {
-      const subscriber = await opts.ctx.db.query.pageSubscriber.findFirst({
-        where: and(
-          eq(pageSubscriber.id, opts.input.id),
-          eq(pageSubscriber.token, opts.input.token),
-        ),
-        with: {
-          page: {
-            with: {
-              workspace: true,
-            },
-          },
-        },
-      });
-
-      if (!subscriber) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Subscriber not found",
-        });
-      }
-
-      const workspace = selectWorkspaceSchema.safeParse(
-        subscriber.page?.workspace,
-      );
-
-      if (!workspace.success) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Invalid workspace",
-        });
-      }
-
-      if (!workspace.data.limits["status-subscribers"]) {
-        return;
-      }
-
-      if (!subscriber.email) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "No email associated with this subscription",
-        });
-      }
-
-      if (subscriber.acceptedAt) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Subscription already verified",
-        });
-      }
-
-      if (!subscriber.token) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Subscription has no verification token",
-        });
-      }
-
-      const verifyUrl = subscriber.page.customDomain
-        ? `https://${subscriber.page.customDomain}/verify/${subscriber.token}`
-        : `https://${subscriber.page.slug}.openstatus.dev/verify/${subscriber.token}`;
-
-      const channel = getChannel("email");
-      if (!channel) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Email channel not found",
-        });
-      }
-
-      await channel.sendVerification?.(
-        {
-          id: subscriber.id,
-          pageId: subscriber.pageId,
-          pageName: subscriber.page.title,
-          pageSlug: subscriber.page.slug,
-          customDomain: subscriber.page.customDomain,
-          componentIds: [],
-          channelType: "email",
-          email: subscriber.email,
-          token: subscriber.token,
-          acceptedAt: subscriber.acceptedAt ?? undefined,
-        },
-        verifyUrl,
-      );
-
-      return { success: true };
-    }),
-
   sendTeamInvitation: protectedProcedure
     .input(z.object({ id: z.number(), baseUrl: z.string().optional() }))
     .mutation(async (opts) => {

--- a/packages/api/src/router/statusPage.ts
+++ b/packages/api/src/router/statusPage.ts
@@ -18,16 +18,16 @@ import {
 } from "@openstatus/db/src/schema";
 import {
   getSubscriberByToken,
-  hasPendingSubscriber,
+  subscribeSelfSignupSubscriber,
   unsubscribeSubscriber,
   updateSubscriberScope,
-  upsertSelfSignupSubscriber,
   verifySelfSignupSubscriber,
 } from "@openstatus/services/page-subscriber";
 import { TRPCError } from "@trpc/server";
 import { endOfDay, startOfDay, subDays } from "date-fns";
 import { z } from "zod";
 
+import { toTRPCError } from "../service-adapter";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 import {
   type StatusData,
@@ -1194,9 +1194,7 @@ export const statusPageRouter = createTRPCRouter({
 
       const _page = await opts.ctx.db.query.page.findFirst({
         where: sql`lower(${page.slug}) = ${opts.input.slug} OR lower(${page.customDomain}) = ${opts.input.slug}`,
-        with: {
-          workspace: true,
-        },
+        columns: { id: true },
       });
 
       if (!_page) {
@@ -1206,53 +1204,20 @@ export const statusPageRouter = createTRPCRouter({
         });
       }
 
-      const workspace = selectWorkspaceSchema.safeParse(_page.workspace);
-
-      if (!workspace.success) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Workspace data is invalid",
+      try {
+        return await subscribeSelfSignupSubscriber({
+          input: {
+            email: opts.input.email,
+            pageId: _page.id,
+            componentIds: opts.input.subscribeComponents
+              ? opts.input.pageComponents
+              : [],
+          },
+          db: opts.ctx.db,
         });
+      } catch (error) {
+        toTRPCError(error);
       }
-
-      if (!workspace.data.limits["status-subscribers"]) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "Upgrade to use status subscribers",
-        });
-      }
-
-      // Guard against email spam: reject if a pending (unverified, unexpired) subscription exists
-      const isPending = await hasPendingSubscriber({
-        input: { email: opts.input.email, pageId: _page.id },
-      });
-      if (isPending) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message:
-            "A confirmation link was already sent. Please check your email or wait until it expires to request a new one.",
-        });
-      }
-
-      const subscription = await upsertSelfSignupSubscriber({
-        input: {
-          email: opts.input.email,
-          pageId: _page.id,
-          componentIds: opts.input.subscribeComponents
-            ? opts.input.pageComponents
-            : [],
-        },
-      });
-
-      // Already verified — no need to send another verification email
-      if (subscription.acceptedAt) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Email already subscribed",
-        });
-      }
-
-      return { id: subscription.id, token: subscription.token };
     }),
 
   getSubscriptionByToken: publicProcedure

--- a/packages/emails/src/client.tsx
+++ b/packages/emails/src/client.tsx
@@ -337,6 +337,7 @@ export class EmailClient {
       throw result.error;
     } catch (err) {
       console.error(`Error sending page subscription to ${req.to}`, err);
+      throw err;
     }
   }
 

--- a/packages/emails/src/client.tsx
+++ b/packages/emails/src/client.tsx
@@ -39,6 +39,18 @@ const NON_RETRYABLE_RESEND_ERRORS = new Set<string>([
   "validation_error",
 ]);
 
+const defaultNotificationFrom = "OpenStatus <notifications@notifications.openstatus.dev>";
+
+function notificationFrom(displayName?: string): string {
+  const configuredFrom = process.env.OPENSTATUS_EMAIL_FROM?.trim();
+  if (!configuredFrom) {
+    return displayName
+      ? `${displayName} <notifications@notifications.openstatus.dev>`
+      : defaultNotificationFrom;
+  }
+  return displayName ? `${displayName} <${configuredFrom}>` : configuredFrom;
+}
+
 function isRetryableSendError(error: { name: string }): boolean {
   return !NON_RETRYABLE_RESEND_ERRORS.has(error.name);
 }
@@ -216,7 +228,7 @@ export class EmailClient {
               const unsubscribeUrl = `${statusPageBaseUrl}/unsubscribe/${subscriber.token}`;
               const manageUrl = `${statusPageBaseUrl}/manage/${subscriber.token}`;
               return {
-                from: `${req.pageTitle} <notifications@notifications.openstatus.dev>`,
+                from: notificationFrom(req.pageTitle),
                 subject: statusReportSubject(req),
                 to: subscriber.email,
                 react: (
@@ -294,7 +306,7 @@ export class EmailClient {
       // const html = await render(<MonitorAlertEmail {...req} />);
       const html = monitorAlertEmail(req);
       const result = await this.client.emails.send({
-        from: "OpenStatus <notifications@notifications.openstatus.dev>",
+        from: notificationFrom(),
         subject: `${req.name}: ${req.type.toUpperCase()}`,
         to: req.to,
         html,
@@ -323,7 +335,7 @@ export class EmailClient {
     try {
       const html = await render(<PageSubscriptionEmail {...req} />);
       const result = await this.client.emails.send({
-        from: "Status Page <notifications@notifications.openstatus.dev>",
+        from: notificationFrom("Status Page"),
         subject: `Confirm your subscription to ${req.page}`,
         to: req.to,
         html,
@@ -353,7 +365,7 @@ export class EmailClient {
     try {
       const html = await render(<StatusPageMagicLinkEmail {...req} />);
       const result = await this.client.emails.send({
-        from: "Status Page <notifications@notifications.openstatus.dev>",
+        from: notificationFrom("Status Page"),
         subject: `Authenticate to ${req.page}`,
         to: req.to,
         html,
@@ -408,7 +420,7 @@ export class EmailClient {
               const unsubscribeUrl = `${statusPageBaseUrl}/unsubscribe/${subscriber.token}`;
               const manageUrl = `${statusPageBaseUrl}/manage/${subscriber.token}`;
               return {
-                from: `${req.pageTitle} <notifications@notifications.openstatus.dev>`,
+                from: notificationFrom(req.pageTitle),
                 subject: `Scheduled Maintenance: ${req.maintenanceTitle}`,
                 to: subscriber.email,
                 react: (
@@ -481,7 +493,7 @@ export class EmailClient {
       );
       const result = await this.client.batch.send(
         req.to.map((to) => ({
-          from: "OpenStatus <notifications@notifications.openstatus.dev>",
+          from: notificationFrom(),
           subject,
           to,
           html,

--- a/packages/services/src/page-subscriber/__tests__/page-subscriber.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/page-subscriber.test.ts
@@ -53,7 +53,9 @@ let COMPONENT_2: number;
 // Each describe block owns its own email so suites are independent.
 const EMAILS = {
   upsert: "svc-upsert-test@example.com",
+  upsertActiveClaim: "svc-upsert-active-claim@example.com",
   upsertCase: "svc-upsert-case-test@example.com",
+  upsertExpiredClaim: "svc-upsert-expired-claim@example.com",
   upsertReactivate: "svc-upsert-reactivate-test@example.com",
   upsertPendingThenUnsub: "svc-upsert-pending-unsub-test@example.com",
   planGate: "svc-plan-gate-test@example.com",
@@ -200,7 +202,7 @@ describe("upsertSelfSignupSubscriber", () => {
   });
 
   test("merges component scope without refreshing an active verification claim", async () => {
-    const fresh = "svc-upsert-active-claim@example.com";
+    const fresh = EMAILS.upsertActiveClaim;
     await db.delete(pageSubscriber).where(eq(pageSubscriber.email, fresh));
     const initial = await upsertSelfSignupSubscriber({
       input: { email: fresh, pageId: PAGE_ID },
@@ -227,7 +229,7 @@ describe("upsertSelfSignupSubscriber", () => {
   });
 
   test("rotates the token when reclaiming an expired verification", async () => {
-    const fresh = "svc-upsert-expired-claim@example.com";
+    const fresh = EMAILS.upsertExpiredClaim;
     await db.delete(pageSubscriber).where(eq(pageSubscriber.email, fresh));
     const initial = await upsertSelfSignupSubscriber({
       input: { email: fresh, pageId: PAGE_ID },
@@ -254,6 +256,30 @@ describe("upsertSelfSignupSubscriber", () => {
       where: eq(pageSubscriber.id, initial.id),
     });
     expect(current?.expiresAt?.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test("does not reclaim an expired verification without a send claim", async () => {
+    const fresh = EMAILS.upsertExpiredClaim;
+    await db.delete(pageSubscriber).where(eq(pageSubscriber.email, fresh));
+    const initial = await upsertSelfSignupSubscriber({
+      input: { email: fresh, pageId: PAGE_ID },
+    });
+    const expiredAt = new Date(0);
+    await db
+      .update(pageSubscriber)
+      .set({ expiresAt: expiredAt })
+      .where(eq(pageSubscriber.id, initial.id));
+
+    const result = await upsertSelfSignupSubscriber({
+      input: { email: fresh, pageId: PAGE_ID },
+    });
+    const current = await db.query.pageSubscriber.findFirst({
+      where: eq(pageSubscriber.id, initial.id),
+    });
+
+    expect(result.shouldSendVerification).toBe(false);
+    expect(result.token).toBe(initial.token);
+    expect(current?.expiresAt).toEqual(expiredAt);
   });
 
   test("stores email in lowercase regardless of input casing", async () => {

--- a/packages/services/src/page-subscriber/__tests__/page-subscriber.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/page-subscriber.test.ts
@@ -113,6 +113,7 @@ describe("upsertSelfSignupSubscriber", () => {
     expect(result.token).toBeDefined();
     expect(result.acceptedAt).toBeNull();
     expect(result.componentIds).toEqual([]);
+    expect(result.shouldSendVerification).toBe(true);
 
     // Audit row written, attributed to the subscriber (not a workspace user).
     await expectAuditRow({
@@ -148,7 +149,10 @@ describe("upsertSelfSignupSubscriber", () => {
   });
 
   test("does not create a duplicate row when called again", async () => {
-    await upsertSelfSignupSubscriber({ input: { email, pageId: PAGE_ID } });
+    const result = await upsertSelfSignupSubscriber({
+      input: { email, pageId: PAGE_ID },
+    });
+    expect(result.shouldSendVerification).toBe(false);
     const rows = await db.query.pageSubscriber.findMany({
       where: eq(pageSubscriber.email, email),
     });
@@ -282,6 +286,7 @@ describe("upsertSelfSignupSubscriber", () => {
     });
     expect(result.id).toBe(initial.id);
     expect(result.acceptedAt).not.toBeNull();
+    expect(result.shouldSendVerification).toBe(false);
 
     const rows = await readAuditLog({
       workspaceId: WORKSPACE_ID,

--- a/packages/services/src/page-subscriber/__tests__/page-subscriber.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/page-subscriber.test.ts
@@ -28,6 +28,7 @@ import {
   withTestTransaction,
 } from "../../../test/helpers";
 import { ForbiddenError } from "../../errors";
+import { expireSelfSignupVerification } from "../expire-verification.ts";
 import {
   createPageSubscriber,
   getSubscriberByToken,
@@ -196,6 +197,63 @@ describe("upsertSelfSignupSubscriber", () => {
       where: eq(pageSubscriber.email, email),
     });
     expect(row?.expiresAt?.getTime()).toBeGreaterThan(before.getTime());
+  });
+
+  test("merges component scope without refreshing an active verification claim", async () => {
+    const fresh = "svc-upsert-active-claim@example.com";
+    await db.delete(pageSubscriber).where(eq(pageSubscriber.email, fresh));
+    const initial = await upsertSelfSignupSubscriber({
+      input: { email: fresh, pageId: PAGE_ID },
+    });
+    const before = await db.query.pageSubscriber.findFirst({
+      where: eq(pageSubscriber.id, initial.id),
+    });
+
+    const result = await upsertSelfSignupSubscriber({
+      input: {
+        email: fresh,
+        pageId: PAGE_ID,
+        componentIds: [COMPONENT_1],
+      },
+      claimVerification: true,
+    });
+    const after = await db.query.pageSubscriber.findFirst({
+      where: eq(pageSubscriber.id, initial.id),
+    });
+
+    expect(result.shouldSendVerification).toBe(false);
+    expect(result.componentIds).toEqual([COMPONENT_1]);
+    expect(after?.expiresAt).toEqual(before?.expiresAt);
+  });
+
+  test("rotates the token when reclaiming an expired verification", async () => {
+    const fresh = "svc-upsert-expired-claim@example.com";
+    await db.delete(pageSubscriber).where(eq(pageSubscriber.email, fresh));
+    const initial = await upsertSelfSignupSubscriber({
+      input: { email: fresh, pageId: PAGE_ID },
+    });
+    await db
+      .update(pageSubscriber)
+      .set({ expiresAt: new Date(0) })
+      .where(eq(pageSubscriber.id, initial.id));
+
+    const result = await upsertSelfSignupSubscriber({
+      input: { email: fresh, pageId: PAGE_ID },
+      claimVerification: true,
+    });
+
+    expect(result.shouldSendVerification).toBe(true);
+    expect(result.token).not.toBe(initial.token);
+
+    if (!initial.token) throw new Error("Initial token is undefined");
+    await expireSelfSignupVerification({
+      subscriberId: initial.id,
+      token: initial.token,
+    });
+    const current = await db.query.pageSubscriber.findFirst({
+      where: eq(pageSubscriber.id, initial.id),
+    });
+    expect(current?.expiresAt?.getTime()).toBeGreaterThan(Date.now());
   });
 
   test("stores email in lowercase regardless of input casing", async () => {

--- a/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
@@ -179,6 +179,32 @@ describe("subscribeSelfSignupSubscriber", () => {
     });
   });
 
+  test("preserves the delivery error when verification cleanup fails", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx);
+      const deliveryError = new Error("Email provider unavailable");
+      const failedChannel: SubscriptionChannel = {
+        id: "email",
+        validateConfig: () => Promise.resolve({ valid: true }),
+        sendNotifications: () => Promise.resolve(),
+        sendVerification: () => Promise.reject(deliveryError),
+      };
+
+      await expect(
+        subscribeSelfSignupSubscriber({
+          input: {
+            email: "failed-cleanup@example.com",
+            pageId: statusPage.id,
+          },
+          db: tx,
+          channel: failedChannel,
+          expireVerification: () =>
+            Promise.reject(new Error("Database unavailable")),
+        }),
+      ).rejects.toBe(deliveryError);
+    });
+  });
+
   test("does not send another email for a verified subscription", async () => {
     await withTestTransaction(async (tx) => {
       const statusPage = await createStatusPage(tx);

--- a/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
@@ -1,0 +1,159 @@
+import { eq } from "@openstatus/db";
+import { page, pageSubscriber } from "@openstatus/db/src/schema";
+import type {
+  PageUpdate,
+  Subscription,
+  SubscriptionChannel,
+} from "@openstatus/subscriptions";
+import { expect } from "@std/expect";
+import { beforeAll, describe, test } from "@std/testing/bdd";
+
+import {
+  createWorkspaceFixture,
+  withTestTransaction,
+} from "../../../test/helpers";
+import type { DB } from "../../context";
+import {
+  subscribeSelfSignupSubscriber,
+  upsertSelfSignupSubscriber,
+} from "../index.ts";
+
+let workspaceId: number;
+
+beforeAll(async () => {
+  workspaceId = (await createWorkspaceFixture("team")).workspace.id;
+});
+
+async function createStatusPage(
+  tx: DB,
+  overrides: { customDomain?: string } = {},
+) {
+  return tx
+    .insert(page)
+    .values({
+      workspaceId,
+      title: "Subscriber Test Page",
+      description: "Subscriber email verification test",
+      slug: `subscriber-test-${crypto.randomUUID()}`,
+      customDomain: overrides.customDomain ?? "",
+      published: true,
+    })
+    .returning()
+    .get();
+}
+
+function verificationChannel(
+  onSend: (subscription: Subscription, verifyUrl: string) => void,
+): SubscriptionChannel {
+  return {
+    id: "email",
+    validateConfig: () => Promise.resolve({ valid: true }),
+    sendNotifications: (_subscriptions: Subscription[], _update: PageUpdate) =>
+      Promise.resolve(),
+    sendVerification: (subscription, verifyUrl) => {
+      onSend(subscription, verifyUrl);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("subscribeSelfSignupSubscriber", () => {
+  test("creates a pending subscriber and sends its verification email", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx, {
+        customDomain: "status.example.com",
+      });
+      const deliveries: { subscription: Subscription; verifyUrl: string }[] =
+        [];
+
+      const result = await subscribeSelfSignupSubscriber({
+        input: {
+          email: "subscriber@example.com",
+          pageId: statusPage.id,
+        },
+        db: tx,
+        channel: verificationChannel((subscription, verifyUrl) => {
+          deliveries.push({ subscription, verifyUrl });
+        }),
+      });
+
+      expect(result.success).toBe(true);
+      expect(deliveries).toHaveLength(1);
+      expect(deliveries[0]?.subscription.email).toBe("subscriber@example.com");
+      expect(deliveries[0]?.verifyUrl).toBe(
+        `https://status.example.com/verify/${deliveries[0]?.subscription.token}`,
+      );
+    });
+  });
+
+  test("uses the hosted page URL when no custom domain is configured", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx);
+      let verifyUrl = "";
+      let verificationToken: string | undefined;
+
+      await subscribeSelfSignupSubscriber({
+        input: {
+          email: "hosted-subscriber@example.com",
+          pageId: statusPage.id,
+        },
+        db: tx,
+        channel: verificationChannel((subscription, url) => {
+          verificationToken = subscription.token;
+          verifyUrl = url;
+        }),
+      });
+
+      expect(verifyUrl).toBe(
+        `https://${statusPage.slug}.openstatus.dev/verify/${verificationToken}`,
+      );
+    });
+  });
+
+  test("does not send another email for an existing pending subscription", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx);
+      let deliveries = 0;
+      const channel = verificationChannel(() => {
+        deliveries += 1;
+      });
+      const input = {
+        email: "pending-subscriber@example.com",
+        pageId: statusPage.id,
+      };
+
+      await subscribeSelfSignupSubscriber({ input, db: tx, channel });
+      await expect(
+        subscribeSelfSignupSubscriber({ input, db: tx, channel }),
+      ).rejects.toThrow("A confirmation link was already sent");
+      expect(deliveries).toBe(1);
+    });
+  });
+
+  test("does not send another email for a verified subscription", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx);
+      const input = {
+        email: "verified-subscriber@example.com",
+        pageId: statusPage.id,
+      };
+      const subscriber = await upsertSelfSignupSubscriber({ input, db: tx });
+      await tx
+        .update(pageSubscriber)
+        .set({ acceptedAt: new Date() })
+        .where(eq(pageSubscriber.id, subscriber.id));
+      let deliveries = 0;
+
+      await expect(
+        subscribeSelfSignupSubscriber({
+          input,
+          db: tx,
+          channel: verificationChannel(() => {
+            deliveries += 1;
+          }),
+        }),
+      ).rejects.toThrow("Email already subscribed");
+      expect(deliveries).toBe(0);
+    });
+  });
+});

--- a/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
@@ -271,4 +271,33 @@ describe("subscribeSelfSignupSubscriber", () => {
       expect(deliveries).toBe(0);
     });
   });
+
+  test("allows adapters to preserve an idempotent accepted response", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx);
+      const deliveries: Subscription[] = [];
+      const input = {
+        email: "subscribe-accepted-adapter@example.com",
+        pageId: statusPage.id,
+      };
+      const subscriber = await upsertSelfSignupSubscriber({ input, db: tx });
+      await tx
+        .update(pageSubscriber)
+        .set({ acceptedAt: new Date() })
+        .where(eq(pageSubscriber.id, subscriber.id))
+        .run();
+
+      const result = await subscribeSelfSignupSubscriber({
+        input,
+        db: tx,
+        channel: verificationChannel((subscription) => {
+          deliveries.push(subscription);
+        }),
+        allowAccepted: true,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(deliveries).toHaveLength(0);
+    });
+  });
 });

--- a/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
@@ -123,9 +123,58 @@ describe("subscribeSelfSignupSubscriber", () => {
       };
 
       await subscribeSelfSignupSubscriber({ input, db: tx, channel });
+      const initialPending = await tx.query.pageSubscriber.findFirst({
+        where: eq(pageSubscriber.email, input.email),
+      });
       await expect(
         subscribeSelfSignupSubscriber({ input, db: tx, channel }),
       ).rejects.toThrow("A confirmation link was already sent");
+      const pendingAfterRetry = await tx.query.pageSubscriber.findFirst({
+        where: eq(pageSubscriber.email, input.email),
+      });
+      expect(deliveries).toBe(1);
+      expect(pendingAfterRetry?.expiresAt).toEqual(initialPending?.expiresAt);
+    });
+  });
+
+  test("allows an immediate retry when verification delivery fails", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx);
+      const input = {
+        email: "failed-delivery@example.com",
+        pageId: statusPage.id,
+      };
+      const deliveryError = new Error("Email provider unavailable");
+      const failedChannel: SubscriptionChannel = {
+        id: "email",
+        validateConfig: () => Promise.resolve({ valid: true }),
+        sendNotifications: () => Promise.resolve(),
+        sendVerification: () => Promise.reject(deliveryError),
+      };
+
+      await expect(
+        subscribeSelfSignupSubscriber({
+          input,
+          db: tx,
+          channel: failedChannel,
+        }),
+      ).rejects.toThrow("Email provider unavailable");
+
+      const pending = await tx.query.pageSubscriber.findFirst({
+        where: eq(pageSubscriber.email, input.email),
+      });
+      expect(pending?.expiresAt?.getTime()).toBeLessThanOrEqual(Date.now());
+
+      let deliveries = 0;
+      await expect(
+        subscribeSelfSignupSubscriber({
+          input,
+          db: tx,
+          channel: verificationChannel(() => {
+            deliveries += 1;
+          }),
+        }),
+      ).resolves.toEqual({ success: true });
       expect(deliveries).toBe(1);
     });
   });

--- a/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
+++ b/packages/services/src/page-subscriber/__tests__/subscribe.test.ts
@@ -13,6 +13,7 @@ import {
   withTestTransaction,
 } from "../../../test/helpers";
 import type { DB } from "../../context";
+import { expireSelfSignupVerification } from "../expire-verification.ts";
 import {
   subscribeSelfSignupSubscriber,
   upsertSelfSignupSubscriber,
@@ -189,6 +190,7 @@ describe("subscribeSelfSignupSubscriber", () => {
         sendNotifications: () => Promise.resolve(),
         sendVerification: () => Promise.reject(deliveryError),
       };
+      let cleanupAttempts = 0;
 
       await expect(
         subscribeSelfSignupSubscriber({
@@ -198,10 +200,48 @@ describe("subscribeSelfSignupSubscriber", () => {
           },
           db: tx,
           channel: failedChannel,
-          expireVerification: () =>
-            Promise.reject(new Error("Database unavailable")),
+          expireVerification: () => {
+            cleanupAttempts += 1;
+            return Promise.reject(new Error("Database unavailable"));
+          },
         }),
       ).rejects.toBe(deliveryError);
+      expect(cleanupAttempts).toBe(3);
+    });
+  });
+
+  test("retries verification cleanup after transient failures", async () => {
+    await withTestTransaction(async (tx) => {
+      const statusPage = await createStatusPage(tx);
+      const email = "transient-cleanup@example.com";
+      const deliveryError = new Error("Email provider unavailable");
+      let cleanupAttempts = 0;
+
+      await expect(
+        subscribeSelfSignupSubscriber({
+          input: { email, pageId: statusPage.id },
+          db: tx,
+          channel: {
+            id: "email",
+            validateConfig: () => Promise.resolve({ valid: true }),
+            sendNotifications: () => Promise.resolve(),
+            sendVerification: () => Promise.reject(deliveryError),
+          },
+          expireVerification: (input) => {
+            cleanupAttempts += 1;
+            if (cleanupAttempts < 3) {
+              return Promise.reject(new Error("Database unavailable"));
+            }
+            return expireSelfSignupVerification(input);
+          },
+        }),
+      ).rejects.toBe(deliveryError);
+
+      const pending = await tx.query.pageSubscriber.findFirst({
+        where: eq(pageSubscriber.email, email),
+      });
+      expect(cleanupAttempts).toBe(3);
+      expect(pending?.expiresAt?.getTime()).toBeLessThanOrEqual(Date.now());
     });
   });
 

--- a/packages/services/src/page-subscriber/expire-verification.ts
+++ b/packages/services/src/page-subscriber/expire-verification.ts
@@ -1,0 +1,64 @@
+import { and, eq, isNull } from "@openstatus/db";
+import {
+  pageSubscriber,
+  selectPageSubscriberSchema,
+} from "@openstatus/db/src/schema";
+
+import { emitAudit } from "../audit";
+import { type DB, type ServiceContext, withTransaction } from "../context";
+import { parseWorkspaceForContext } from "./internal";
+
+// Anonymous self-signup compensation uses the subscriber as its audit actor.
+// oxlint-disable-next-line openstatus/services-mutation-guards
+export async function expireSelfSignupVerification(args: {
+  subscriberId: number;
+  token: string;
+  db?: DB;
+}) {
+  await withTransaction({ db: args.db } as ServiceContext, async (tx) => {
+    const existing = await tx.query.pageSubscriber.findFirst({
+      where: and(
+        eq(pageSubscriber.id, args.subscriberId),
+        eq(pageSubscriber.token, args.token),
+        isNull(pageSubscriber.acceptedAt),
+        isNull(pageSubscriber.unsubscribedAt),
+      ),
+      with: { page: { with: { workspace: true } } },
+    });
+    if (!existing) return;
+
+    const beforeRow = selectPageSubscriberSchema.parse(existing);
+    const updatedRow = await tx
+      .update(pageSubscriber)
+      .set({ expiresAt: new Date(0), updatedAt: new Date() })
+      .where(
+        and(
+          eq(pageSubscriber.id, args.subscriberId),
+          eq(pageSubscriber.token, args.token),
+          isNull(pageSubscriber.acceptedAt),
+          isNull(pageSubscriber.unsubscribedAt),
+        ),
+      )
+      .returning()
+      .get();
+    if (!updatedRow) return;
+
+    const workspace = parseWorkspaceForContext(existing.page.workspace);
+    const auditCtx: ServiceContext = {
+      workspace,
+      actor: { type: "subscriber", subscriberId: existing.id },
+      db: tx,
+    };
+    const afterRow = selectPageSubscriberSchema.parse(updatedRow);
+    const { token: _beforeToken, ...before } = beforeRow;
+    const { token: _afterToken, ...after } = afterRow;
+    await emitAudit(tx, auditCtx, {
+      action: "page_subscriber.update",
+      entityType: "page_subscriber",
+      entityId: existing.id,
+      before,
+      after,
+      metadata: { reason: "verification_delivery_failed" },
+    });
+  });
+}

--- a/packages/services/src/page-subscriber/index.ts
+++ b/packages/services/src/page-subscriber/index.ts
@@ -10,6 +10,7 @@ export {
 export { hasPendingSubscriber } from "./has-pending";
 export { listPageSubscribers, type PageSubscriberListItem } from "./list";
 export { sendPageSubscriberTestWebhook } from "./send-test-webhook";
+export { subscribeSelfSignupSubscriber } from "./subscribe";
 export {
   createSlackSubscriber,
   listSlackSubscribersForChannel,

--- a/packages/services/src/page-subscriber/subscribe.ts
+++ b/packages/services/src/page-subscriber/subscribe.ts
@@ -9,6 +9,7 @@ import { upsertSelfSignupSubscriber } from "./upsert";
 
 const PENDING_SUBSCRIPTION_MESSAGE =
   "A confirmation link was already sent. Please check your email or wait until it expires to request a new one.";
+const EXPIRY_CLEANUP_ATTEMPTS = 3;
 
 // Anonymous self-signup resolves workspace and audit actor in the upsert verb.
 // oxlint-disable-next-line openstatus/services-mutation-guards
@@ -62,17 +63,24 @@ export async function subscribeSelfSignupSubscriber(args: {
       verifyUrl,
     );
   } catch (error) {
-    try {
-      await (args.expireVerification ?? expireSelfSignupVerification)({
-        subscriberId: subscription.id,
-        token: subscription.token,
-        db: args.db,
-      });
-    } catch (cleanupError) {
-      console.warn("Failed to expire undelivered subscriber verification", {
-        subscriberId: subscription.id,
-        cleanupError,
-      });
+    const expireVerification =
+      args.expireVerification ?? expireSelfSignupVerification;
+    for (let attempt = 1; attempt <= EXPIRY_CLEANUP_ATTEMPTS; attempt++) {
+      try {
+        await expireVerification({
+          subscriberId: subscription.id,
+          token: subscription.token,
+          db: args.db,
+        });
+        break;
+      } catch (cleanupError) {
+        if (attempt === EXPIRY_CLEANUP_ATTEMPTS) {
+          console.warn("Failed to expire undelivered subscriber verification", {
+            subscriberId: subscription.id,
+            cleanupError,
+          });
+        }
+      }
     }
     throw error;
   }

--- a/packages/services/src/page-subscriber/subscribe.ts
+++ b/packages/services/src/page-subscriber/subscribe.ts
@@ -18,6 +18,7 @@ export async function subscribeSelfSignupSubscriber(args: {
   db?: DB;
   channel?: SubscriptionChannel;
   expireVerification?: typeof expireSelfSignupVerification;
+  allowAccepted?: boolean;
 }) {
   const input = UpsertSelfSignupSubscriberInput.parse(args.input);
   const channel = args.channel ?? getChannel("email");
@@ -32,6 +33,7 @@ export async function subscribeSelfSignupSubscriber(args: {
   });
 
   if (subscription.acceptedAt) {
+    if (args.allowAccepted) return { success: true };
     throw new ValidationError("Email already subscribed");
   }
   if (!subscription.shouldSendVerification) {

--- a/packages/services/src/page-subscriber/subscribe.ts
+++ b/packages/services/src/page-subscriber/subscribe.ts
@@ -16,6 +16,7 @@ export async function subscribeSelfSignupSubscriber(args: {
   input: UpsertSelfSignupSubscriberInput;
   db?: DB;
   channel?: SubscriptionChannel;
+  expireVerification?: typeof expireSelfSignupVerification;
 }) {
   const input = UpsertSelfSignupSubscriberInput.parse(args.input);
   const channel = args.channel ?? getChannel("email");
@@ -61,11 +62,18 @@ export async function subscribeSelfSignupSubscriber(args: {
       verifyUrl,
     );
   } catch (error) {
-    await expireSelfSignupVerification({
-      subscriberId: subscription.id,
-      token: subscription.token,
-      db: args.db,
-    });
+    try {
+      await (args.expireVerification ?? expireSelfSignupVerification)({
+        subscriberId: subscription.id,
+        token: subscription.token,
+        db: args.db,
+      });
+    } catch (cleanupError) {
+      console.warn("Failed to expire undelivered subscriber verification", {
+        subscriberId: subscription.id,
+        cleanupError,
+      });
+    }
     throw error;
   }
 

--- a/packages/services/src/page-subscriber/subscribe.ts
+++ b/packages/services/src/page-subscriber/subscribe.ts
@@ -1,0 +1,69 @@
+import type { SubscriptionChannel } from "@openstatus/subscriptions";
+import { getChannel } from "@openstatus/subscriptions";
+
+import type { DB } from "../context";
+import { InternalServiceError, ValidationError } from "../errors";
+import { hasPendingSubscriber } from "./has-pending";
+import { UpsertSelfSignupSubscriberInput } from "./schemas";
+import { upsertSelfSignupSubscriber } from "./upsert";
+
+const PENDING_SUBSCRIPTION_MESSAGE =
+  "A confirmation link was already sent. Please check your email or wait until it expires to request a new one.";
+
+// Anonymous self-signup resolves workspace and audit actor in the upsert verb.
+// oxlint-disable-next-line openstatus/services-mutation-guards
+export async function subscribeSelfSignupSubscriber(args: {
+  input: UpsertSelfSignupSubscriberInput;
+  db?: DB;
+  channel?: SubscriptionChannel;
+}) {
+  const input = UpsertSelfSignupSubscriberInput.parse(args.input);
+
+  const isPending = await hasPendingSubscriber({
+    input: { email: input.email, pageId: input.pageId },
+    db: args.db,
+  });
+  if (isPending) {
+    throw new ValidationError(PENDING_SUBSCRIPTION_MESSAGE);
+  }
+
+  const subscription = await upsertSelfSignupSubscriber({
+    input,
+    db: args.db,
+  });
+
+  if (subscription.acceptedAt) {
+    throw new ValidationError("Email already subscribed");
+  }
+  if (!subscription.token) {
+    throw new InternalServiceError("Subscription has no verification token");
+  }
+
+  const channel = args.channel ?? getChannel("email");
+  if (!channel?.sendVerification) {
+    throw new InternalServiceError("Email channel not found");
+  }
+
+  const verifyUrl = subscription.customDomain
+    ? `https://${subscription.customDomain}/verify/${subscription.token}`
+    : `https://${subscription.pageSlug}.openstatus.dev/verify/${subscription.token}`;
+
+  await channel.sendVerification(
+    {
+      id: subscription.id,
+      pageId: subscription.pageId,
+      pageName: subscription.pageName,
+      pageSlug: subscription.pageSlug,
+      customDomain: subscription.customDomain,
+      componentIds: subscription.componentIds,
+      channelType: "email",
+      email: subscription.email,
+      token: subscription.token,
+      acceptedAt: subscription.acceptedAt ?? undefined,
+      unsubscribedAt: subscription.unsubscribedAt ?? undefined,
+    },
+    verifyUrl,
+  );
+
+  return { success: true };
+}

--- a/packages/services/src/page-subscriber/subscribe.ts
+++ b/packages/services/src/page-subscriber/subscribe.ts
@@ -3,7 +3,7 @@ import { getChannel } from "@openstatus/subscriptions";
 
 import type { DB } from "../context";
 import { InternalServiceError, ValidationError } from "../errors";
-import { hasPendingSubscriber } from "./has-pending";
+import { expireSelfSignupVerification } from "./expire-verification";
 import { UpsertSelfSignupSubscriberInput } from "./schemas";
 import { upsertSelfSignupSubscriber } from "./upsert";
 
@@ -18,52 +18,56 @@ export async function subscribeSelfSignupSubscriber(args: {
   channel?: SubscriptionChannel;
 }) {
   const input = UpsertSelfSignupSubscriberInput.parse(args.input);
-
-  const isPending = await hasPendingSubscriber({
-    input: { email: input.email, pageId: input.pageId },
-    db: args.db,
-  });
-  if (isPending) {
-    throw new ValidationError(PENDING_SUBSCRIPTION_MESSAGE);
+  const channel = args.channel ?? getChannel("email");
+  if (!channel?.sendVerification) {
+    throw new InternalServiceError("Email channel not found");
   }
 
   const subscription = await upsertSelfSignupSubscriber({
     input,
     db: args.db,
+    claimVerification: true,
   });
 
   if (subscription.acceptedAt) {
     throw new ValidationError("Email already subscribed");
   }
+  if (!subscription.shouldSendVerification) {
+    throw new ValidationError(PENDING_SUBSCRIPTION_MESSAGE);
+  }
   if (!subscription.token) {
     throw new InternalServiceError("Subscription has no verification token");
-  }
-
-  const channel = args.channel ?? getChannel("email");
-  if (!channel?.sendVerification) {
-    throw new InternalServiceError("Email channel not found");
   }
 
   const verifyUrl = subscription.customDomain
     ? `https://${subscription.customDomain}/verify/${subscription.token}`
     : `https://${subscription.pageSlug}.openstatus.dev/verify/${subscription.token}`;
 
-  await channel.sendVerification(
-    {
-      id: subscription.id,
-      pageId: subscription.pageId,
-      pageName: subscription.pageName,
-      pageSlug: subscription.pageSlug,
-      customDomain: subscription.customDomain,
-      componentIds: subscription.componentIds,
-      channelType: "email",
-      email: subscription.email,
+  try {
+    await channel.sendVerification(
+      {
+        id: subscription.id,
+        pageId: subscription.pageId,
+        pageName: subscription.pageName,
+        pageSlug: subscription.pageSlug,
+        customDomain: subscription.customDomain,
+        componentIds: subscription.componentIds,
+        channelType: "email",
+        email: subscription.email,
+        token: subscription.token,
+        acceptedAt: subscription.acceptedAt ?? undefined,
+        unsubscribedAt: subscription.unsubscribedAt ?? undefined,
+      },
+      verifyUrl,
+    );
+  } catch (error) {
+    await expireSelfSignupVerification({
+      subscriberId: subscription.id,
       token: subscription.token,
-      acceptedAt: subscription.acceptedAt ?? undefined,
-      unsubscribedAt: subscription.unsubscribedAt ?? undefined,
-    },
-    verifyUrl,
-  );
+      db: args.db,
+    });
+    throw error;
+  }
 
   return { success: true };
 }

--- a/packages/services/src/page-subscriber/upsert.ts
+++ b/packages/services/src/page-subscriber/upsert.ts
@@ -215,14 +215,12 @@ export async function upsertSelfSignupSubscriber(args: {
 
         if (newIds.length > 0) {
           const { token: _beforeToken, ...before } = beforeRow;
-          const { token: _afterToken, ...after } =
-            selectPageSubscriberSchema.parse(active);
           await emitAudit(tx, auditCtx, {
             action: "page_subscriber.update",
             entityType: "page_subscriber",
             entityId: existing.id,
             before,
-            after,
+            after: before,
             metadata: { componentIds: mergedIds },
           });
         }

--- a/packages/services/src/page-subscriber/upsert.ts
+++ b/packages/services/src/page-subscriber/upsert.ts
@@ -123,26 +123,12 @@ export async function upsertSelfSignupSubscriber(args: {
     }
 
     if (existing) {
-      // Pending row — merge components, refresh expiry.
+      // Pending row — always merge scope; refresh only when issuing a link.
       const shouldSendVerification =
-        !existing.expiresAt || existing.expiresAt <= new Date();
+        !existing.token ||
+        !existing.expiresAt ||
+        existing.expiresAt <= new Date();
       const currentIds = existing.components.map((c) => c.pageComponentId);
-      if (args.claimVerification && !shouldSendVerification) {
-        return {
-          id: existing.id,
-          pageId: existing.pageId,
-          pageName: pageData.title,
-          pageSlug: pageData.slug,
-          customDomain: pageData.customDomain,
-          channelType: existing.channelType,
-          email: existing.email ?? emailLower,
-          token: existing.token,
-          acceptedAt: null,
-          componentIds: currentIds,
-          shouldSendVerification: false,
-        };
-      }
-
       const mergedIds = [...new Set([...currentIds, ...componentIds])];
       const newIds = mergedIds.filter((id) => !currentIds.includes(id));
 
@@ -159,21 +145,52 @@ export async function upsertSelfSignupSubscriber(args: {
           .run();
       }
 
-      const newExpiresAt = new Date(Date.now() + VERIFICATION_EXPIRY_MS);
       const beforeRow = selectPageSubscriberSchema.parse(existing);
-      const updatedRow = await tx
-        .update(pageSubscriber)
-        .set({ expiresAt: newExpiresAt, updatedAt: new Date() })
-        .where(eq(pageSubscriber.id, existing.id))
-        .returning()
-        .get();
-      const afterRow = selectPageSubscriberSchema.parse(updatedRow ?? existing);
-
       const auditCtx: ServiceContext = {
         workspace,
         actor: { type: "subscriber", subscriberId: existing.id },
         db: tx,
       };
+
+      if (args.claimVerification && !shouldSendVerification) {
+        if (newIds.length > 0) {
+          const { token: _beforeToken, ...before } = beforeRow;
+          await emitAudit(tx, auditCtx, {
+            action: "page_subscriber.update",
+            entityType: "page_subscriber",
+            entityId: existing.id,
+            before,
+            after: before,
+            metadata: { componentIds: mergedIds },
+          });
+        }
+
+        return {
+          id: existing.id,
+          pageId: existing.pageId,
+          pageName: pageData.title,
+          pageSlug: pageData.slug,
+          customDomain: pageData.customDomain,
+          channelType: existing.channelType,
+          email: existing.email ?? emailLower,
+          token: existing.token,
+          acceptedAt: null,
+          componentIds: mergedIds,
+          shouldSendVerification: false,
+        };
+      }
+
+      const newExpiresAt = new Date(Date.now() + VERIFICATION_EXPIRY_MS);
+      const token = shouldSendVerification
+        ? crypto.randomUUID()
+        : existing.token;
+      const updatedRow = await tx
+        .update(pageSubscriber)
+        .set({ expiresAt: newExpiresAt, token, updatedAt: new Date() })
+        .where(eq(pageSubscriber.id, existing.id))
+        .returning()
+        .get();
+      const afterRow = selectPageSubscriberSchema.parse(updatedRow ?? existing);
 
       // Strip token (capability for self-manage / unsubscribe URLs).
       // Component scope changes don't show in the row diff — surface
@@ -197,7 +214,7 @@ export async function upsertSelfSignupSubscriber(args: {
         customDomain: pageData.customDomain,
         channelType: existing.channelType,
         email: existing.email ?? emailLower,
-        token: existing.token,
+        token,
         acceptedAt: null,
         componentIds: mergedIds,
         shouldSendVerification,

--- a/packages/services/src/page-subscriber/upsert.ts
+++ b/packages/services/src/page-subscriber/upsert.ts
@@ -213,6 +213,20 @@ export async function upsertSelfSignupSubscriber(args: {
           throw new NotFoundError("page_subscriber", existing.id);
         }
 
+        if (newIds.length > 0) {
+          const { token: _beforeToken, ...before } = beforeRow;
+          const { token: _afterToken, ...after } =
+            selectPageSubscriberSchema.parse(active);
+          await emitAudit(tx, auditCtx, {
+            action: "page_subscriber.update",
+            entityType: "page_subscriber",
+            entityId: existing.id,
+            before,
+            after,
+            metadata: { componentIds: mergedIds },
+          });
+        }
+
         return {
           id: active.id,
           pageId: active.pageId,

--- a/packages/services/src/page-subscriber/upsert.ts
+++ b/packages/services/src/page-subscriber/upsert.ts
@@ -152,7 +152,7 @@ export async function upsertSelfSignupSubscriber(args: {
         db: tx,
       };
 
-      if (args.claimVerification && !shouldSendVerification) {
+      if (!args.claimVerification || !shouldSendVerification) {
         if (newIds.length > 0) {
           const { token: _beforeToken, ...before } = beforeRow;
           await emitAudit(tx, auditCtx, {
@@ -181,16 +181,54 @@ export async function upsertSelfSignupSubscriber(args: {
       }
 
       const newExpiresAt = new Date(Date.now() + VERIFICATION_EXPIRY_MS);
-      const token = shouldSendVerification
-        ? crypto.randomUUID()
-        : existing.token;
+      const token = crypto.randomUUID();
       const updatedRow = await tx
         .update(pageSubscriber)
         .set({ expiresAt: newExpiresAt, token, updatedAt: new Date() })
-        .where(eq(pageSubscriber.id, existing.id))
+        .where(
+          and(
+            eq(pageSubscriber.id, existing.id),
+            existing.token
+              ? eq(pageSubscriber.token, existing.token)
+              : isNull(pageSubscriber.token),
+            existing.expiresAt
+              ? eq(pageSubscriber.expiresAt, existing.expiresAt)
+              : isNull(pageSubscriber.expiresAt),
+            isNull(pageSubscriber.acceptedAt),
+            isNull(pageSubscriber.unsubscribedAt),
+          ),
+        )
         .returning()
         .get();
-      const afterRow = selectPageSubscriberSchema.parse(updatedRow ?? existing);
+
+      if (!updatedRow) {
+        const active = await tx.query.pageSubscriber.findFirst({
+          where: and(
+            eq(pageSubscriber.id, existing.id),
+            isNull(pageSubscriber.unsubscribedAt),
+          ),
+          with: { components: true },
+        });
+        if (!active) {
+          throw new NotFoundError("page_subscriber", existing.id);
+        }
+
+        return {
+          id: active.id,
+          pageId: active.pageId,
+          pageName: pageData.title,
+          pageSlug: pageData.slug,
+          customDomain: pageData.customDomain,
+          channelType: active.channelType,
+          email: active.email ?? emailLower,
+          token: active.token,
+          acceptedAt: active.acceptedAt,
+          componentIds: active.components.map((c) => c.pageComponentId),
+          shouldSendVerification: false,
+        };
+      }
+
+      const afterRow = selectPageSubscriberSchema.parse(updatedRow);
 
       // Strip token (capability for self-manage / unsubscribe URLs).
       // Component scope changes don't show in the row diff — surface

--- a/packages/services/src/page-subscriber/upsert.ts
+++ b/packages/services/src/page-subscriber/upsert.ts
@@ -32,6 +32,7 @@ export type UpsertSelfSignupResult = {
   acceptedAt: Date | null;
   unsubscribedAt?: Date | null;
   componentIds: number[];
+  shouldSendVerification: boolean;
 };
 
 /**
@@ -55,6 +56,7 @@ export type UpsertSelfSignupResult = {
 export async function upsertSelfSignupSubscriber(args: {
   input: UpsertSelfSignupSubscriberInput;
   db?: DB;
+  claimVerification?: boolean;
 }): Promise<UpsertSelfSignupResult> {
   const input = UpsertSelfSignupSubscriberInput.parse(args.input);
   const componentIds = input.componentIds ?? [];
@@ -116,12 +118,31 @@ export async function upsertSelfSignupSubscriber(args: {
         token: existing.token,
         acceptedAt: existing.acceptedAt,
         componentIds: existing.components.map((c) => c.pageComponentId),
+        shouldSendVerification: false,
       };
     }
 
     if (existing) {
       // Pending row — merge components, refresh expiry.
+      const shouldSendVerification =
+        !existing.expiresAt || existing.expiresAt <= new Date();
       const currentIds = existing.components.map((c) => c.pageComponentId);
+      if (args.claimVerification && !shouldSendVerification) {
+        return {
+          id: existing.id,
+          pageId: existing.pageId,
+          pageName: pageData.title,
+          pageSlug: pageData.slug,
+          customDomain: pageData.customDomain,
+          channelType: existing.channelType,
+          email: existing.email ?? emailLower,
+          token: existing.token,
+          acceptedAt: null,
+          componentIds: currentIds,
+          shouldSendVerification: false,
+        };
+      }
+
       const mergedIds = [...new Set([...currentIds, ...componentIds])];
       const newIds = mergedIds.filter((id) => !currentIds.includes(id));
 
@@ -179,6 +200,7 @@ export async function upsertSelfSignupSubscriber(args: {
         token: existing.token,
         acceptedAt: null,
         componentIds: mergedIds,
+        shouldSendVerification,
       };
     }
 
@@ -237,6 +259,7 @@ export async function upsertSelfSignupSubscriber(args: {
       acceptedAt: inserted.acceptedAt ?? null,
       unsubscribedAt: inserted.unsubscribedAt ?? null,
       componentIds,
+      shouldSendVerification: true,
     };
   });
 }


### PR DESCRIPTION
## Summary

- move public status-page email signup into a service-layer workflow
- create the pending subscriber and send its verification email in one server request
- remove the client-side follow-up mutation and redundant public email endpoint
- stop returning subscriber verification tokens to the browser

## Root cause

The status-page UI first created a pending subscriber, then relied on a second client-side tRPC mutation to send the verification email. If that follow-up request did not run or failed, the subscriber remained pending without receiving a link, and the pending guard blocked another attempt.

## Validation

- `pnpm --filter @openstatus/services check`
- changed-file `oxlint`
- focused service test against the libSQL image pinned by upstream CI: 5 steps passed
- formatting and documentation-reference checks passed as part of `pnpm verify`

The repository-wide verifier still fails on pre-existing Deno type errors involving `Buffer` in `apps/workflows/src/cron/checker.ts` and `packages/api`; the affected service package type-checks cleanly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

