### PR TITLE
fix(support): reject whitespace-only input and show a type error

### DIFF
--- a/apps/dashboard/src/components/forms/support-contact/form.tsx
+++ b/apps/dashboard/src/components/forms/support-contact/form.tsx
@@ -50,16 +50,14 @@ export const types = [
 ];
 
 export const schema = z.object({
-  name: z.string().min(1, {
-    error: "Name is required",
+  name: z.string().trim().min(1, "Name is required"),
+  type: z.enum(["bug", "demo", "feature", "security", "question"], {
+    error: "Type is required",
   }),
-  type: z.enum(["bug", "demo", "feature", "security", "question"]),
   email: z.email({
     error: "Invalid email address",
   }),
-  message: z.string().min(1, {
-    error: "Message is required",
-  }),
+  message: z.string().trim().min(1, "Message is required"),
   blocker: z.boolean(),
 });
 

--- a/packages/api/src/router/feedback.ts
+++ b/packages/api/src/router/feedback.ts
@@ -12,7 +12,7 @@ export const feedbackRouter = createTRPCRouter({
   submit: protectedProcedure
     .input(
       z.object({
-        message: z.string().min(1, "Message required"),
+        message: z.string().trim().min(1, "Message required"),
         source: z.enum(feedbackSource),
         path: z.string(),
         isMobile: z.boolean().optional(),


### PR DESCRIPTION
This PR fixes three validation issues in the Support dialog: the name and message fields accepted whitespace-only input, and an unselected Type surfaced a raw Zod error string.

**Before**

https://github.com/user-attachments/assets/6b3cd5e0-0a03-4e72-977f-3d81f3f6eda2




**After**

https://github.com/user-attachments/assets/1ddaefc0-224a-4a35-9c64-83dd95622351



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

