### PR TITLE
perf(server): reuse validated monitors in page routes

### DIFF
--- a/apps/server/src/routes/v1/pages/post.ts
+++ b/apps/server/src/routes/v1/pages/post.ts
@@ -134,30 +134,36 @@ export function registerPostPage(api: typeof pagesApi) {
 
     const { monitors, ...rest } = input;
 
-    if (monitors?.length) {
-      const monitorIds = isNumberArray(monitors)
+    const monitorIds = monitors
+      ? isNumberArray(monitors)
         ? monitors
-        : monitors.map((m) => m.monitorId);
+        : monitors.map((m) => m.monitorId)
+      : [];
 
-      const _monitors = await db
-        .select()
-        .from(monitor)
-        .where(
-          and(
-            inArray(monitor.id, monitorIds),
-            eq(monitor.workspaceId, workspaceId),
-            isNull(monitor.deletedAt),
-          ),
-        )
-        .all();
+    const monitorsData = monitors?.length
+      ? await db
+          .select()
+          .from(monitor)
+          .where(
+            and(
+              inArray(monitor.id, monitorIds),
+              eq(monitor.workspaceId, workspaceId),
+              isNull(monitor.deletedAt),
+            ),
+          )
+          .all()
+      : [];
 
-      if (_monitors.length !== monitors.length) {
+    if (monitors?.length) {
+      if (monitorsData.length !== monitors.length) {
         throw new OpenStatusApiError({
           code: "BAD_REQUEST",
           message: `Some of the monitors ${monitorIds.join(", ")} not found`,
         });
       }
     }
+
+    const monitorsById = new Map(monitorsData.map((m) => [m.id, m]));
 
     const _page = await db
       .insert(page)
@@ -177,13 +183,7 @@ export function registerPostPage(api: typeof pagesApi) {
       for (const [index, m] of monitors.entries()) {
         const values = typeof m === "number" ? { monitorId: m } : m;
 
-        const _monitor = await db.query.monitor.findFirst({
-          where: and(
-            eq(monitor.id, values.monitorId),
-            eq(monitor.workspaceId, workspaceId),
-            isNull(monitor.deletedAt),
-          ),
-        });
+        const _monitor = monitorsById.get(values.monitorId);
 
         if (!_monitor) {
           throw new OpenStatusApiError({

--- a/apps/server/src/routes/v1/pages/put.ts
+++ b/apps/server/src/routes/v1/pages/put.ts
@@ -143,19 +143,21 @@ export function registerPutPage(api: typeof pagesApi) {
         : monitors.map((m) => m.monitorId)
       : [];
 
-    if (monitors?.length) {
-      const monitorsData = await db
-        .select()
-        .from(monitor)
-        .where(
-          and(
-            inArray(monitor.id, monitorIds),
-            eq(monitor.workspaceId, workspaceId),
-            isNull(monitor.deletedAt),
-          ),
-        )
-        .all();
+    const monitorsData = monitors?.length
+      ? await db
+          .select()
+          .from(monitor)
+          .where(
+            and(
+              inArray(monitor.id, monitorIds),
+              eq(monitor.workspaceId, workspaceId),
+              isNull(monitor.deletedAt),
+            ),
+          )
+          .all()
+      : [];
 
+    if (monitors?.length) {
       if (monitorsData.length !== monitors.length) {
         throw new OpenStatusApiError({
           code: "BAD_REQUEST",
@@ -163,6 +165,8 @@ export function registerPutPage(api: typeof pagesApi) {
         });
       }
     }
+
+    const monitorsById = new Map(monitorsData.map((m) => [m.id, m]));
 
     const newPage = await db
       .update(page)
@@ -209,13 +213,7 @@ export function registerPutPage(api: typeof pagesApi) {
       for (const [index, m] of monitors.entries()) {
         const values = typeof m === "number" ? { monitorId: m } : m;
 
-        const _monitor = await db.query.monitor.findFirst({
-          where: and(
-            eq(monitor.id, values.monitorId),
-            eq(monitor.workspaceId, workspaceId),
-            isNull(monitor.deletedAt),
-          ),
-        });
+        const _monitor = monitorsById.get(values.monitorId);
 
         if (!_monitor) {
           throw new OpenStatusApiError({


### PR DESCRIPTION
## Summary

- reuse the monitor rows already fetched for page validation
- remove one redundant monitor lookup per component in the POST and PUT routes
- preserve monitor validation, ordering, and external name behavior

## Verification

- `pnpm verify`
- targeted POST and PUT page route tests: 22 passed, 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

