### PR TITLE
fix(header-analysis): reject unknown Vercel regions

### DIFF
--- a/packages/header-analysis/src/parser/x-vercel-id.test.ts
+++ b/packages/header-analysis/src/parser/x-vercel-id.test.ts
@@ -33,4 +33,14 @@ describe("parseXVercelId", () => {
       expect(result.error.message).toBe("Couldn't parse the header.");
     }
   });
+
+  it("fails when the region id is not in the list", () => {
+    const result = parseXVercelId("zzz9::qwert-1700000000000-abc123");
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.error.message).toBe(
+        "It seems like the region 'zzz9' is not listed.",
+      );
+    }
+  });
 });

--- a/packages/header-analysis/src/parser/x-vercel-id.ts
+++ b/packages/header-analysis/src/parser/x-vercel-id.ts
@@ -9,10 +9,20 @@ export function parseXVercelId(header: string): ParserReturn<Region[]> {
     return { status: "failed", error: new Error("Couldn't parse the header.") };
   }
 
-  const data = arr.map((r) => {
+  const data: Region[] = [];
+  for (const r of arr) {
     const regionId = r.replace(/:+/, "");
-    return regions[regionId];
-  });
+    const region = regions[regionId];
+    if (!region) {
+      return {
+        status: "failed",
+        error: new Error(
+          `It seems like the region '${regionId}' is not listed.`,
+        ),
+      };
+    }
+    data.push(region);
+  }
 
   return { status: "success", data };
 }


### PR DESCRIPTION
Follow-up to #2395’s review note about unlisted Vercel region IDs.

## Summary

`parseXVercelId()` promises `ParserReturn<Region[]>`, but a syntactically valid, unlisted Vercel region (for example `zzz9`) currently returns `status: "success"` with `undefined` in the data array. Consumers then fail only when accessing a region property.

Sibling region parsers reject unlisted values, so this makes the Vercel parser honor the same contract.

## Changes

- Validate every parsed Vercel region ID before adding it to the result.
- Return a clear failed result when any ID is unknown.
- Add a regression test for an unknown but syntactically valid region ID.

## Validation

- [x] `oxfmt --check packages/header-analysis/src/parser/x-vercel-id.ts packages/header-analysis/src/parser/x-vercel-id.test.ts`
- [x] `oxlint packages/header-analysis/src/parser/x-vercel-id.ts packages/header-analysis/src/parser/x-vercel-id.test.ts`
- [x] Focused Deno 2.9.4 runtime check: unknown IDs fail; known multi-region headers still resolve in order.
- [x] `git diff --check`

## Scope and Compatibility

This changes only the parser and its existing unit test. No dependencies, configuration, or documentation changes are included. The public return type is unchanged; the runtime behavior now matches it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

