### PR TITLE
docs: fix 404 link to contributing guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ See [apps/dashboard/README.md](apps/dashboard/README.md) for full steps (env, db
 
 ## Contributing
 
-If you want to help us build the best status page and monitoring platform, check our [contributing guidelines](https://github.com/openstatusHQ/openstatus/blob/main/CONTRIBUTING.MD).
+If you want to help us build the best status page and monitoring platform, check our [contributing guidelines](CONTRIBUTING.md).
 
 <a href="https://github.com/openstatushq/openstatus/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=openstatushq/openstatus" />


### PR DESCRIPTION
The README's Contributing section links to `https://github.com/openstatusHQ/openstatus/blob/main/CONTRIBUTING.MD` (uppercase `.MD`), which 404s. The file is `CONTRIBUTING.md` — the uppercase path was left behind when the file was renamed.

Switched it to a relative `CONTRIBUTING.md` link, matching how the README already links to `DOCKER.md`, so it resolves on GitHub and in local checkouts.

Docs-only, no code changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

