### PR TITLE
docs(readme): add Deploy on Railway button

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ ghcr.io/openstatushq/openstatus-checker:latest
 
 [Complete Coolify Deployment Guide](./COOLIFY_DEPLOYMENT.md)
 
+### Self-Hosting with Railway
+
+Deploy the full stack (dashboard, status pages, API, workflows, probes, libSQL, and Tinybird Local) to one Railway project with one click:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/openstatus?utm_medium=integration&utm_source=button&utm_campaign=openstatus)
+
+The template source and the setup instructions are in [ephraimduncan/openstatus-railway](https://github.com/ephraimduncan/openstatus-railway).
+
 ### Manual Setup
 
 #### Requirements


### PR DESCRIPTION
This PR adds a "Self-Hosting with Railway" section to the README, after the Coolify section.

The section has the one-click "Deploy on Railway" button and a link to the template repository, [ephraimduncan/openstatus-railway](https://github.com/ephraimduncan/openstatus-railway). The template deploys the full stack to one Railway project: dashboard, status pages, API, workflows, probes, libSQL, and Tinybird Local.

`node scripts/check-doc-refs.mts` passes. `oxfmt` ignores `.md` files, so `pnpm verify` is not affected.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

