### PR TITLE
feat: add Passbolt theme to theme store

### DIFF
--- a/packages/theme-store/src/index.ts
+++ b/packages/theme-store/src/index.ts
@@ -8,6 +8,7 @@ import {
 import { DRACULA_THEME } from "./dracula";
 import { GITHUB_HIGH_CONTRAST_THEME } from "./github";
 import { OPENSTATUS_ROUNDED_THEME, OPENSTATUS_THEME } from "./openstatus";
+import { PASSBOLT_THEME } from "./passbolt";
 import { SUPABASE_THEME } from "./supabase";
 import type { Theme, ThemeDefinition, ThemeMap } from "./types";
 import { assertUniqueThemeIds } from "./utils";
@@ -18,6 +19,7 @@ const THEMES_LIST = [
   SUPABASE_THEME,
   GITHUB_HIGH_CONTRAST_THEME,
   DRACULA_THEME,
+  PASSBOLT_THEME,
 ] satisfies Theme[];
 
 // NOTE: runtime validation to ensure that the theme IDs are unique

--- a/packages/theme-store/src/passbolt.ts
+++ b/packages/theme-store/src/passbolt.ts
@@ -1,0 +1,51 @@
+import type { Theme } from "./types";
+
+export const PASSBOLT_THEME = {
+  id: "passbolt",
+  name: "Passbolt",
+  author: { name: "@Passbolt", url: "https://passbolt.com" },
+  light: {
+    "--background": "oklch(100% 0 0)",
+    "--foreground": "#000000",
+    "--border": "oklch(92.2% 0 0)",
+    "--input": "oklch(92.2% 0 0)",
+    "--primary": "#3b83d7",
+
+    "--primary-foreground": "oklch(98.5% 0 0)",
+    "--secondary": "oklch(97% 0 0)",
+    "--secondary-foreground": "oklch(20.5% 0 0)",
+    "--muted": "oklch(97% 0 0)",
+    "--muted-foreground": "oklch(55.6% 0 0)",
+    "--accent": "oklch(97% 0 0)",
+    "--accent-foreground": "#0f0f0f",
+
+    "--success": "#b6dcaf",
+    "--destructive": "#ffa6a6",
+    "--warning": "#ffdca8",
+    "--info": "#abd2f9",
+
+    "--radius": "0.5rem"
+  },
+  dark: {
+    "--background": "#171717",
+    "--foreground": "#ffffff",
+    "--border": "#333333",
+    "--input": "#000000",
+
+    "--primary": "#58acff",
+    "--primary-foreground": "#ffffff",
+    "--secondary": "#000000",
+    "--secondary-foreground": "oklch(98.5% 0 0)",
+    "--muted": "#333333",
+    "--muted-foreground": "#999999",
+    "--accent": "oklch(26.9% 0 0)",
+    "--accent-foreground": "#ffffff",
+
+    "--success": "#088869",
+    "--destructive": "#d40101",
+    "--warning": "#f2ae55",
+    "--info": "#4b92d9",
+
+    "--radius": "0.5rem"
+  },
+} as const satisfies Theme;

--- a/packages/theme-store/src/passbolt.ts
+++ b/packages/theme-store/src/passbolt.ts
@@ -24,7 +24,7 @@ export const PASSBOLT_THEME = {
     "--warning": "#ffdca8",
     "--info": "#abd2f9",
 
-    "--radius": "0.5rem"
+    "--radius": "0.5rem",
   },
   dark: {
     "--background": "#171717",
@@ -46,6 +46,6 @@ export const PASSBOLT_THEME = {
     "--warning": "#f2ae55",
     "--info": "#4b92d9",
 
-    "--radius": "0.5rem"
+    "--radius": "0.5rem",
   },
 } as const satisfies Theme;


### PR DESCRIPTION
## What

Adds an official **Passbolt** theme to the theme store, so it's available to all OpenStatus users.

Passbolt (https://passbolt.com) is an open-source password manager for teams. We're excited to make our brand theme available for status pages! 🔐

## Changes

- Added `passbolt.ts` with light and dark variants
- Registered `PASSBOLT_THEME` in `THEMES_LIST`

## Testing

- Tested locally via `dev:status-page` on the theme explorer and `/status` page, in both light and dark mode

## Screenshots

### Light
<img width="1716" height="1286" alt="light" src="https://github.com/user-attachments/assets/99d4443c-2002-455c-b861-adff6a0ea19e" />
 
### Dark 
<img width="1723" height="1289" alt="dark" src="https://github.com/user-attachments/assets/1c7949ff-9f0b-4d42-894d-7fdd6287a14d" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

