### PR TITLE
docs: link ICMP monitor reference from the reference overview

### DIFF
--- a/apps/web/src/content/pages/docs/reference/overview.mdx
+++ b/apps/web/src/content/pages/docs/reference/overview.mdx
@@ -12,6 +12,7 @@ How each monitor type runs checks and what you can configure on it.
 
 - **[HTTP monitor](/docs/reference/http-monitor)** — URL, method, headers, body, assertions, regions.
 - **[TCP monitor](/docs/reference/tcp-monitor)** — host:port checks for non-HTTP services.
+- **[ICMP monitor](/docs/reference/icmp-monitor)** — ping checks for host reachability, latency, and packet loss.
 - **[DNS monitor](/docs/reference/dns-monitor)** — record-type assertions for A, AAAA, CNAME, MX, NS, TXT.
 
 ## Status pages


### PR DESCRIPTION
#2405 added the ICMP monitor reference page and put it in the docs sidebar, but the reference overview page still only lists HTTP, TCP and DNS under "Monitors". Since that page calls itself the source of truth for monitor types, someone skimming it would conclude ICMP isn't supported.

This adds the missing line, worded to match the implementation in `apps/checker/checker/icmp.go` (reachability, latency, packet loss). Checked that all internal links on the page resolve.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

