### PR TITLE
docs: note the Deno prerequisite for pnpm verify in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ To contribute code changes, follow these steps:
 3. Run `pnpm verify` — formatting, lint, doc references and type checks. It needs
    no database and takes seconds. `pnpm verify:test` runs the tests for the
    packages your diff touches; those do need a local libSQL server.
+
+   Note: the type checks (`check` task) in most packages run through
+   [Deno](https://deno.com/), which must be installed locally. Without it,
+   `pnpm verify` fails with `deno: command not found` in every package.
+   See the [Requirements](./README.md#requirements) list in the README for the
+   full toolchain (Node.js, pnpm, Bun, Deno, Turso CLI).
 4. Make commits with clear and descriptive messages. Each commit should have a single logical purpose.
 5. Push your branch to your forked repository.
 6. Open a pull request (PR) from your branch to the original repository's `main` branch.


### PR DESCRIPTION
While setting up a fresh machine to work on #2622, following CONTRIBUTING.md alone, `pnpm verify` failed with `deno: command not found` across all 39 type-check tasks - the `check` task in 25 packages runs `deno check`, but Deno is only listed in the README's Requirements section, not in CONTRIBUTING.

This adds a short note to step 3 calling out the failure mode and pointing at the README requirements list (Node.js, pnpm, Bun, Deno, Turso CLI), so new contributors don't lose their first hour to a missing toolchain piece.

No code changes - one paragraph in CONTRIBUTING.md.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

