### PR TITLE
fix(docs): clean up TOC labels and stop sideways scrolling

### DIFF
--- a/apps/web/src/content/docs-toc.tsx
+++ b/apps/web/src/content/docs-toc.tsx
@@ -60,7 +60,7 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
             <a
               href={`#${item.slug}`}
               className={cn(
-                "ease text-muted-foreground hover:bg-muted hover:text-foreground block py-2 transition-colors duration-150 motion-reduce:transition-none",
+                "ease text-muted-foreground hover:bg-muted hover:text-foreground block py-2 break-words transition-colors duration-150 motion-reduce:transition-none",
                 item.depth === 2 ? "pl-2" : "pl-4",
                 active === item.slug && "bg-muted text-foreground",
               )}

--- a/apps/web/src/content/toc.ts
+++ b/apps/web/src/content/toc.ts
@@ -5,7 +5,8 @@ export type TocItem = { depth: 2 | 3; text: string; slug: string };
 // Extract h2/h3 headings from raw MDX for the table of contents. Slugs are
 // produced with the same `slugify` that `createHeading` uses at render time, so
 // the TOC links resolve to the real heading ids. Fenced code blocks are skipped
-// so `## comment` lines inside code don't leak into the TOC.
+// so `## comment` lines inside code don't leak into the TOC. Inline-code
+// backticks are dropped to match the label `createHeading` renders.
 export function extractHeadings(source: string): TocItem[] {
   const items: TocItem[] = [];
   let inFence = false;
@@ -22,7 +23,7 @@ export function extractHeadings(source: string): TocItem[] {
     if (!heading) continue;
 
     const depth = heading[1].length as 2 | 3;
-    const text = heading[2].trim();
+    const text = heading[2].trim().replace(/`/g, "");
     items.push({ depth, text, slug: slugify(text) });
   }
 


### PR DESCRIPTION
This PR fixes the "On this page" TOC on docs pages with inline-code headings: labels rendered raw backticks, and long identifiers forced a horizontal scrollbar that clipped them.

**Before**

https://github.com/user-attachments/assets/639a2a33-7f7f-4607-b5e1-81c87e481ded


**After**

https://github.com/user-attachments/assets/6f119940-2b10-4fc2-aeb5-aae0de6d3e71



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

