### PR TITLE
seo: internal links, homepage trim and product page content

### DIFF
--- a/apps/web/src/app/(landing)/status/[id]/[component]/page.tsx
+++ b/apps/web/src/app/(landing)/status/[id]/[component]/page.tsx
@@ -118,7 +118,12 @@ export default async function Page(args: { params: Promise<RouteParams> }) {
           Looking for a status page?
         </ContentBoxTitle>
         <ContentBoxDescription className="m-0! text-sm">
-          Every service needs a status page. Run yours with OpenStatus.
+          Every service needs a status page. Run yours with OpenStatus — see
+          what a{" "}
+          <CustomLink href="/status-page" className="underline-offset-4">
+            hosted status page
+          </CustomLink>{" "}
+          includes.
         </ContentBoxDescription>
         <ButtonLink href={`${APP_URL}?ref=status-component-bottom`}>
           Create your status page

--- a/apps/web/src/app/(landing)/status/[id]/page.tsx
+++ b/apps/web/src/app/(landing)/status/[id]/page.tsx
@@ -135,7 +135,12 @@ export default async function Page(args: { params: Promise<RouteParams> }) {
           Looking for a status page?
         </ContentBoxTitle>
         <ContentBoxDescription className="m-0! text-sm">
-          Every service needs a status page. Run yours with OpenStatus.
+          Every service needs a status page. Run yours with OpenStatus — see
+          what a{" "}
+          <CustomLink href="/status-page" className="underline-offset-4">
+            hosted status page
+          </CustomLink>{" "}
+          includes.
         </ContentBoxDescription>
         <ButtonLink href={`${APP_URL}?ref=status-service-bottom`}>
           Create your status page

--- a/apps/web/src/app/(landing)/status/page.tsx
+++ b/apps/web/src/app/(landing)/status/page.tsx
@@ -86,7 +86,12 @@ export default async function Page() {
           Looking for a status page?
         </ContentBoxTitle>
         <ContentBoxDescription className="m-0! text-sm">
-          Every service needs a status page. Run yours with OpenStatus.
+          Every service needs a status page. Run yours with OpenStatus — see
+          what a{" "}
+          <CustomLink href="/status-page" className="underline-offset-4">
+            hosted status page
+          </CustomLink>{" "}
+          includes.
         </ContentBoxDescription>
         <ButtonLink href={`${APP_URL}?ref=status-index-bottom`}>
           Create your status page

--- a/apps/web/src/content/mdx-components/customer-logos.tsx
+++ b/apps/web/src/content/mdx-components/customer-logos.tsx
@@ -1,0 +1,28 @@
+import { Grid } from "./grid";
+
+const customers: { name: string; href: string }[] = [
+  { name: "Cal.com", href: "https://status.cal.com" },
+  { name: "Documenso", href: "https://status.documenso.com" },
+  { name: "WhiteBIT", href: "https://status.whitebit.com" },
+  { name: "Traefik", href: "/customers/traefik" },
+  { name: "OpenPanel", href: "https://status.openpanel.dev" },
+  { name: "Probo", href: "https://probostatus.com" },
+  { name: "Hanko", href: "https://status.hanko.io" },
+  { name: "Superwall", href: "https://status.superwall.com" },
+  { name: "StreamElements", href: "https://status.streamelements.com/" },
+  { name: "Smplrspace", href: "https://status.smplrspace.com" },
+  { name: "Passbolt", href: "https://passboltuptime.com" },
+  { name: "TwentyCRM", href: "/customers/twenty" },
+];
+
+export function CustomerLogos() {
+  return (
+    <Grid cols={4}>
+      {customers.map((customer) => (
+        <a key={customer.href} href={customer.href}>
+          {customer.name}
+        </a>
+      ))}
+    </Grid>
+  );
+}

--- a/apps/web/src/content/mdx-components/index.tsx
+++ b/apps/web/src/content/mdx-components/index.tsx
@@ -7,6 +7,7 @@ import { Card, CardGrid, LinkCard } from "./card";
 import { Code } from "./code";
 import { CustomImage } from "./custom-image";
 import { CustomLink } from "./custom-link";
+import { CustomerLogos } from "./customer-logos";
 import { Details } from "./details";
 import { Grid } from "./grid";
 import { createHeading } from "./heading";
@@ -33,6 +34,7 @@ export const components = {
   pre: Pre,
   table: Table,
   Grid,
+  CustomerLogos,
   Aside,
   Card,
   CardGrid,

--- a/apps/web/src/content/pages/compare/betterstack.mdx
+++ b/apps/web/src/content/pages/compare/betterstack.mdx
@@ -86,6 +86,8 @@ Use our **[BetterStack import tool](/guides/migrate-from-betterstack)** to autom
 
 ## Related Resources
 
+- [Status page](/status-page)
+- [Uptime monitoring](/uptime-monitoring)
 - [Migrate from BetterStack](/guides/migrate-from-betterstack)
 - [Why Every SaaS Needs a Status Page](/guides/why-every-saas-needs-a-status-page)
 - [SLA vs SLO vs SLI](/guides/sla-vs-slo-vs-sli)

--- a/apps/web/src/content/pages/compare/checkly.mdx
+++ b/apps/web/src/content/pages/compare/checkly.mdx
@@ -78,6 +78,8 @@ If you rely heavily on Playwright browser checks, openstatus is not a direct rep
 
 ## Related Resources
 
+- [Status page](/status-page)
+- [Uptime monitoring](/uptime-monitoring)
 - [Why Every SaaS Needs a Status Page](/guides/why-every-saas-needs-a-status-page)
 - [SLA vs SLO vs SLI](/guides/sla-vs-slo-vs-sli)
 - [Status Pages for API Providers](/use-case/api-providers)

--- a/apps/web/src/content/pages/compare/datadog.mdx
+++ b/apps/web/src/content/pages/compare/datadog.mdx
@@ -80,6 +80,8 @@ If you depend on Datadog's browser synthetics and trace correlation, keep those 
 
 ## Related Resources
 
+- [Status page](/status-page)
+- [Uptime monitoring](/uptime-monitoring)
 - [Checkly vs openstatus](/compare/checkly) — another synthetic-monitoring comparison
 - [What Is Synthetic Monitoring?](/guides/what-is-synthetic-monitoring)
 - [What Is Uptime Monitoring?](/guides/what-is-uptime-monitoring)

--- a/apps/web/src/content/pages/compare/incidentio.mdx
+++ b/apps/web/src/content/pages/compare/incidentio.mdx
@@ -78,6 +78,8 @@ If you only need the detection and communication layer, openstatus covers it alo
 
 ## Related Resources
 
+- [Status page](/status-page)
+- [Uptime monitoring](/uptime-monitoring)
 - [Incident Severity Matrix Guide](/guides/incident-severity-matrix)
 - [Why Every SaaS Needs a Status Page](/guides/why-every-saas-needs-a-status-page)
 - [Status Pages for Compliance](/use-case/compliance)

--- a/apps/web/src/content/pages/compare/statusio.mdx
+++ b/apps/web/src/content/pages/compare/statusio.mdx
@@ -78,6 +78,8 @@ Status.io costs nearly 3x more than openstatus's Starter plan — and doesn't in
 
 ## Related Resources
 
+- [Status page](/status-page)
+- [Uptime monitoring](/uptime-monitoring)
 - [Top 5 Atlassian Statuspage Alternatives](/guides/top-five-atlassian-statuspage-alternatives)
 - [Why Every SaaS Needs a Status Page](/guides/why-every-saas-needs-a-status-page)
 - [Status Pages for Enterprise Sales](/use-case/enterprise-sales)

--- a/apps/web/src/content/pages/compare/uptime-robot.mdx
+++ b/apps/web/src/content/pages/compare/uptime-robot.mdx
@@ -86,6 +86,8 @@ Most teams complete the switch in under an hour. If you need help, reach out at 
 
 ## Related Resources
 
+- [Status page](/status-page)
+- [Uptime monitoring](/uptime-monitoring)
 - [Why Uptime Percentage Is Misleading](/guides/why-uptime-percentage-is-misleading)
 - [SLA vs SLO vs SLI](/guides/sla-vs-slo-vs-sli)
 - [Why Every SaaS Needs a Status Page](/guides/why-every-saas-needs-a-status-page)

--- a/apps/web/src/content/pages/guides/what-is-a-status-page.mdx
+++ b/apps/web/src/content/pages/guides/what-is-a-status-page.mdx
@@ -123,6 +123,8 @@ A status page is the simplest, highest-leverage trust-building tool you have dur
 
 If you don't have one, you're either too small to need one (rare) or losing trust during every outage without realizing it (common).
 
+If you are ready to run one, a [hosted status page](/status-page) gives you components, incident history, maintenance windows and subscriber notifications on your own domain without building any of it yourself.
+
 ## Frequently asked questions
 
 <Details summary="What is a status page?">

--- a/apps/web/src/content/pages/guides/what-is-uptime-monitoring.mdx
+++ b/apps/web/src/content/pages/guides/what-is-uptime-monitoring.mdx
@@ -142,6 +142,8 @@ Uptime monitoring exists because you cannot trust your own infrastructure to tel
 
 Set it up. Monitor the things customers actually depend on. Use multiple regions. Tune the check frequency for the criticality. Push results into a [status page](/guides/what-is-a-status-page) so users can self-serve when things break.
 
+If you would rather not run the probes yourself, [openstatus uptime monitoring](/uptime-monitoring) checks your websites, APIs and services from 28 regions and feeds the results straight into your status page.
+
 ## Frequently asked questions
 
 <Details summary="What is uptime monitoring?">

--- a/apps/web/src/content/pages/home.mdx
+++ b/apps/web/src/content/pages/home.mdx
@@ -8,7 +8,7 @@ faq:
   - question: "What is openstatus?"
     answer: "Openstatus gives you a branded status page and uptime monitoring that's audit-ready out of the box. Set up status.yourcompany.com, connect your monitors, and start communicating incidents — in minutes. It's open-source, self-hostable, and used by teams like Cal.com, WhiteBIT, and Documenso."
   - question: "Do I need a status page for SOC 2?"
-    answer: "SOC 2's CC2.3 criteria requires you to demonstrate incident communication with external parties — but it doesn't prescribe a specific tool. That said, a status page is the fastest, most auditor-friendly way to satisfy that requirement. Every status report on openstatus is timestamped and documented automatically, giving you an audit-ready trail of how you communicated during incidents. Most teams set it up in under 10 minutes."
+    answer: "SOC 2's CC2.3 criteria requires you to demonstrate incident communication with external parties — but it doesn't prescribe a specific tool. That said, a status page is the fastest, most auditor-friendly way to satisfy that requirement. Every status report on openstatus is timestamped and documented automatically, giving you an audit-ready trail of how you communicated during incidents. Most teams set it up in under 10 minutes. Read more about [SOC 2 status pages](/use-case/compliance)."
   - question: "How does openstatus help with SOC 2 compliance?"
     answer: "Openstatus gives you a branded status page with incident history, subscriber notifications, and maintenance windows — all the evidence an auditor needs to verify your incident communication process. Every status report and update is timestamped and documented automatically."
   - question: "What does the free plan include?"
@@ -44,20 +44,7 @@ Free to start. Paid plans from $30/mo.
 
 ## Trusted by teams who ship transparency
 
-<Grid cols={4}>
-  <a href="https://status.cal.com">Cal.com</a>
-  <a href="https://status.documenso.com">Documenso</a>
-  <a href="https://status.whitebit.com">WhiteBIT</a>
-  <a href="/customers/traefik">Traefik</a>
-  <a href="https://status.openpanel.dev">OpenPanel</a>
-  <a href="https://probostatus.com">Probo</a>
-  <a href="https://status.hanko.io">Hanko</a>
-  <a href="https://status.superwall.com">Superwall</a>
-  <a href="https://status.streamelements.com/">StreamElements</a>
-  <a href="https://status.smplrspace.com">Smplrspace</a>
-  <a href="https://passboltuptime.com">Passbolt</a>
-  <a href="/customers/twenty">TwentyCRM</a>
-</Grid>
+<CustomerLogos />
 
 ## The status page that closes enterprise deals
 
@@ -69,19 +56,13 @@ Make it yours with [themes from our Theme Store](https://themes.openstatus.dev),
 - Public or **password protected** pages
 - **Custom domains**
 - **Status reports** and **maintenance windows**
-- **Subscription channels**: email, RSS/Atom, SSH
+- **Subscription channels**: email, RSS/Atom, JSON
 
 Read more [about status pages](/status-page).
 
 ## Monitor from 28 regions — know before your customers do
 
 Monitor your endpoints from 28 regions across multiple clouds. Get alerted on Slack, Discord, PagerDuty, or email the moment something breaks. Your status page updates automatically — no manual work during incidents.
-
-- **28 regions**, 3 cloud providers — no blind spots
-- Monitor any **HTTP endpoint**, REST or GraphQL
-- Version your monitors with **YAML** and **CI/CD**
-- Monitor behind firewalls with a single **Docker container**
-- Alerts on **Slack**, **Discord**, **PagerDuty**, email, webhooks, ...
 
 Read more about [uptime monitoring](/uptime-monitoring).
 
@@ -141,6 +122,8 @@ It's open-source, self-hostable, and used by teams like [Cal.com](https://status
 SOC 2's CC2.3 criteria requires you to demonstrate incident communication with external parties — but it doesn't prescribe a specific tool. That said, a status page is the **fastest, most auditor-friendly** way to satisfy that requirement.
 
 Every status report on openstatus is **timestamped** and documented automatically, giving you an audit-ready trail of how you communicated during incidents. Most teams set it up in under 2 minutes.
+
+Read more about [SOC 2 status pages](/use-case/compliance).
 
 </Details>
 

--- a/apps/web/src/content/pages/product/status-page.mdx
+++ b/apps/web/src/content/pages/product/status-page.mdx
@@ -23,12 +23,14 @@ faq:
     answer: "Users can subscribe to receive updates when you post status reports or maintenance notices. We support email notifications, RSS/Atom feeds for feed readers, and JSON feeds for programmatic consumption. Subscribers are automatically notified when you publish updates."
   - question: "Can I customize the appearance of my status page?"
     answer: "Yes, use the Theme Store to apply community themes or create your own. Themes control colors, fonts, and layout. For private custom themes, contact us. You can also define which data to share (uptime percentages, response times, or manual reports only)."
+  - question: "How do I create a status page?"
+    answer: "Sign up, create a status page, give it a name and a slug, then add page components — either monitors synced from your uptime monitoring or external services you manage by hand. Point a custom domain at it if you want status.yourcompany.com, pick a theme, and publish. Most teams are live in under ten minutes on the free plan."
+  - question: "Public vs internal status page?"
+    answer: "A public status page is customer-facing and indexed — it deflects support tickets and answers vendor questionnaires. An internal or private status page is for staff, contractors, or a single client, and access is controlled with password protection, magic link authentication, or an IP allowlist. You can run both from the same workspace."
+  - question: "How much does a status page cost?"
+    answer: "The free Hobby plan includes one status page with three components and no credit card. Paid plans start at $30/month for Starter (one status page, 20 components, custom domain, subscribers), $100/month for Pro, and $500/month for Scale. Annual billing gives you two months free. Extra status pages are $20/month each."
   - question: "What is the Slack agent and what can it do?"
     answer: "The Slack agent lets you manage your status page directly from Slack using natural language. @mention @openstatus in any channel or thread to create incidents, post updates, and resolve reports — without leaving Slack. No slash commands required."
-  - question: "Does the Slack agent publish status reports automatically?"
-    answer: "No. The agent always shows a confirmation card before publishing anything. You can review the drafted title, status, and message, then choose to Approve, Approve & Notify (sends notifications to all subscribers), or Cancel. Nothing goes public without your explicit approval."
-  - question: "Which plan includes the Slack agent?"
-    answer: "The Slack agent is available on paid plans. Install it from your dashboard under Settings > Integrations."
 ---
 
 ## What is a status page?
@@ -44,9 +46,23 @@ A typical status page includes:
 - **Subscriber notifications** via email, RSS, or webhook
 - **Uptime history** showing reliability over time
 
+<div className="space-x-2">
+  <ButtonLink href="https://app.openstatus.dev?ref=status-page-top" children="Create Your Status Page" variant="default" />
+</div>
+
+Free to start. Paid plans from $30/mo.
+
+## Trusted by teams who ship transparency
+
+<CustomerLogos />
+
 ## Why do you need a status page?
 
-A status page is a dedicated webpage that provides real-time information about the operational status of your services. It serves as a communication tool to inform your users about any ongoing incidents, maintenance activities, or service disruptions.
+**It deflects support load.** During an outage, every user asks the same question: is it down, or is it me? Without somewhere to point them, that question arrives one ticket at a time while your team is already busy fixing the thing. A status page answers it once, for everyone. See [reducing support tickets](/use-case/reduce-support-tickets).
+
+**Enterprise buyers ask for one.** Security questionnaires and vendor reviews routinely ask how you notify customers during an incident. "We email the affected accounts" is a weaker answer than a public URL with a year of incident history behind it. See [status pages for enterprise sales](/use-case/enterprise-sales).
+
+**Auditors want the evidence.** SOC 2's CC2.3 criteria asks you to demonstrate that you communicate incidents to external parties. Every status report on openstatus is timestamped and archived automatically, so the trail already exists when the auditor asks for it. See [status pages for compliance](/use-case/compliance).
 
 <Grid>
 <div>
@@ -79,14 +95,6 @@ Page components provide a **flexible structure** that supports both:
 
 You can **group page components** by their services, locations, or any logical grouping, and they will be collapsible for better organization.
 
-### Customization
-
-Match your brand **appearance** by contributing your own theme to the community. We have build a **[Theme Store](https://themes.openstatus.dev)** that helps you create and use custom themes on your status page. Contribute your own theme. If you a private custom theme let us know via [email](mailto:ping@openstatus.dev?subject=Private%20Theme).
-
-You can **define the values** you want to share with your users. If can decide between duration values/uptime ping values or purely based on manual status report updates.
-
-You can create **custom domains** to keep the domain your users are used to.
-
 ### Links
 
 Add a **Get in touch** in touch button and add a specific **website** link or a **`mailto:`** address.
@@ -109,11 +117,6 @@ We support following communication channels:
 
 Offer your status page in **multiple languages**. Set a default locale and enable a **locale switcher** so visitors can read updates in their preferred language. Currently supports English, French, German, Turkish, Hindi, and Korean — with more languages coming from community contributions.
 
-### Audience
-
-By default, your status page is public. For internal or client-specific pages, you can protect access using **password protection**, **magic link** authentication, or **IP restriction** (CIDR-based network allowlist) to control who can view your updates.
-
-
 ### Slack Agent
 
 Manage incidents without leaving Slack. Install the **@openstatus** Slack agent and @mention it in any channel or thread to create, update, and resolve status reports using plain language - no slash commands, no tab switching.
@@ -129,6 +132,24 @@ The agent is **thread-aware**: when you follow up in the same thread (_"we found
 Already using Atlassian Statuspage, Better Stack, or Instatus? Import your entire setup -- components, component groups, incidents, maintenances, subscribers, and monitors -- in minutes. Open a status page, go to the **Components** tab, scroll down to the **Import** section, paste your API key, preview what will be imported, and confirm.
 
 Read the [migration guides](/blog/import-from-statuspage-betterstack-instatus) for details on each provider.
+
+## Branded status pages
+
+Match your brand **appearance** by contributing your own theme to the community. We have build a **[Theme Store](https://themes.openstatus.dev)** that helps you create and use custom themes on your status page. Contribute your own theme. If you a private custom theme let us know via [email](mailto:ping@openstatus.dev?subject=Private%20Theme).
+
+You can **define the values** you want to share with your users. If can decide between duration values/uptime ping values or purely based on manual status report updates.
+
+You can create **custom domains** to keep the domain your users are used to.
+
+## Internal & private status pages
+
+By default, your status page is public. For internal or client-specific pages, you can protect access using **password protection**, **magic link** authentication, or **IP restriction** (CIDR-based network allowlist) to control who can view your updates.
+
+<div className="space-x-2">
+  <ButtonLink href="https://app.openstatus.dev?ref=status-page-bottom" children="Create Your Status Page" variant="default" />
+</div>
+
+Free to start. Paid plans from $30/mo.
 
 ## Frequently asked questions
 
@@ -174,20 +195,27 @@ Yes, use the Theme Store to apply community themes or create your own. Themes co
 
 </Details>
 
+<Details summary="How do I create a status page?">
+
+Sign up, create a status page, give it a name and a slug, then add page components — either monitors synced from your uptime monitoring or external services you manage by hand. Point a custom domain at it if you want status.yourcompany.com, pick a theme, and publish. Most teams are live in under ten minutes on the free plan.
+
+</Details>
+
+<Details summary="Public vs internal status page?">
+
+A public status page is customer-facing and indexed — it deflects support tickets and answers vendor questionnaires. An internal or private status page is for staff, contractors, or a single client, and access is controlled with password protection, magic link authentication, or an IP allowlist. You can run both from the same workspace.
+
+</Details>
+
+<Details summary="How much does a status page cost?">
+
+The free Hobby plan includes one status page with three components and no credit card. Paid plans start at $30/month for Starter (one status page, 20 components, custom domain, subscribers), $100/month for Pro, and $500/month for Scale. Annual billing gives you two months free. Extra status pages are $20/month each.
+
+</Details>
+
 <Details summary="What is the Slack agent and what can it do?">
 
 The Slack agent lets you manage your status page directly from Slack using natural language. @mention @openstatus in any channel or thread to create incidents, post updates, and resolve reports — without leaving Slack. No slash commands required.
 
 </Details>
 
-<Details summary="Does the Slack agent publish status reports automatically?">
-
-No. The agent always shows a confirmation card before publishing anything. You can review the drafted title, status, and message, then choose to Approve, Approve & Notify (sends notifications to all subscribers), or Cancel. Nothing goes public without your explicit approval.
-
-</Details>
-
-<Details summary="Which plan includes the Slack agent?">
-
-The Slack agent is available on paid plans. Install it from your dashboard under Settings > Integrations.
-
-</Details>

--- a/apps/web/src/content/pages/product/uptime-monitoring.mdx
+++ b/apps/web/src/content/pages/product/uptime-monitoring.mdx
@@ -9,6 +9,18 @@ author: "Thibault Le Ouay Ducasse"
 description: "Monitor your websites, APIs and services from 28 regions. Get alerted the moment a check fails an assertion or exceeds your threshold."
 category: "Product"
 faq:
+  - question: "What is uptime monitoring?"
+    answer: "Uptime monitoring is the practice of checking, on a fixed schedule and from outside your own network, whether a service is reachable and responding correctly. Checks typically run every 30 seconds to 10 minutes from probe locations around the world. Because the checks originate externally, they catch failures your internal dashboards cannot see — DNS problems, expired certificates, and regional outages."
+  - question: "How often should I check my service?"
+    answer: "Match the frequency to the cost of the outage. Revenue-critical endpoints justify 30-second checks; internal tooling is usually fine at 5 or 10 minutes. Higher frequency shortens the time between a failure starting and you hearing about it, but consumes more of your check quota. openstatus supports 30s, 1m, 5m and 10m intervals depending on your plan."
+  - question: "What is the difference between uptime and availability?"
+    answer: "Uptime is what your monitor measures: the proportion of checks that succeeded. Availability is what your users experienced, which includes degraded performance your checks may have passed. A service returning HTTP 200 in eight seconds is up but arguably not available. This is why thresholds matter alongside assertions — they let you count slow responses as degraded rather than healthy."
+  - question: "Can I monitor internal services?"
+    answer: "Yes. Deploy a private location probe inside your network as an 8.5MB Docker container and it appears as another monitoring region in your dashboard. The probe reaches out to openstatus, so no inbound firewall rule is needed. You can run as many private locations as you like across different VPCs or networks."
+  - question: "How do I monitor a REST or GraphQL API?"
+    answer: "Create an HTTP monitor pointing at the endpoint, choose the method, and add any headers your API needs for authentication. For GraphQL, send a POST with the query in the body. Then add assertions on the status code, response headers, or body content so the monitor verifies the response is correct rather than merely present, and set a threshold so slow responses register as degraded."
+  - question: "How much does uptime monitoring cost?"
+    answer: "The free Hobby plan includes one monitor at a 10-minute interval with no credit card. Paid plans start at $30/month for Starter (20 monitors, 1-minute checks, 6 regions per monitor), $100/month for Pro (50 monitors, 30-second checks, all 28 regions), and $500/month for Scale. Annual billing gives you two months free."
   - question: "How many regions should I monitor from?"
     answer: "Start with 3-5 regions covering your main user geographies. More regions provide better global coverage but use more check quota. For critical services, monitor from all major regions (North America, Europe, Asia) to catch regional issues quickly."
   - question: "Why monitor from multiple cloud providers instead of just one?"
@@ -26,6 +38,30 @@ faq:
   - question: "Can I run private monitoring locations in different networks?"
     answer: "Yes, you can deploy as many private location probes as needed across different networks, VPCs, or regions. Each gets its own API key and appears as a separate monitoring region in your dashboard. The Docker image is only 8.5MB and supports ARM64 and AMD64."
 ---
+
+## Why is uptime monitoring important?
+
+Uptime monitoring is the practice of continuously asking one question on your users' behalf: is this service working right now? Instead of waiting for a customer to report a problem, checks run on a schedule from outside your own network and tell you the moment the answer changes.
+
+It answers three things a dashboard inside your own infrastructure cannot:
+
+1. **Is my service reachable?** Can users actually get to it, from where they are?
+2. **Is it fast enough?** Are response times inside the range you promised?
+3. **Is it correct?** Is it returning the data you expect, not just a 200?
+
+That external vantage point is the whole point. If your service runs on the same infrastructure as your monitoring, an outage that takes down one takes down the other — and you find out from your customers instead.
+
+<div className="space-x-2">
+  <ButtonLink href="https://app.openstatus.dev?ref=uptime-monitoring-top" children="Start Monitoring Free" variant="default" />
+</div>
+
+Free to start. Paid plans from $30/mo.
+
+## Trusted by teams who ship transparency
+
+<CustomerLogos />
+
+## How uptime monitoring works
 
 ```
 +----------------+
@@ -60,11 +96,6 @@ faq:
 | Your Team |
 +-----------+
 ```
-
-
-## Why uptime monitoring is important?
-
-Uptime monitoring is your first line of defense to ensure your service is available for your customers. By monitoring your service from multiple regions around the world, you can be sure that your customers are able to reach your service.
 
 
 <Grid>
@@ -118,13 +149,13 @@ When needed, you can export to your **OTLP endpoint** the metrics for every requ
 
 ### Notification channels
 
-Set different notification channels and **get notified** whenever a not satisfying your assertions or are exceeding the thresholds.
+Set different notification channels and **get notified** whenever a response fails your assertions or exceeds your thresholds.
 
 We support:
 
-- Socials: Slack, Discord, Telegram Bot
-- Direct: Email, SMS
-- Incident Management: OpsGenie, PagerDuty
+- Socials: Slack, Discord, Telegram Bot, Google Chat, Microsoft Teams
+- Direct: Email, SMS, WhatsApp
+- Incident Management: OpsGenie, PagerDuty, Grafana OnCall
 - Custom: Webhook, Ntfy
 
 ### Status Pages
@@ -206,6 +237,42 @@ You can read more here:
 
 ## Frequently asked questions
 
+<Details summary="What is uptime monitoring?">
+
+Uptime monitoring is the practice of checking, on a fixed schedule and from outside your own network, whether a service is reachable and responding correctly. Checks typically run every 30 seconds to 10 minutes from probe locations around the world. Because the checks originate externally, they catch failures your internal dashboards cannot see — DNS problems, expired certificates, and regional outages.
+
+</Details>
+
+<Details summary="How often should I check my service?">
+
+Match the frequency to the cost of the outage. Revenue-critical endpoints justify 30-second checks; internal tooling is usually fine at 5 or 10 minutes. Higher frequency shortens the time between a failure starting and you hearing about it, but consumes more of your check quota. openstatus supports 30s, 1m, 5m and 10m intervals depending on your plan.
+
+</Details>
+
+<Details summary="What is the difference between uptime and availability?">
+
+Uptime is what your monitor measures: the proportion of checks that succeeded. Availability is what your users experienced, which includes degraded performance your checks may have passed. A service returning HTTP 200 in eight seconds is up but arguably not available. This is why thresholds matter alongside assertions — they let you count slow responses as degraded rather than healthy.
+
+</Details>
+
+<Details summary="Can I monitor internal services?">
+
+Yes. Deploy a private location probe inside your network as an 8.5MB Docker container and it appears as another monitoring region in your dashboard. The probe reaches out to openstatus, so no inbound firewall rule is needed. You can run as many private locations as you like across different VPCs or networks.
+
+</Details>
+
+<Details summary="How do I monitor a REST or GraphQL API?">
+
+Create an HTTP monitor pointing at the endpoint, choose the method, and add any headers your API needs for authentication. For GraphQL, send a POST with the query in the body. Then add assertions on the status code, response headers, or body content so the monitor verifies the response is correct rather than merely present, and set a threshold so slow responses register as degraded.
+
+</Details>
+
+<Details summary="How much does uptime monitoring cost?">
+
+The free Hobby plan includes one monitor at a 10-minute interval with no credit card. Paid plans start at $30/month for Starter (20 monitors, 1-minute checks, 6 regions per monitor), $100/month for Pro (50 monitors, 30-second checks, all 28 regions), and $500/month for Scale. Annual billing gives you two months free.
+
+</Details>
+
 <Details summary="How many regions should I monitor from?">
 
 Start with 3-5 regions covering your main user geographies. More regions provide better global coverage but use more check quota. For critical services, monitor from all major regions (North America, Europe, Asia) to catch regional issues quickly.
@@ -253,6 +320,14 @@ Use YAML + CLI for simplicity and if you're not already using Terraform. It's li
 Yes, you can deploy as many private location probes as needed across different networks, VPCs, or regions. Each gets its own API key and appears as a separate monitoring region in your dashboard. The Docker image is only 8.5MB and supports ARM64 and AMD64.
 
 </Details>
+
+---
+
+<div className="space-x-2">
+  <ButtonLink href="https://app.openstatus.dev?ref=uptime-monitoring-bottom" children="Start Monitoring Free" variant="default" />
+</div>
+
+Free to start. Paid plans from $30/mo.
 
 ---
 


### PR DESCRIPTION
Second of three SEO PRs. **Stacked on #2607** — review that one first; this diff shows only its own changes.

## Internal links

**The `/status/*` templates now link to `/status-page`.** This is the largest single item and wasn't in the original brief. That section is the site's highest-authority content — `/status/anthropic` alone holds **2,710 clicks and 156,425 impressions** — and it previously linked out only to `app.openstatus.dev`, an external subdomain that passes no internal link equity. All that authority dead-ended.

The existing app CTAs are untouched, so the signup path is unchanged. One template edit reaches every service page.

Also: the six surviving compare pages now link to both product pages (none did before), the homepage SOC 2 FAQ links to `/use-case/compliance`, and the two definitional guides link to their product pages.

## Homepage

- Fix a real typo: subscription channels read "email, RSS/Atom, **SSH**" → **JSON**.
- Trim the uptime bullet list to prose plus link, consistent with the page no longer claiming uptime in its title or meta (#2607). The status-page bullets stay — that's the conversion surface on the page with 4,846 clicks.

## `/status-page`

Had **no CTA anywhere in the body**. Now has one after the intro and one before the FAQ, plus a pricing line and customer logos.

- Removed the definition duplicated verbatim under "Why do you need a status page?" and rewrote that section to answer *why* rather than *what* — ticket deflection, enterprise procurement, SOC 2 CC2.3.
- Promoted two existing sections to H2s matching queries the page already ranks for: **Branded status pages** (`branded status page` → position **3.5**) and **Internal & private status pages** (`private status page` 7.4, `internal status page` 8.1).
- FAQ rebalanced: Slack agent 3 → 1, added create / public-vs-internal / cost. Now 11.

## `/uptime-monitoring`

The ASCII architecture diagram was the first body content — a monospace block with no semantic content, immediately after the H1. Moved below the opening prose under its own H2.

- Expanded "Why **is** uptime monitoring important?" (also fixes the heading grammar) from two sentences.
- Fixed a broken sentence: *"get notified whenever a not satisfying your assertions or are exceeding the thresholds"*.
- Added CTA, pricing line, customer logos.
- FAQ grew 8 → 14 with the evaluator questions it had no answer for (what it is, how often to check, uptime vs availability, internal services, REST/GraphQL, cost). Worth noting the brief claimed this page had zero FAQs; it had 8, all configuration-oriented.
- The notification list understated the product — `packages/notification/` also ships Google Chat, MS Teams, Grafana OnCall and WhatsApp. Now listed.

## Component

Extracted the 12-logo grid into a `<CustomerLogos />` MDX component used by all three pages, rather than three copies that drift.

## Verification

`pnpm tsc` clean, `oxfmt --check` and `oxlint` clean, frontmatter validated across all MDX. FAQ frontmatter and body `<Details>` counts confirmed in sync on every file touched — they're separate copies and the frontmatter feeds JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

