### PR TITLE
fix: never store a check under a region the user did not select

### DIFF
--- a/apps/checker/handlers/checker.go
+++ b/apps/checker/handlers/checker.go
@@ -55,15 +55,8 @@ func (h Handler) HTTPCheckerHandler(c *gin.Context) {
 		return
 	}
 
-	if h.CloudProvider == "fly" {
-		// if the request has been routed to a wrong region, we forward it to the correct one.
-		region := c.GetHeader("fly-prefer-region")
-		if region != "" && region != h.Region {
-			c.Header("fly-replay", fmt.Sprintf("region=%s", region))
-			c.String(http.StatusAccepted, "Forwarding request to %s", region)
-
-			return
-		}
+	if !h.serveRegion(c, requestedRegion(c)) {
+		return
 	}
 
 	var req request.HttpCheckerRequest

--- a/apps/checker/handlers/dns.go
+++ b/apps/checker/handlers/dns.go
@@ -68,14 +68,8 @@ func (h Handler) DNSHandler(c *gin.Context) {
 		return
 	}
 
-	// Fly region forwarding
-	if h.CloudProvider == "fly" {
-		region := c.GetHeader("fly-prefer-region")
-		if region != "" && region != h.Region {
-			c.Header("fly-replay", fmt.Sprintf("region=%s", region))
-			c.String(http.StatusAccepted, "Forwarding request to %s", region)
-			return
-		}
+	if !h.serveRegion(c, requestedRegion(c)) {
+		return
 	}
 
 	// Parse request
@@ -249,20 +243,20 @@ func (h Handler) DNSHandlerRegion(c *gin.Context) {
 	dataSourceName := "check_response_dns__v0"
 	const defaultRetry = 3
 
+	region := c.Param("region")
+	if region == "" {
+		c.String(http.StatusBadRequest, "region is required")
+		return
+	}
+
 	// Authorization check
 	if c.GetHeader("Authorization") != fmt.Sprintf("Basic %s", h.Secret) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
 
-	// Fly region forwarding
-	if h.CloudProvider == "fly" {
-		region := c.GetHeader("fly-prefer-region")
-		if region != "" && region != h.Region {
-			c.Header("fly-replay", fmt.Sprintf("region=%s", region))
-			c.String(http.StatusAccepted, "Forwarding request to %s", region)
-			return
-		}
+	if !h.serveRegion(c, region) {
+		return
 	}
 
 	// Parse request

--- a/apps/checker/handlers/ping.go
+++ b/apps/checker/handlers/ping.go
@@ -59,13 +59,8 @@ func (h Handler) PingRegionHandler(c *gin.Context) {
 		return
 	}
 
-	if h.CloudProvider == "fly" {
-		if region != h.Region {
-			c.Header("fly-replay", fmt.Sprintf("region=%s", region))
-			c.String(http.StatusAccepted, "Forwarding request to %s", region)
-
-			return
-		}
+	if !h.serveRegion(c, region) {
+		return
 	}
 
 	//  We need a new client for each request to avoid connection reuse.

--- a/apps/checker/handlers/region.go
+++ b/apps/checker/handlers/region.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+)
+
+// requestedRegion is the region the caller asked the check to run in. The query
+// parameter is authoritative: fly-prefer-region is consumed by fly-proxy, which
+// silently falls back to the nearest healthy region, so a request landing here
+// is no proof this is the region that was asked for.
+func requestedRegion(c *gin.Context) string {
+	if region := c.Query("region"); region != "" {
+		return region
+	}
+
+	if region := c.GetHeader("fly-force-region"); region != "" {
+		return region
+	}
+
+	return c.GetHeader("fly-prefer-region")
+}
+
+// serveRegion reports whether this machine may run the check. A misrouted
+// request is replayed to the region the caller asked for; once the proxy tells
+// us the replay itself failed we refuse the request, because running it here
+// would store the check under a region the user never selected.
+func (h Handler) serveRegion(c *gin.Context, region string) bool {
+	if region == "" || region == h.Region {
+		return true
+	}
+
+	replayFailed := c.GetHeader("fly-replay-failed")
+
+	if h.CloudProvider != "fly" {
+		// Koyeb and Railway have no replay mechanism, and their region strings
+		// are not verified end to end yet: keep serving, but make it visible.
+		log.Ctx(c.Request.Context()).Warn().
+			Str("requested_region", region).
+			Str("region", h.Region).
+			Msg("check served from a region the caller did not request")
+
+		return true
+	}
+
+	if replayFailed == "" {
+		c.Header("fly-replay", fmt.Sprintf("region=%s;fallback=force_self", region))
+		c.String(http.StatusAccepted, "Forwarding request to %s", region)
+
+		return false
+	}
+
+	log.Ctx(c.Request.Context()).Error().
+		Str("requested_region", region).
+		Str("region", h.Region).
+		Str("fly_replay_failed", replayFailed).
+		Msg("check dropped: request could not be routed to the requested region")
+
+	c.JSON(http.StatusServiceUnavailable, gin.H{
+		"error":  fmt.Sprintf("region %s is unavailable", region),
+		"region": h.Region,
+	})
+
+	return false
+}

--- a/apps/checker/handlers/region_internal_test.go
+++ b/apps/checker/handlers/region_internal_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func regionContext(t *testing.T, target string, headers map[string]string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, target, nil)
+
+	for key, value := range headers {
+		c.Request.Header.Set(key, value)
+	}
+
+	return c, rec
+}
+
+func TestRequestedRegionPrefersQueryParam(t *testing.T) {
+	c, _ := regionContext(t, "/checker/http?region=fra", map[string]string{
+		"fly-force-region": "arn",
+	})
+
+	if got := requestedRegion(c); got != "fra" {
+		t.Fatalf("requestedRegion() = %q, want %q", got, "fra")
+	}
+}
+
+func TestRequestedRegionFallsBackToHeaders(t *testing.T) {
+	c, _ := regionContext(t, "/checker/http", map[string]string{
+		"fly-prefer-region": "ams",
+	})
+
+	if got := requestedRegion(c); got != "ams" {
+		t.Fatalf("requestedRegion() = %q, want %q", got, "ams")
+	}
+}
+
+func TestServeRegionMatching(t *testing.T) {
+	h := Handler{CloudProvider: "fly", Region: "ams"}
+	c, _ := regionContext(t, "/checker/http?region=ams", nil)
+
+	if !h.serveRegion(c, requestedRegion(c)) {
+		t.Fatal("serveRegion() = false, want true for the requested region")
+	}
+}
+
+func TestServeRegionReplaysMisroutedRequest(t *testing.T) {
+	h := Handler{CloudProvider: "fly", Region: "arn"}
+	c, rec := regionContext(t, "/checker/http?region=fra", nil)
+
+	if h.serveRegion(c, requestedRegion(c)) {
+		t.Fatal("serveRegion() = true, want false for a misrouted request")
+	}
+	if got := rec.Header().Get("fly-replay"); got != "region=fra;fallback=force_self" {
+		t.Fatalf("fly-replay = %q, want the request replayed to fra", got)
+	}
+}
+
+func TestServeRegionDropsCheckWhenReplayFailed(t *testing.T) {
+	h := Handler{CloudProvider: "fly", Region: "arn"}
+	c, rec := regionContext(t, "/checker/http?region=fra", map[string]string{
+		"fly-replay-failed": "region=fra;reason=no_candidate",
+	})
+
+	if h.serveRegion(c, requestedRegion(c)) {
+		t.Fatal("serveRegion() = true, want false once the replay failed")
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if got := rec.Header().Get("fly-replay"); got != "" {
+		t.Fatalf("fly-replay = %q, want no second replay", got)
+	}
+}
+
+func TestServeRegionKeepsServingOutsideFly(t *testing.T) {
+	h := Handler{CloudProvider: "koyeb", Region: "koyeb_fra"}
+	c, _ := regionContext(t, "/ping/koyeb_par", nil)
+
+	if !h.serveRegion(c, "koyeb_par") {
+		t.Fatal("serveRegion() = false, want true: only Fly can replay")
+	}
+}

--- a/apps/checker/handlers/tcp.go
+++ b/apps/checker/handlers/tcp.go
@@ -46,15 +46,8 @@ func (h Handler) TCPHandler(c *gin.Context) {
 		return
 	}
 
-	if h.CloudProvider == "fly" {
-		// if the request has been routed to a wrong region, we forward it to the correct one.
-		region := c.GetHeader("fly-prefer-region")
-		if region != "" && region != h.Region {
-			c.Header("fly-replay", fmt.Sprintf("region=%s", region))
-			c.String(http.StatusAccepted, "Forwarding request to %s", region)
-
-			return
-		}
+	if !h.serveRegion(c, requestedRegion(c)) {
+		return
 	}
 
 	var req request.TCPCheckerRequest
@@ -271,15 +264,8 @@ func (h Handler) TCPHandlerRegion(c *gin.Context) {
 		return
 	}
 
-	if h.CloudProvider == "fly" {
-		// if the request has been routed to a wrong region, we forward it to the correct one.
-		region := c.GetHeader("fly-prefer-region")
-		if region != "" && region != h.Region {
-			c.Header("fly-replay", fmt.Sprintf("region=%s", region))
-			c.String(http.StatusAccepted, "Forwarding request to %s", region)
-
-			return
-		}
+	if !h.serveRegion(c, region) {
+		return
 	}
 
 	var req request.TCPCheckerRequest

--- a/apps/server/src/libs/checker/utils.ts
+++ b/apps/server/src/libs/checker/utils.ts
@@ -1,5 +1,6 @@
 import type { z } from "@hono/zod-openapi";
 import type { selectMonitorSchema } from "@openstatus/db/src/schema";
+import type { Region } from "@openstatus/db/src/schema/constants";
 import {
   type httpPayloadSchema,
   type tpcPayloadSchema,
@@ -76,16 +77,17 @@ export function getCheckerTimeout(
 
 export function getCheckerUrl(
   monitor: z.infer<typeof selectMonitorSchema>,
-  opts: { trigger?: "api" | "cron"; data?: boolean } = {
+  opts: { trigger?: "api" | "cron"; data?: boolean; region?: Region } = {
     trigger: "api",
     data: false,
   },
 ): string {
+  const region = opts.region ? `&region=${opts.region}` : "";
   switch (monitor.jobType) {
     case "http":
-      return `https://openstatus-checker.fly.dev/checker/http?monitor_id=${monitor.id}&trigger=${opts.trigger}&data=${opts.data}`;
+      return `https://openstatus-checker.fly.dev/checker/http?monitor_id=${monitor.id}&trigger=${opts.trigger}&data=${opts.data}${region}`;
     case "tcp":
-      return `https://openstatus-checker.fly.dev/checker/tcp?monitor_id=${monitor.id}&trigger=${opts.trigger}&data=${opts.data}`;
+      return `https://openstatus-checker.fly.dev/checker/tcp?monitor_id=${monitor.id}&trigger=${opts.trigger}&data=${opts.data}${region}`;
     default:
       throw new OpenStatusApiError({
         code: "BAD_REQUEST",

--- a/apps/server/src/routes/rpc/handlers/monitor/index.ts
+++ b/apps/server/src/routes/rpc/handlers/monitor/index.ts
@@ -15,6 +15,7 @@ import type {
   TCPMonitor,
 } from "@openstatus/proto/monitor/v1";
 import { TimeRange } from "@openstatus/proto/monitor/v1";
+import { regionDict } from "@openstatus/regions";
 import {
   ForbiddenError,
   LimitExceededError,
@@ -474,26 +475,29 @@ export const monitorServiceImpl: ServiceImpl<typeof MonitorService> = {
     }
 
     const row = run.monitor;
-    const url = getCheckerUrl(row);
     const timeout = getCheckerTimeout(row);
 
-    // Trigger checks for each region in parallel
+    // Trigger checks for each region in parallel. A deprecated region has no
+    // checker machine, and Fly serves the check from the nearest one instead,
+    // storing it under that region.
     await Promise.all(
-      row.regions.map((region) => {
-        const status = run.regionStatus.get(region) || "active";
-        const payload = getCheckerPayload(row, status);
+      row.regions
+        .filter((region) => !regionDict[region]?.deprecated)
+        .map((region) => {
+          const status = run.regionStatus.get(region) || "active";
+          const payload = getCheckerPayload(row, status);
 
-        return fetch(url, {
-          headers: {
-            "Content-Type": "application/json",
-            "fly-prefer-region": region,
-            Authorization: `Basic ${env.CRON_SECRET}`,
-          },
-          method: "POST",
-          body: JSON.stringify(payload),
-          signal: AbortSignal.timeout(timeout),
-        });
-      }),
+          return fetch(getCheckerUrl(row, { region }), {
+            headers: {
+              "Content-Type": "application/json",
+              "fly-force-region": region,
+              Authorization: `Basic ${env.CRON_SECRET}`,
+            },
+            method: "POST",
+            body: JSON.stringify(payload),
+            signal: AbortSignal.timeout(timeout),
+          });
+        }),
     );
 
     return { success: true };

--- a/apps/server/src/routes/v1/check/http/post.ts
+++ b/apps/server/src/routes/v1/check/http/post.ts
@@ -78,7 +78,7 @@ export function registerHTTPPostCheck(api: typeof checkApi) {
           headers: {
             Authorization: `Basic ${env.CRON_SECRET}`,
             "Content-Type": "application/json",
-            "fly-prefer-region": region,
+            "fly-force-region": region,
           },
           method: "POST",
           body: JSON.stringify({

--- a/apps/server/src/routes/v1/monitors/run/post.ts
+++ b/apps/server/src/routes/v1/monitors/run/post.ts
@@ -1,6 +1,7 @@
 import { createRoute } from "@hono/zod-openapi";
 import { getLogger } from "@logtape/logtape";
 import { and, eq, gte, isNull, sql } from "@openstatus/db";
+import { regionDict } from "@openstatus/regions";
 
 import { env } from "@/env";
 import {
@@ -136,15 +137,19 @@ export function registerRunMonitor(api: typeof monitorsApi) {
 
     const allResult = [];
     for (const region of parseMonitor.data.regions) {
+      // A deprecated region has no checker machine, and Fly serves the check
+      // from the nearest one instead, storing it under that region.
+      if (regionDict[region]?.deprecated) continue;
+
       const status =
         monitorStatus.data.find((m) => region === m.region)?.status || "active";
       const payload = getCheckerPayload(row, status);
-      const url = getCheckerUrl(row, { data: true });
+      const url = getCheckerUrl(row, { data: true, region });
 
       const result = fetch(url, {
         headers: {
           "Content-Type": "application/json",
-          "fly-prefer-region": region, // Specify the region you want the request to be sent to
+          "fly-force-region": region, // Specify the region you want the request to be sent to
           Authorization: `Basic ${env.CRON_SECRET}`,
         },
         method: "POST",

--- a/apps/server/src/routes/v1/monitors/trigger/post.ts
+++ b/apps/server/src/routes/v1/monitors/trigger/post.ts
@@ -6,6 +6,7 @@ import { monitorStatusTable } from "@openstatus/db/src/schema/monitor_status/mon
 import { selectMonitorStatusSchema } from "@openstatus/db/src/schema/monitor_status/validation";
 import { monitor } from "@openstatus/db/src/schema/monitors/monitor";
 import { selectMonitorSchema } from "@openstatus/db/src/schema/monitors/validation";
+import { regionDict } from "@openstatus/regions";
 import { HTTPException } from "hono/http-exception";
 
 import { env } from "@/env";
@@ -137,15 +138,19 @@ export function registerTriggerMonitor(api: typeof monitorsApi) {
     const allResult = [];
 
     for (const region of validateMonitor.data.regions) {
+      // A deprecated region has no checker machine, and Fly serves the check
+      // from the nearest one instead, storing it under that region.
+      if (regionDict[region]?.deprecated) continue;
+
       const status =
         monitorStatus.data.find((m) => region === m.region)?.status || "active";
       const payload = getCheckerPayload(row, status);
-      const url = getCheckerUrl(row);
+      const url = getCheckerUrl(row, { region });
 
       const result = fetch(url, {
         headers: {
           "Content-Type": "application/json",
-          "fly-prefer-region": region, // Specify the region you want the request to be sent to
+          "fly-force-region": region, // Specify the region you want the request to be sent to
           Authorization: `Basic ${env.CRON_SECRET}`,
         },
         method: "POST",

--- a/apps/web/src/app/api/checker/cron/_cron.ts
+++ b/apps/web/src/app/api/checker/cron/_cron.ts
@@ -240,7 +240,7 @@ const createCronTask = async ({
   const regionInfo = regionDict[region];
   let regionHeader = {};
   if (regionInfo.provider === "fly") {
-    regionHeader = { "fly-prefer-region": region };
+    regionHeader = { "fly-force-region": region };
   }
   if (regionInfo.provider === "koyeb") {
     regionHeader = { "X-KOYEB-REGION-OVERRIDE": region.replace("koyeb_", "") };
@@ -279,7 +279,7 @@ function generateUrl({
 
   switch (regionInfo.provider) {
     case "fly":
-      return `https://openstatus-checker.fly.dev/checker/${row.jobType}?monitor_id=${row.id}`;
+      return `https://openstatus-checker.fly.dev/checker/${row.jobType}?monitor_id=${row.id}&region=${region}`;
     case "koyeb":
       return `https://openstatus-checker.koyeb.app/checker/${row.jobType}?monitor_id=${row.id}`;
     case "railway":

--- a/apps/web/src/app/api/checker/test/tcp/route.ts
+++ b/apps/web/src/app/api/checker/test/tcp/route.ts
@@ -44,7 +44,7 @@ async function checkTCP(url: string, region: Region) {
     headers: {
       Authorization: `Basic ${process.env.CRON_SECRET}`,
       "Content-Type": "application/json",
-      "fly-prefer-region": region,
+      "fly-force-region": region,
     },
     method: "POST",
     body: JSON.stringify({

--- a/apps/web/src/lib/checker/utils.ts
+++ b/apps/web/src/lib/checker/utils.ts
@@ -193,7 +193,7 @@ export async function checkRegion(
   switch (regionInfo.provider) {
     case "fly":
       endpoint = `${FLY_CHECKER_URL}/${region}`;
-      regionHeader = { "fly-prefer-region": region };
+      regionHeader = { "fly-force-region": region };
       break;
     case "koyeb":
       endpoint = `${KOYEB_CHECKER_URL}/${region}`;

--- a/apps/workflows/src/cron/checker.ts
+++ b/apps/workflows/src/cron/checker.ts
@@ -360,7 +360,7 @@ const createCronTask = async (
   const regionInfo = regionDict[region];
   let regionHeader = {};
   if (regionInfo.provider === "fly") {
-    regionHeader = { "fly-prefer-region": region };
+    regionHeader = { "fly-force-region": region };
   }
   if (regionInfo.provider === "koyeb") {
     regionHeader = { "X-KOYEB-REGION-OVERRIDE": region.replace("koyeb_", "") };
@@ -401,7 +401,7 @@ function generateUrl({
 
   switch (regionInfo.provider) {
     case "fly":
-      return `https://openstatus-checker.fly.dev/checker/${row.jobType}?monitor_id=${row.id}`;
+      return `https://openstatus-checker.fly.dev/checker/${row.jobType}?monitor_id=${row.id}&region=${region}`;
     case "koyeb":
       return `https://openstatus-checker.koyeb.app/checker/${row.jobType}?monitor_id=${row.id}`;
     case "railway":

--- a/packages/api/src/router/checker.ts
+++ b/packages/api/src/router/checker.ts
@@ -10,7 +10,11 @@ import {
 } from "@openstatus/assertions";
 import { and, db, eq } from "@openstatus/db";
 import { monitor, selectMonitorSchema } from "@openstatus/db/src/schema";
-import { monitorRegionSchema } from "@openstatus/db/src/schema/constants";
+import {
+  type Region,
+  monitorRegionSchema,
+} from "@openstatus/db/src/schema/constants";
+import { regionDict } from "@openstatus/regions";
 import {
   type httpPayloadSchema,
   safeUrlSchema,
@@ -166,7 +170,7 @@ export async function testHttp(input: z.infer<typeof httpTestInput>) {
         headers: {
           Authorization: `Basic ${env.CRON_SECRET}`,
           "Content-Type": "application/json",
-          "fly-prefer-region": input.region,
+          "fly-force-region": input.region,
         },
         body: JSON.stringify({
           url: input.url,
@@ -258,7 +262,7 @@ export async function testTcp(input: z.infer<typeof tcpTestInput>) {
         headers: {
           Authorization: `Basic ${env.CRON_SECRET}`,
           "Content-Type": "application/json",
-          "fly-prefer-region": input.region,
+          "fly-force-region": input.region,
         },
         body: JSON.stringify({ uri: input.url }),
         signal: AbortSignal.timeout(ABORT_TIMEOUT),
@@ -309,7 +313,7 @@ export async function testDns(input: z.infer<typeof dnsTestInput>) {
         headers: {
           Authorization: `Basic ${env.CRON_SECRET}`,
           "Content-Type": "application/json",
-          "fly-prefer-region": input.region,
+          "fly-force-region": input.region,
         },
         body: JSON.stringify({
           uri: input.url,
@@ -453,12 +457,16 @@ export async function triggerChecker(
   const allResult = [];
 
   for (const region of input.regions) {
-    const res = fetch(generateUrl({ row: input }), {
+    // A deprecated region has no checker machine, and Fly serves the check from
+    // the nearest one instead, storing it under that region.
+    if (regionDict[region]?.deprecated) continue;
+
+    const res = fetch(generateUrl({ row: input, region }), {
       method: "POST",
       headers: {
         Authorization: `Basic ${env.CRON_SECRET}`,
         "Content-Type": "application/json",
-        "fly-prefer-region": region,
+        "fly-force-region": region,
       },
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(ABORT_TIMEOUT),
@@ -469,14 +477,20 @@ export async function triggerChecker(
   await Promise.allSettled(allResult);
 }
 
-function generateUrl({ row }: { row: z.infer<typeof selectMonitorSchema> }) {
+function generateUrl({
+  row,
+  region,
+}: {
+  row: z.infer<typeof selectMonitorSchema>;
+  region: Region;
+}) {
   switch (row.jobType) {
     case "http":
-      return `https://openstatus-checker.fly.dev/checker/http?monitor_id=${row.id}`;
+      return `https://openstatus-checker.fly.dev/checker/http?monitor_id=${row.id}&region=${region}`;
     case "tcp":
-      return `https://openstatus-checker.fly.dev/checker/tcp?monitor_id=${row.id}`;
+      return `https://openstatus-checker.fly.dev/checker/tcp?monitor_id=${row.id}&region=${region}`;
     case "dns":
-      return `https://openstatus-checker.fly.dev/checker/dns?monitor_id=${row.id}`;
+      return `https://openstatus-checker.fly.dev/checker/dns?monitor_id=${row.id}&region=${region}`;
     default:
       throw new Error("Invalid jobType");
   }

--- a/packages/services/src/monitor/stream-monitor-preview.ts
+++ b/packages/services/src/monitor/stream-monitor-preview.ts
@@ -63,7 +63,7 @@ function getCheckerEndpoint(region: Region): {
     case "fly":
       return {
         endpoint: `${FLY_CHECKER_URL}/${region}`,
-        regionHeader: { "fly-prefer-region": region },
+        regionHeader: { "fly-force-region": region },
       };
     case "koyeb":
       return {


### PR DESCRIPTION
## Summary

- A check that Fly routes away from the requested region is no longer stored under the region that happened to run it. Reported case: `arn` pings on a monitor where `arn` was never selected.
- The requested region now travels with the request as a `?region=` query param instead of relying on `fly-prefer-region` — a routing hint fly-proxy consumes, so the machine never saw it and could not tell it was the wrong one.
- A misrouted check is replayed to the region that was asked for (`fly-replay: region=X;fallback=force_self`). If the proxy reports the replay failed, the check is dropped with a 503 and an error log rather than ingested under the wrong region — a data gap instead of wrong data.
- The on-demand run/trigger paths (v1 `/run`, v1 `/trigger`, rpc `runMonitor`, and the create-page `triggerChecker`) now skip deprecated regions, like the cron already did. Those regions have no machine at all, so every one of their checks fell back to a neighbour.
- Dispatchers send `fly-force-region` instead of `fly-prefer-region`, so a region with an unhealthy machine fails loudly instead of spilling into the nearest one.

## Context

Probing `/health` once per fly region shows 17 of 35 have no checker machine and answer from a neighbour — exactly the regions marked `deprecated` in `packages/regions`. `waw` is the only one that falls back to `arn`:

```
waw -> arn    otp -> fra    hkg -> sin    mad -> cdg    bos -> ewr    yul -> yyz
atl,den,gdl,mia,qro -> dfw    bog,eze,gig,scl -> gru    phx -> lax    sea -> sjc
```

All 18 active fly regions answer with their own code, so nothing goes dark from the `fly-force-region` switch.

## Deploy order

Ship the checker first: it understands both the new query param and the old headers, the reverse is not true.

## Follow-ups (not in this PR)

- Existing monitors still carry deprecated regions in `monitor.regions`; those produce no cron data today and want a cleanup migration.
- After deploy, `check dropped: request could not be routed to the requested region` in Axiom reports which regions Fly is failing to route to, with the proxy's own reason (`timeout` / `retries_exhausted` / `no_candidate`).

## Test plan

- `go build ./...`, `go vet ./handlers`, `go test ./handlers` in `apps/checker` — green, including 6 new tests for the region guard (match, replay, drop-after-failed-replay, query param precedence, non-Fly providers).
- `pnpm verify` — the `deno check` failures in `packages/emails` (`hono/jsx`, `Buffer`) are pre-existing; error counts are identical with these changes stashed. DB-backed tests were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

