### PR TITLE
fix: correct jobType guard in DNS monitor update route

### DIFF
--- a/apps/server/src/routes/v1/monitors/put_dns.test.ts
+++ b/apps/server/src/routes/v1/monitors/put_dns.test.ts
@@ -3,6 +3,113 @@ import { test } from "@std/testing/bdd";
 
 import { app } from "@/index";
 
+import { MonitorSchema } from "./schema";
+
+test("update a dns monitor", async () => {
+  const create = await app.request("/v1/monitor/dns", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      frequency: "10m",
+      name: "OpenStatus",
+      description: "OpenStatus website",
+      regions: ["ams", "gru"],
+      request: {
+        uri: "openstatus.dev",
+      },
+      active: true,
+      public: true,
+    }),
+  });
+
+  expect(create.status).toBe(200);
+  const created = MonitorSchema.parse(await create.json());
+
+  const res = await app.request(`/v1/monitor/dns/${created.id}`, {
+    method: "PUT",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      frequency: "10m",
+      name: "New Name",
+      description: "OpenStatus website",
+      regions: ["ams", "gru"],
+      request: {
+        uri: "openstatus.dev",
+      },
+      active: true,
+      public: true,
+    }),
+  });
+
+  expect(res.status).toBe(200);
+  const updated = MonitorSchema.parse(await res.json());
+  expect(updated.name).toBe("New Name");
+
+  // Cleanup: delete the created monitor
+  await app.request(`/v1/monitor/${created.id}`, {
+    method: "DELETE",
+    headers: { "x-openstatus-key": "1" },
+  });
+});
+
+test("updating a tcp monitor via the dns route should return 404", async () => {
+  const create = await app.request("/v1/monitor/tcp", {
+    method: "POST",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      frequency: "10m",
+      name: "OpenStatus",
+      description: "OpenStatus website",
+      regions: ["ams", "gru"],
+      request: {
+        host: "openstatus.dev",
+        port: 443,
+      },
+      active: true,
+      public: true,
+    }),
+  });
+
+  expect(create.status).toBe(200);
+  const created = MonitorSchema.parse(await create.json());
+
+  const res = await app.request(`/v1/monitor/dns/${created.id}`, {
+    method: "PUT",
+    headers: {
+      "x-openstatus-key": "1",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      frequency: "10m",
+      name: "New Name",
+      description: "OpenStatus website",
+      regions: ["ams", "gru"],
+      request: {
+        uri: "openstatus.dev",
+      },
+      active: true,
+      public: true,
+    }),
+  });
+
+  expect(res.status).toBe(404);
+
+  // Cleanup: delete the created monitor
+  await app.request(`/v1/monitor/${created.id}`, {
+    method: "DELETE",
+    headers: { "x-openstatus-key": "1" },
+  });
+});
+
 test("update the monitor", async () => {
   const res = await app.request("/v1/monitor/dns/1", {
     method: "PUT",

--- a/apps/server/src/routes/v1/monitors/put_dns.ts
+++ b/apps/server/src/routes/v1/monitors/put_dns.ts
@@ -83,7 +83,7 @@ export function registerPutDNSMonitor(api: typeof monitorsApi) {
       });
     }
 
-    if (_monitor.jobType !== "tcp") {
+    if (_monitor.jobType !== "dns") {
       throw new OpenStatusApiError({
         code: "NOT_FOUND",
         message: `Monitor ${id} not found`,


### PR DESCRIPTION
Fixes #2604

`put_dns.ts` guarded on `jobType !== "tcp"`, so `PUT /v1/monitor/dns/{id}` 404'd for every DNS monitor, while TCP monitors could be updated through the DNS route. Changed the guard to `!== "dns"`, matching `put_http.ts` / `put_tcp.ts`.

Added two tests to `put_dns.test.ts`: create a DNS monitor via the API, update it, expect 200; and updating a TCP monitor via the DNS route now returns 404. Both create their own fixtures and clean up after themselves — the shared seed is untouched.

Full `apps/server` suite passes locally against a fresh sqld: 247 passed (1021 steps), 0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

