### PR TITLE
fix(status-page): make badge status API URL configurable

### DIFF
--- a/coolify-deployment.yaml
+++ b/coolify-deployment.yaml
@@ -329,6 +329,7 @@ services:
       - PORT=${STATUS_PAGE_PORT:-3000}
       - HOSTNAME=${STATUS_PAGE_HOSTNAME:-0.0.0.0}
       - AUTH_TRUST_HOST=${STATUS_PAGE_AUTH_TRUST_HOST:-true}
+      - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
     depends_on:
       workflows:
         condition: service_healthy

--- a/coolify-deployment.yaml
+++ b/coolify-deployment.yaml
@@ -329,7 +329,7 @@ services:
       - PORT=${STATUS_PAGE_PORT:-3000}
       - HOSTNAME=${STATUS_PAGE_HOSTNAME:-0.0.0.0}
       - AUTH_TRUST_HOST=${STATUS_PAGE_AUTH_TRUST_HOST:-true}
-      - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
+      - OPENSTATUS_API_URL=${OPENSTATUS_API_URL:-http://server:3000}
     depends_on:
       workflows:
         condition: service_healthy

--- a/docker-compose-lightweight.yaml
+++ b/docker-compose-lightweight.yaml
@@ -115,7 +115,6 @@ services:
             - PORT=3000
             - HOSTNAME=0.0.0.0
             - AUTH_TRUST_HOST=true
-            - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
         depends_on:
             db-migrate:
                 condition: service_completed_successfully

--- a/docker-compose-lightweight.yaml
+++ b/docker-compose-lightweight.yaml
@@ -115,6 +115,7 @@ services:
             - PORT=3000
             - HOSTNAME=0.0.0.0
             - AUTH_TRUST_HOST=true
+            - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
         depends_on:
             db-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -285,7 +285,7 @@ services:
             - PORT=3000
             - HOSTNAME=0.0.0.0
             - AUTH_TRUST_HOST=true
-            - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
+            - OPENSTATUS_API_URL=${OPENSTATUS_API_URL:-http://server:3000}
         depends_on:
             db-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.github-packages.yaml
+++ b/docker-compose.github-packages.yaml
@@ -285,6 +285,7 @@ services:
             - PORT=3000
             - HOSTNAME=0.0.0.0
             - AUTH_TRUST_HOST=true
+            - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
         depends_on:
             db-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -267,7 +267,7 @@ services:
             - PORT=3000
             - HOSTNAME=0.0.0.0
             - AUTH_TRUST_HOST=true
-            - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
+            - OPENSTATUS_API_URL=${OPENSTATUS_API_URL:-http://server:3000}
         depends_on:
             db-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -267,6 +267,7 @@ services:
             - PORT=3000
             - HOSTNAME=0.0.0.0
             - AUTH_TRUST_HOST=true
+            - NEXT_PUBLIC_OPENSTATUS_API_URL=${NEXT_PUBLIC_OPENSTATUS_API_URL:-http://server:3000}
         depends_on:
             db-migrate:
                 condition: service_completed_successfully

--- a/packages/react/src/widget.tsx
+++ b/packages/react/src/widget.tsx
@@ -13,10 +13,12 @@ export type StatusResponse = { status: Status };
 
 export async function getStatus(
   slug: string,
-  baseUrl = process.env.NEXT_PUBLIC_OPENSTATUS_API_URL ??
-    "https://api.openstatus.dev",
+  baseUrl = process.env.OPENSTATUS_API_URL ?? "https://api.openstatus.dev",
 ): Promise<StatusResponse> {
-  const res = await fetch(`${baseUrl}/public/status/${slug}`, {
+  // read at runtime on the server: no NEXT_PUBLIC_ prefix, so deployments
+  // shipping prebuilt images can still point badges at their own API
+  const base = baseUrl.replace(/\/+$/, "") || "https://api.openstatus.dev";
+  const res = await fetch(`${base}/public/status/${slug}`, {
     cache: "no-cache",
   });
 

--- a/packages/react/src/widget.tsx
+++ b/packages/react/src/widget.tsx
@@ -18,15 +18,19 @@ export async function getStatus(
   // read at runtime on the server: no NEXT_PUBLIC_ prefix, so deployments
   // shipping prebuilt images can still point badges at their own API
   const base = baseUrl.replace(/\/+$/, "") || "https://api.openstatus.dev";
-  const res = await fetch(`${base}/public/status/${slug}`, {
-    cache: "no-cache",
-  });
+  try {
+    const res = await fetch(`${base}/public/status/${slug}`, {
+      cache: "no-cache",
+    });
 
-  if (res.ok) {
-    const data = (await res.json()) as StatusResponse;
-    return data;
+    if (res.ok) {
+      const data = (await res.json()) as StatusResponse;
+      return data;
+    }
+  } catch {
+    // network-level failures (unreachable host, DNS, …) degrade to "unknown"
+    // instead of bubbling a 500 out of the badge routes
   }
-
   return { status: "unknown" };
 }
 

--- a/packages/react/src/widget.tsx
+++ b/packages/react/src/widget.tsx
@@ -11,8 +11,12 @@ export type Status =
 
 export type StatusResponse = { status: Status };
 
-export async function getStatus(slug: string): Promise<StatusResponse> {
-  const res = await fetch(`https://api.openstatus.dev/public/status/${slug}`, {
+export async function getStatus(
+  slug: string,
+  baseUrl = process.env.NEXT_PUBLIC_OPENSTATUS_API_URL ??
+    "https://api.openstatus.dev",
+): Promise<StatusResponse> {
+  const res = await fetch(`${baseUrl}/public/status/${slug}`, {
     cache: "no-cache",
   });
 


### PR DESCRIPTION
Fixes #2517

## Root cause

`getStatus()` in `packages/react/src/widget.tsx` had the OpenStatus Cloud API hardcoded:

```ts
const res = await fetch(`https://api.openstatus.dev/public/status/${slug}`, ...)
```

A self-hosted badge route (v1 and v2 alike) asks the Cloud API about a slug it doesn't know, the request fails, and the helper falls back to `{ status: "unknown" }`. Every badge on every self-hosted instance renders "Unknown" forever.

## Fix

- `getStatus()` reads `OPENSTATUS_API_URL` from the environment. I deliberately avoided a `NEXT_PUBLIC_` prefix: the lookup happens server-side at runtime, and Next.js inlines `NEXT_PUBLIC_*` at image build time, so a value passed at runtime would never reach a prebuilt GHCR image. Empty values and trailing slashes are normalized, and with nothing set the default stays `https://api.openstatus.dev`, so cloud behavior doesn't change.
- `docker-compose.yaml`, `docker-compose.github-packages.yaml` and `coolify-deployment.yaml` set `OPENSTATUS_API_URL=http://server:3000` on the status-page service, so badges work out of the box wherever `apps/server` is deployed. Overriding works the same way as `${DATABASE_URL:-...}` and friends: shell env or project root `.env`, not the service `env_file`.
- `docker-compose-lightweight.yaml` gets no default on purpose. That stack doesn't run `apps/server`, so there's no `/public/status` endpoint to point at; operators can aim `OPENSTATUS_API_URL` at any reachable server instance, or leave it unset on cloud.

## Validation

- `pnpm verify`: 39/39 checks pass
- all four YAML files parse
- I haven't run a full self-hosted stack; the server route (`/public/status/:slug`) is untouched, and a sanity check from someone with a live setup would be welcome.
