### PR TITLE
seo: retarget homepage and product page titles and metas

### DIFF
--- a/apps/web/src/content/pages/home.mdx
+++ b/apps/web/src/content/pages/home.mdx
@@ -2,7 +2,7 @@
 title: "Ship your status page before your SOC 2 auditor asks for it"
 publishedAt: "2026-04-07"
 author: "openstatus"
-description: "The status page trusted by growing teams. Communicate incidents, prove compliance readiness, and monitor uptime from 28 global regions."
+description: "The open source status page trusted by growing teams. Communicate incidents, prove compliance readiness, and monitor uptime from 28 global regions."
 category: "product"
 faq:
   - question: "What is openstatus?"

--- a/apps/web/src/content/pages/product/status-page.mdx
+++ b/apps/web/src/content/pages/product/status-page.mdx
@@ -1,7 +1,8 @@
 ---
 title: "Status Page"
-seo: 
-  title: "Hosted Status Pages - Public & Private"
+seo:
+  title: "Create a Status Page — Hosted, Branded, Public or Private"
+  description: "Launch a branded status page on your own domain in minutes. Public or private, with password protection, IP allowlists, maintenance windows and RSS alerts."
 hero: "Status pages your users actually trust"
 publishedAt: "2025-11-10"
 author: "Maximilian Kaske"

--- a/apps/web/src/content/pages/product/uptime-monitoring.mdx
+++ b/apps/web/src/content/pages/product/uptime-monitoring.mdx
@@ -2,10 +2,11 @@
 title: "Uptime Monitoring"
 publishedAt: "2025-11-10"
 seo:
-  title: "Uptime Monitoring - Website & API Uptime Monitor"
-hero: "Uptime monitoring for websites and APIs"
+  title: "API & Service Uptime Monitoring for Developers"
+  description: "Monitor API and service uptime from 28 regions. Instant alerts via Slack, Discord, PagerDuty and email. Monitoring as code with YAML, CLI and Terraform."
+hero: "Uptime monitoring for websites, APIs and services"
 author: "Thibault Le Ouay Ducasse"
-description: "Monitor website and API uptime from around the world. Get instant downtime alerts via Slack, email and SMS. Free, open-source uptime monitoring"
+description: "Monitor your websites, APIs and services from 28 regions. Get alerted the moment a check fails an assertion or exceeds your threshold."
 category: "Product"
 faq:
   - question: "How many regions should I monitor from?"

--- a/apps/web/src/lib/metadata/shared-metadata.ts
+++ b/apps/web/src/lib/metadata/shared-metadata.ts
@@ -3,9 +3,9 @@ import type { Metadata } from "next";
 import type { MDXData } from "../../content/utils";
 
 export const TITLE = "openstatus";
-export const HOMEPAGE_TITLE = "The Compliance-First Status Page";
+export const HOMEPAGE_TITLE = "Free & Open Source Status Page ";
 export const DESCRIPTION =
-  "Ship your status page before your SOC 2 auditor asks for it. Communicate incidents, prove compliance readiness, and monitor uptime from 28 global regions. Open source and free to start.";
+  "Ship your status page before your SOC 2 auditor asks for it. Open source, free to start, self-hostable.";
 
 export const OG_DESCRIPTION = "The status page for compliance-ready teams";
 


### PR DESCRIPTION
First of three SEO PRs. Titles and meta descriptions only — no content, no URL changes. Fully reversible.

## What changes

| Page | Before | After |
|---|---|---|
| `/` title | The Compliance-First Status Page | Free & Open Source Status Page \| openstatus |
| `/` meta | …monitor uptime from 28 global regions. Open source and free to start. | Ship your status page before your SOC 2 auditor asks for it. Open source, free to start, self-hostable. |
| `/status-page` title | Hosted Status Pages - Public & Private | Create a Status Page — Hosted, Branded, Public or Private |
| `/uptime-monitoring` title | Uptime Monitoring - Website & API Uptime Monitor | API & Service Uptime Monitoring for Developers |

Plus: the homepage hero subheading gains "open source" (keeping the 28-region proof point), and `/uptime-monitoring`'s H1 broadens to "websites, APIs and services".

## Why

Verified against 90 days of Search Console data (2026-05-26 → 2026-08-26).

**Homepage** drops uptime and leads on what it already wins: `status page open source` **1.6** (106 clicks), `free status page` **2.2** (59), `status page` 6.4 (160). Its generic-uptime rankings (12.9–18.0 across ~9,000 impressions) return **4 clicks** — not worth title real estate.

**`/uptime-monitoring`** ranks 28.7–47.9 on generic uptime terms but 2.1–6.7 on the API cluster:

| Query | Position | Impressions |
|---|---|---|
| developer uptime monitoring | **2.1** | 113 |
| api uptime checker | 5.6 | 385 |
| api uptime monitoring | 6.2 | 803 |
| uptime monitoring api | 6.3 | 273 |
| service uptime monitoring | 11.6 | 590 |

`api uptime monitoring` returns **1 click on 803 impressions at position 6.2** — a snippet problem, not a ranking problem, which makes the title the highest-leverage edit on the page. The body stays broad; only the SERP framing narrows.

## Notes

- New SEO titles go in `seo.title`, not `title` — the latter is also the nav label (`data/content.ts:14-20`).
- `seo.title` emits as `absolute`, so no `| openstatus` suffix on the product pages (the `/status-page` one would truncate at 69 chars).
- The homepage title/meta live in `shared-metadata.ts`, not `home.mdx` frontmatter.

Verified with `pnpm tsc`, `oxfmt --check`, `oxlint`, and frontmatter validation across all 300 MDX files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

