### PR TITLE
fix(dashboard): expose auth user id in session

### DIFF
--- a/apps/dashboard/src/lib/auth/index.ts
+++ b/apps/dashboard/src/lib/auth/index.ts
@@ -145,7 +145,7 @@ const {
         ...session,
         user: {
           ...session.user,
-          id: user.id,
+          id: String(user.id),
         },
       };
     },

--- a/apps/dashboard/src/lib/auth/index.ts
+++ b/apps/dashboard/src/lib/auth/index.ts
@@ -140,8 +140,14 @@ const {
 
       return true;
     },
-    async session(params) {
-      return params.session;
+    async session({ session, user }) {
+      return {
+        ...session,
+        user: {
+          ...session.user,
+          id: user.id,
+        },
+      };
     },
   },
   events: {

--- a/apps/dashboard/src/next-auth.d.ts
+++ b/apps/dashboard/src/next-auth.d.ts
@@ -1,6 +1,13 @@
 import type { User as DefaultUserSchema } from "@openstatus/db/src/schema";
+import type { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface User extends DefaultUserSchema {}
 }


### PR DESCRIPTION
## Summary
  - add the Auth.js database user id to `session.user.id`
  - type the extended dashboard session shape

fixes #1956 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

