### PR TITLE
fix(status-page): keep the full path on host-keyed status pages

### DIFF
--- a/apps/status-page/src/lib/resolve-route.test.ts
+++ b/apps/status-page/src/lib/resolve-route.test.ts
@@ -364,6 +364,136 @@ describe("resolveRoute", () => {
     });
   });
 
+  // Custom domains with fewer than three labels, or a "www." first label, are
+  // still host-keyed: the path must not be read as `/{slug}/...`.
+  describe('custom domain routing — apex and "www." hosts', () => {
+    test("acme.com/events/report/1 → hostname routing, path preserved", () => {
+      const result = resolveRoute({
+        host: "acme.com",
+        urlHost: "acme.com",
+        pathname: "/events/report/1",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "acme.com",
+        locale: "en",
+        localeExplicit: false,
+        rewritePath: "/acme.com/en/events/report/1",
+      });
+    });
+
+    test("acme.com/fr/events/maintenance/1 → explicit locale, path preserved", () => {
+      const result = resolveRoute({
+        host: "acme.com",
+        urlHost: "acme.com",
+        pathname: "/fr/events/maintenance/1",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "acme.com",
+        locale: "fr",
+        localeExplicit: true,
+        rewritePath: "/acme.com/fr/events/maintenance/1",
+      });
+    });
+
+    test("www.acme.com/monitors/1 → hostname routing, path preserved", () => {
+      const result = resolveRoute({
+        host: "www.acme.com",
+        urlHost: "www.acme.com",
+        pathname: "/monitors/1",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "www.acme.com",
+        locale: "en",
+        localeExplicit: false,
+        rewritePath: "/www.acme.com/en/monitors/1",
+      });
+    });
+  });
+
+  // apps/web proxies a custom domain as `https://www.stpg.dev/{host}/{rest}`
+  // while forwarding the original host, so the leading segment is redundant.
+  describe("custom domain routing — host also present as path prefix", () => {
+    test("status.acme.com + /status.acme.com/events/report/1 → segment not duplicated", () => {
+      const result = resolveRoute({
+        host: "status.acme.com",
+        urlHost: "www.stpg.dev",
+        pathname: "/status.acme.com/events/report/1",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "status.acme.com",
+        locale: "en",
+        localeExplicit: false,
+        rewritePath: "/status.acme.com/en/events/report/1",
+      });
+    });
+
+    test("status.acme.com + /status.acme.com/fr/events → locale read after the prefix", () => {
+      const result = resolveRoute({
+        host: "status.acme.com",
+        urlHost: "www.stpg.dev",
+        pathname: "/status.acme.com/fr/events",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "status.acme.com",
+        locale: "fr",
+        localeExplicit: true,
+        rewritePath: "/status.acme.com/fr/events",
+      });
+    });
+
+    test("status.acme.com + /status.acme.com → page root", () => {
+      const result = resolveRoute({
+        host: "status.acme.com",
+        urlHost: "www.stpg.dev",
+        pathname: "/status.acme.com",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "status.acme.com",
+        locale: "en",
+        localeExplicit: false,
+        rewritePath: "/status.acme.com/en",
+      });
+    });
+
+    test("subdomain + /acme.openstatus.dev/events → forwarded host stripped", () => {
+      const result = resolveRoute({
+        host: "acme.openstatus.dev",
+        urlHost: "www.stpg.dev",
+        pathname: "/acme.openstatus.dev/events",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "acme",
+        locale: "en",
+        localeExplicit: false,
+        rewritePath: "/acme/en/events",
+      });
+    });
+
+    // Only the host is stripped: a first segment that merely matches the slug is
+    // real path, e.g. a page whose slug is also a route name.
+    test('slug "monitors" + /monitors/1 → segment kept', () => {
+      const result = resolveRoute({
+        host: "monitors.stpg.dev",
+        urlHost: "monitors.stpg.dev",
+        pathname: "/monitors/1",
+      });
+      expect(result).toEqual({
+        type: "hostname",
+        prefix: "monitors",
+        locale: "en",
+        localeExplicit: false,
+        rewritePath: "/monitors/en/monitors/1",
+      });
+    });
+  });
+
   describe("edge cases", () => {
     test("root path on localhost returns null (no page)", () => {
       const result = resolveRoute({

--- a/apps/status-page/src/lib/resolve-route.ts
+++ b/apps/status-page/src/lib/resolve-route.ts
@@ -1,5 +1,5 @@
 import { type Locale, defaultLocale, locales } from "../i18n/config";
-import { getValidSubdomain } from "./domain";
+import { getValidSubdomain, stripHostPort } from "./domain";
 
 export type RouteType = "hostname" | "pathname";
 
@@ -53,6 +53,10 @@ export function resolveRoute({
 
   if (subdomain !== null) {
     prefix = subdomain.toLowerCase();
+    // Host-keyed: the path carries no slug. Apex (`acme.com`) and `www.` custom
+    // domains fail the label check above, and reading their first segment as the
+    // slug would drop it (`/events/report/1` → `/{slug}/{locale}/report/1`).
+    type = "hostname";
   }
 
   // Root path on non-hostname type — no page to resolve
@@ -69,12 +73,21 @@ export function resolveRoute({
 
   // Resolve locale based on routing type
   if (type === "hostname") {
-    const firstSegment = pathnames[1]?.toLowerCase();
+    // apps/web proxies custom domains as `https://www.stpg.dev/{host}/{rest}`
+    // and forwards the original host, so drop a leading segment that repeats
+    // the prefix — keeping it duplicates the domain inside the rewrite path.
+    const hostSegment = stripHostPort(host ?? urlHost)?.toLowerCase();
+    const segments =
+      pathnames[1]?.toLowerCase() === hostSegment
+        ? pathnames.slice(1)
+        : pathnames;
+
+    const firstSegment = segments[1]?.toLowerCase();
     const locale: Locale = isLocale(firstSegment)
       ? firstSegment
       : defaultLocale;
     const hasLocale = isLocale(firstSegment);
-    const rest = (hasLocale ? pathnames.slice(2) : pathnames.slice(1))
+    const rest = (hasLocale ? segments.slice(2) : segments.slice(1))
       .filter(Boolean)
       .join("/");
 


### PR DESCRIPTION
#2551 dropped `resolveCustomDomainRewrite`, which built its rewrite from the
raw pathname and so masked two assumptions in `resolveRoute`. With the default
rewrite now serving custom domains, both surfaced as 404s on the deeper routes
(`/events/report/{id}`, `/events/maintenance/{id}`, `/monitors/{id}`):

- Apex (`acme.com`) and `www.` custom domains fail the `hostnames.length > 2`
  check, so they resolved as pathname routing and the first path segment was
  read as the slug and dropped: `/events/report/1` → `/{slug}/en/report/1`.
  A detected subdomain or custom domain is always host-keyed — set the type
  accordingly.
- apps/web proxies custom domains as `https://www.stpg.dev/{host}/{rest}` while
  forwarding the original host. Hostname routing then kept that leading segment
  as path, duplicating the domain: `/{slug}/en/status.acme.com/events/report/1`.
  Strip a leading segment that repeats the forwarded host.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0199Y2TaeKd8PPLBPEUFSqci

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

