### PR TITLE
docs(react): fix two dead documentation links in README

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -61,7 +61,7 @@ access the type response of the api call to:
 `https://api.openstatus.dev/public/status/:slug`
 
 Learn more about our supported
-[API endpoints](https://www.openstatus.dev/docs/api-reference/auth).
+[API endpoints](https://api.openstatus.dev/v1).
 
 ```ts
 import { getStatus } from "@openstatus/react";
@@ -89,7 +89,7 @@ export type Status =
   | "incident";
 ```
 
-Learn more in the [docs](https://www.openstatus.dev/docs/packages/react).
+Learn more in the [docs](https://www.openstatus.dev/docs/guides/how-to-use-react-widget).
 
 ### About OpenStatus
 


### PR DESCRIPTION
Two links in `packages/react/README.md` point at docs pages that have been removed and now 404:

- **"API endpoints"** (in the `getStatus` section) linked to `/docs/api-reference/auth`, which is gone. The API reference now lives at the Scalar page https://api.openstatus.dev/v1, so I pointed it there.
- **"Learn more in the docs"** linked to `/docs/packages/react`, also gone. The React package is documented by the widget guide at `/docs/guides/how-to-use-react-widget`, so I pointed it there.

Both new URLs return 200; both old ones return 404. Docs-only, no code change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

