### PR TITLE
fix: correct typos in user-facing strings

### DIFF
--- a/apps/server/src/routes/v1/whoami/get.ts
+++ b/apps/server/src/routes/v1/whoami/get.ts
@@ -12,7 +12,7 @@ const getRoute = createRoute({
   method: "get",
   tags: ["whoami"],
   path: "/",
-  summary: "Get your informations",
+  summary: "Get your information",
   description: "Get the current workspace information attached to the API key.",
   responses: {
     200: {

--- a/apps/web/src/app/(landing)/play/checker/[slug]/client.tsx
+++ b/apps/web/src/app/(landing)/play/checker/[slug]/client.tsx
@@ -301,7 +301,7 @@ function InfoDialog({
         <DialogHeader>
           <DialogTitle>Response Details</DialogTitle>
           <DialogDescription>
-            Basic informations like header and latency about the response.
+            Basic information like header and latency about the response.
           </DialogDescription>
         </DialogHeader>
         <div className="prose dark:prose-invert max-w-none min-w-0">

--- a/apps/web/src/data/code-dictionary.ts
+++ b/apps/web/src/data/code-dictionary.ts
@@ -7,7 +7,7 @@ export const codesDict = {
   "2xx": {
     prefix: 2,
     label: "2xx",
-    name: "Successfull",
+    name: "Successful",
   },
   "3xx": {
     prefix: 3,


### PR DESCRIPTION
Three user-facing strings have spelling errors:

- `apps/web/src/data/code-dictionary.ts` — "Successfull" → "Successful"
- `apps/server/src/routes/v1/whoami/get.ts` — the OpenAPI summary reads "Get your informations"; "information" is uncountable
- `apps/web/src/app/(landing)/play/checker/[slug]/client.tsx` — "Basic informations like header and latency" → "Basic information"

All three appear either in the UI or in the published API docs. No behaviour change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

