### PR TITLE
fix(self-hosting): run database migrations in Coolify deployment

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
             if echo "$CHANGED" | grep -q '^packages/'; then
               SERVICES_LIST=("server" "dashboard" "workflows" "private-location" "status-page" "checker" "db-migrate")
             else
-              for svc in server dashboard workflows private-location status-page checker db-migrate; do
+              for svc in server dashboard workflows private-location status-page checker; do
                 if echo "$CHANGED" | grep -q "^apps/$svc/"; then
                   SERVICES_LIST+=("$svc")
                 fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ on:
       services:
         description: 'Services to build (comma-separated)'
         required: false
-        default: 'server,dashboard,workflows,private-location,status-page,checker'
+        default: 'server,dashboard,workflows,private-location,status-page,checker,db-migrate'
         type: string
 
 concurrency:
@@ -53,9 +53,9 @@ jobs:
 
             # packages/** changes affect all services
             if echo "$CHANGED" | grep -q '^packages/'; then
-              SERVICES_LIST=("server" "dashboard" "workflows" "private-location" "status-page" "checker")
+              SERVICES_LIST=("server" "dashboard" "workflows" "private-location" "status-page" "checker" "db-migrate")
             else
-              for svc in server dashboard workflows private-location status-page checker; do
+              for svc in server dashboard workflows private-location status-page checker db-migrate; do
                 if echo "$CHANGED" | grep -q "^apps/$svc/"; then
                   SERVICES_LIST+=("$svc")
                 fi
@@ -101,6 +101,9 @@ jobs:
           - service: checker
             context: apps/checker
             dockerfile: apps/checker/Dockerfile
+          - service: db-migrate
+            context: .
+            dockerfile: packages/db/Dockerfile
 
     steps:
       - name: Checkout repository

--- a/COOLIFY_ENVIRONMENT_GUIDE.md
+++ b/COOLIFY_ENVIRONMENT_GUIDE.md
@@ -12,6 +12,8 @@ This guide explains how to configure environment variables for OpenStatus deploy
    ```
 3. Click **"Deploy"**
 
+> **ℹ️ Database migrations:** the stack includes a one-shot `db-migrate` service that applies the database schema before any app service starts. It runs on every deploy and safely skips already-applied migrations — no manual migration step is needed.
+
 ### Step 2: Configure Environment Variables
 1. After deployment, click on the **OpenStatus stack**
 2. Go to **"Settings"** → **"Environment Variables"**

--- a/coolify-deployment.yaml
+++ b/coolify-deployment.yaml
@@ -141,6 +141,24 @@ services:
         reservations:
           memory: 256M
 
+  # One-shot schema migration. Runs before any app service starts; drizzle
+  # skips already-applied migrations, so it is safe on every deploy.
+  db-migrate:
+    image: ghcr.io/openstatushq/openstatus-db-migrate:latest
+    container_name: openstatus-db-migrate
+    networks:
+      - openstatus
+    environment:
+      - DATABASE_URL=${DATABASE_URL:-http://libsql:8080}
+      - DATABASE_AUTH_TOKEN=${DATABASE_AUTH_TOKEN:-}
+    depends_on:
+      libsql:
+        condition: service_healthy
+    # retries absorb transient DB races; exits 0 once migrations are applied
+    restart: on-failure:3
+    # pull on every deploy so a stale :latest image never skips new migrations
+    pull_policy: always
+
   tinybird:
     image: tinybirdco/tinybird-local:latest
     container_name: openstatus-tinybird
@@ -179,6 +197,8 @@ services:
       - DATABASE_AUTH_TOKEN=${DATABASE_AUTH_TOKEN:-}
       - PORT=${WORKFLOWS_PORT:-3000}
     depends_on:
+      db-migrate:
+        condition: service_completed_successfully
       libsql:
         condition: service_healthy
     healthcheck:
@@ -207,6 +227,8 @@ services:
       - DATABASE_AUTH_TOKEN=${DATABASE_AUTH_TOKEN:-}
       - PORT=${SERVER_PORT:-3000}
     depends_on:
+      db-migrate:
+        condition: service_completed_successfully
       workflows:
         condition: service_healthy
       libsql:
@@ -296,6 +318,8 @@ services:
       - HOSTNAME=${DASHBOARD_HOSTNAME:-0.0.0.0}
       - AUTH_TRUST_HOST=${DASHBOARD_AUTH_TRUST_HOST:-true}
     depends_on:
+      db-migrate:
+        condition: service_completed_successfully
       workflows:
         condition: service_healthy
       libsql:
@@ -330,6 +354,8 @@ services:
       - HOSTNAME=${STATUS_PAGE_HOSTNAME:-0.0.0.0}
       - AUTH_TRUST_HOST=${STATUS_PAGE_AUTH_TRUST_HOST:-true}
     depends_on:
+      db-migrate:
+        condition: service_completed_successfully
       workflows:
         condition: service_healthy
       libsql:


### PR DESCRIPTION
Fixes #2532

`coolify-deployment.yaml` starts all eight containers but never migrates libSQL, so a fresh deploy looks healthy and then sign-in fails with `LibsqlError` on the `user` table. Three changes:

1. `docker-publish.yml` now builds the existing one-shot migration runner (`packages/db/Dockerfile`) and publishes it as `ghcr.io/openstatushq/openstatus-db-migrate` (added to the dispatch default, the push-detection list, and the build matrix).
2. `coolify-deployment.yaml` gains a `db-migrate` service - idempotent drizzle run, `restart: on-failure:3`, `pull_policy: always` so redeploys pick up new migrations - and `workflows`, `server`, `dashboard` and `status-page` now wait on `service_completed_successfully`.
3. `COOLIFY_ENVIRONMENT_GUIDE.md` says migrations run automatically on every deploy.

The approach copies what `docker-compose-lightweight.yaml` and `docker-compose.github-packages.yaml` already do (the latter even carries a comment saying "a ghcr-published image could replace it later"). `checker` and `private-location` chain off `server` health, so they inherit the ordering without changes.

One caveat: the published image only shows up on GHCR once this reaches `main`, so I couldn't run a real Coolify import against it beforehand. Both YAML files parse, and `pnpm verify` passes 39/39.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



