### PR TITLE
fix: prevent blank monitor names and status page titles

### DIFF
--- a/apps/dashboard/src/components/forms/monitor/form-general.tsx
+++ b/apps/dashboard/src/components/forms/monitor/form-general.tsx
@@ -77,7 +77,7 @@ const HTTP_ASSERTION_TYPES = ["status", "header", "textBody"] as const;
 const DNS_ASSERTION_TYPES = dnsRecords;
 
 const schema = z.object({
-  name: z.string().min(1, "Name is required"),
+  name: z.string().trim().min(1, "Name is required"),
   type: z.enum(TYPES),
   method: z.enum(monitorMethods),
   url: z.string().min(1, "URL is required"),

--- a/apps/dashboard/src/components/forms/status-page/form-general.tsx
+++ b/apps/dashboard/src/components/forms/status-page/form-general.tsx
@@ -57,7 +57,7 @@ function formatSlug(title: string) {
 }
 
 const schema = z.object({
-  title: z.string().min(1, "Title is required"),
+  title: z.string().trim().min(1, "Title is required"),
   slug: z
     .string()
     .min(3, "Slug is required")

--- a/packages/db/src/schema/monitors/validation.ts
+++ b/packages/db/src/schema/monitors/validation.ts
@@ -63,6 +63,7 @@ const headersSchema = z
 export const insertMonitorSchema = createInsertSchema(monitor, {
   name: z
     .string()
+    .trim()
     .min(1, "Name must be at least 1 character long")
     .max(255, "Name must be at most 255 characters long"),
   periodicity: monitorPeriodicitySchema.prefault("10m"),

--- a/packages/db/src/schema/pages/validation.ts
+++ b/packages/db/src/schema/pages/validation.ts
@@ -68,6 +68,7 @@ export const customThemeWriteSchema = customThemeSchema
   });
 
 export const insertPageSchema = createInsertSchema(page, {
+  title: z.string().trim().min(1, "Title must be at least 1 character long"),
   customDomain: customDomainSchema.prefault(""),
   accessType: z.enum(pageAccessTypes).prefault("public"),
   icon: z.string().optional(),

--- a/packages/services/src/monitor/schemas.ts
+++ b/packages/services/src/monitor/schemas.ts
@@ -37,7 +37,7 @@ const apiTimeoutMs = z.coerce.number().gte(0).lte(120_000);
  * + `30m`/`1m` respectively).
  */
 export const CreateMonitorInput = z.object({
-  name: z.string().min(1),
+  name: z.string().trim().min(1),
   jobType: z.enum(monitorJobTypes),
   url: z.string(),
   method: z.enum(monitorMethods),
@@ -72,7 +72,7 @@ export type CreateMonitorInput = z.infer<typeof CreateMonitorInput>;
  */
 export const UpdateMonitorConfigInput = z.object({
   id: z.number().int(),
-  name: z.string().min(1).optional(),
+  name: z.string().trim().min(1).optional(),
   url: z.string().optional(),
   method: z.enum(monitorMethods).optional(),
   headers: z.array(headerPair).optional(),
@@ -95,7 +95,7 @@ export type UpdateMonitorConfigInput = z.infer<typeof UpdateMonitorConfigInput>;
 /** Update the "general" monitor payload — name / endpoint / headers / assertions. */
 export const UpdateMonitorGeneralInput = z.object({
   id: z.number().int(),
-  name: z.string().min(1),
+  name: z.string().trim().min(1),
   jobType: z.enum(monitorJobTypes),
   url: z.string(),
   method: z.enum(monitorMethods),

--- a/packages/services/src/page/schemas.ts
+++ b/packages/services/src/page/schemas.ts
@@ -49,7 +49,7 @@ export type CreatePageInput = {
 
 /** Minimal create — the onboarding / `new` path with no monitors. */
 export const NewPageInput = z.object({
-  title: z.string(),
+  title: z.string().trim().min(1),
   // Canonical `slugSchema` from db validation — regex + min(3).
   // Plain `z.string().toLowerCase()` here let malformed slugs through
   // that `insertPageSchema` would reject, so `create` and `new` had
@@ -81,7 +81,7 @@ export type GetSlugAvailableInput = z.infer<typeof GetSlugAvailableInput>;
 
 export const UpdatePageGeneralInput = z.object({
   id: z.number().int(),
-  title: z.string(),
+  title: z.string().trim().min(1),
   slug: slugSchema,
   description: z.string().nullish(),
   icon: z.string().nullish(),


### PR DESCRIPTION
This PR fixes monitor names and status page titles accepting a single space as valid input, which saved fine and then showed up as a blank row in the sidebar and monitors table.

Before -

https://github.com/user-attachments/assets/f0089df6-ea34-431e-9d5e-aa988bf6ed1b



After -


https://github.com/user-attachments/assets/f368db4d-2f37-482c-8b81-4901100dc835



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

