### PR TITLE
fix(dashboard): remove default active status filter from subscribers table (#2538)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/status-pages/[id]/subscribers/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/status-pages/[id]/subscribers/page.tsx
@@ -189,7 +189,6 @@ export default function Page() {
             data={subscribers}
             toolbarComponent={SubscribersDataTableToolbar}
             paginationComponent={DataTablePaginationSimple}
-            defaultColumnFilters={[{ id: "status", value: ["active"] }]}
           />
         ) : (
           <EmptyStateContainer>


### PR DESCRIPTION
## Summary
Resolves #2538 by removing the pre-selected `status: ["active"]` column filter on the subscribers data table.

### Changes
- Removed `defaultColumnFilters={[{ id: "status", value: ["active"] }]}` from `DataTable` on the subscribers page.
- Ensures all subscribers (including pending sign-ups) are visible by default without showing an empty table on newly configured status pages.

Closes #2538

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

