### PR TITLE
fix(validation): reject whitespace-only names across dashboard forms

### DIFF
--- a/apps/dashboard/src/components/forms/api-key/form.tsx
+++ b/apps/dashboard/src/components/forms/api-key/form.tsx
@@ -34,7 +34,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 export const schema = z.object({
-  name: z.string().min(1, "Name is required"),
+  name: z.string().trim().min(1, "Name is required"),
   description: z.string().optional(),
   expiresAt: z.string().optional(),
   // Single-value radio. The wire format on the create-key API is

--- a/apps/dashboard/src/components/forms/components/form-components.tsx
+++ b/apps/dashboard/src/components/forms/components/form-components.tsx
@@ -106,7 +106,7 @@ const componentSchema = z.object({
   id: z.number(),
   monitorId: z.number().nullish(),
   order: z.number(),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: z.string().optional(),
   type: z.enum(["monitor", "static"]),
 });

--- a/apps/dashboard/src/components/forms/components/form-components.tsx
+++ b/apps/dashboard/src/components/forms/components/form-components.tsx
@@ -117,7 +117,7 @@ const schema = z.object({
     z.object({
       id: z.number(),
       order: z.number(),
-      name: z.string(),
+      name: z.string().trim().min(1, { message: "Name is required" }),
       defaultOpen: z.boolean(),
       components: z.array(componentSchema).min(1, {
         message: "At least one component is required",

--- a/apps/dashboard/src/components/forms/components/form-components.tsx
+++ b/apps/dashboard/src/components/forms/components/form-components.tsx
@@ -738,7 +738,7 @@ function ComponentRow({
       className={cn("rounded-md", className)}
       {...props}
     >
-      <div className="grid h-9 grid-cols-4 gap-2">
+      <div className="grid min-h-9 grid-cols-4 gap-2">
         <div className="flex flex-row items-center gap-1 self-center">
           <SortableItemHandle>
             <DragHandle

--- a/apps/dashboard/src/components/forms/maintenance/form.tsx
+++ b/apps/dashboard/src/components/forms/maintenance/form.tsx
@@ -53,7 +53,7 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const schema = z
   .object({
-    title: z.string().min(1, "Title is required"),
+    title: z.string().trim().min(1, "Title is required"),
     message: z.string(),
     startDate: z.date(),
     endDate: z.date(),

--- a/apps/dashboard/src/components/forms/monitor-tag/form-monitor-tag.tsx
+++ b/apps/dashboard/src/components/forms/monitor-tag/form-monitor-tag.tsx
@@ -24,7 +24,7 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const tagSchema = z.object({
   id: z.number().optional(),
-  name: z.string().min(1, "Name is required"),
+  name: z.string().trim().min(1, "Name is required"),
   color: z.string().regex(/^#[0-9A-Fa-f]{6}$/, "Invalid color format"),
 });
 

--- a/apps/dashboard/src/components/forms/onboarding/create-page.tsx
+++ b/apps/dashboard/src/components/forms/onboarding/create-page.tsx
@@ -62,7 +62,7 @@ const schema = z.object({
   components: z
     .array(
       z.object({
-        name: z.string().min(1, "Component name is required"),
+        name: z.string().trim().min(1, "Component name is required"),
       }),
     )
     .optional(),

--- a/apps/dashboard/src/components/forms/private-location/form.tsx
+++ b/apps/dashboard/src/components/forms/private-location/form.tsx
@@ -39,7 +39,7 @@ import { useFormSheetDirty } from "@/components/forms/form-sheet";
 import { CheckboxTree } from "@/components/ui/checkbox-tree";
 
 const schema = z.object({
-  name: z.string().min(1, "Name is required"),
+  name: z.string().trim().min(1, "Name is required"),
   token: z.string(),
   monitors: z.array(z.number()),
   metadata: z

--- a/apps/dashboard/src/components/forms/settings/form-workspace.tsx
+++ b/apps/dashboard/src/components/forms/settings/form-workspace.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/forms/form-card";
 
 const schema = z.object({
-  name: z.string(),
+  name: z.string().trim().min(1, "Name is required"),
 });
 
 type FormValues = z.infer<typeof schema>;

--- a/apps/dashboard/src/components/forms/status-report/form.tsx
+++ b/apps/dashboard/src/components/forms/status-report/form.tsx
@@ -64,7 +64,7 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const schema = z.object({
   status: z.enum(statusReportStatus),
-  title: z.string().min(1, "Title is required.").max(256),
+  title: z.string().trim().min(1, "Title is required.").max(256),
   message: z.string(),
   date: z.date(),
   pageComponents: z.array(z.number()),

--- a/apps/dashboard/src/components/nav/nav-feedback.tsx
+++ b/apps/dashboard/src/components/nav/nav-feedback.tsx
@@ -27,7 +27,7 @@ import { z } from "zod";
 import { useTRPC } from "@/lib/trpc/client";
 
 const schema = z.object({
-  message: z.string().min(1),
+  message: z.string().trim().min(1),
 });
 
 export function NavFeedback() {

--- a/packages/services/src/api-key/schemas.ts
+++ b/packages/services/src/api-key/schemas.ts
@@ -19,7 +19,7 @@ export const apiKeyCreateScopesSchema = z
   .default(["write"]);
 
 export const CreateApiKeyInput = z.object({
-  name: z.string().min(1, "Name is required"),
+  name: z.string().trim().min(1, "Name is required"),
   description: z.string().optional(),
   expiresAt: z.date().optional(),
   scopes: apiKeyCreateScopesSchema,

--- a/packages/services/src/maintenance/schemas.ts
+++ b/packages/services/src/maintenance/schemas.ts
@@ -12,7 +12,7 @@ export const maintenanceListPeriodSchema = z.enum(maintenanceListPeriods);
 
 export const CreateMaintenanceInput = z
   .object({
-    title: z.string().min(1).max(256),
+    title: z.string().trim().min(1).max(256),
     message: z.string().min(1),
     from: z.coerce.date(),
     to: z.coerce.date(),
@@ -27,7 +27,7 @@ export type CreateMaintenanceInput = z.infer<typeof CreateMaintenanceInput>;
 
 export const UpdateMaintenanceInput = z.object({
   id: z.number().int(),
-  title: z.string().min(1).max(256).optional(),
+  title: z.string().trim().min(1).max(256).optional(),
   message: z.string().min(1).optional(),
   from: z.coerce.date().optional(),
   to: z.coerce.date().optional(),

--- a/packages/services/src/monitor-tag/schemas.ts
+++ b/packages/services/src/monitor-tag/schemas.ts
@@ -5,7 +5,7 @@ export type ListMonitorTagsInput = z.infer<typeof ListMonitorTagsInput>;
 
 const tagInput = z.object({
   id: z.number().int().optional(),
-  name: z.string(),
+  name: z.string().trim().min(1),
   color: z.string(),
 });
 

--- a/packages/services/src/page-component/schemas.ts
+++ b/packages/services/src/page-component/schemas.ts
@@ -37,7 +37,7 @@ const groupInput = z.object({
   // assignments, subscriber scopes) off a cliff.
   id: z.number().int().optional(),
   order: z.number().int(),
-  name: z.string(),
+  name: z.string().trim().min(1),
   defaultOpen: z.boolean().optional().default(false),
   components: z.array(componentInput),
 });

--- a/packages/services/src/page-component/schemas.ts
+++ b/packages/services/src/page-component/schemas.ts
@@ -17,7 +17,7 @@ const componentInput = z
     id: z.number().int().optional(),
     monitorId: z.number().int().nullish(),
     order: z.number().int(),
-    name: z.string().trim(),
+    name: z.string().trim().min(1),
     description: z.string().nullish(),
     type: z.enum(["monitor", "static"]),
   })

--- a/packages/services/src/page-component/schemas.ts
+++ b/packages/services/src/page-component/schemas.ts
@@ -17,7 +17,7 @@ const componentInput = z
     id: z.number().int().optional(),
     monitorId: z.number().int().nullish(),
     order: z.number().int(),
-    name: z.string(),
+    name: z.string().trim(),
     description: z.string().nullish(),
     type: z.enum(["monitor", "static"]),
   })
@@ -60,7 +60,7 @@ export const CreatePageComponentInput = z
     pageId: z.number().int(),
     type: z.enum(["monitor", "static"]),
     monitorId: z.number().int().nullish(),
-    name: z.string().min(1).optional(),
+    name: z.string().trim().min(1).optional(),
     description: z.string().nullish(),
     order: z.number().int().default(0),
     groupId: z.number().int().nullish(),
@@ -84,7 +84,7 @@ export type CreatePageComponentInput = z.input<typeof CreatePageComponentInput>;
 /** Partial patch — `undefined` leaves a field as-is, `null` clears it. */
 export const UpdatePageComponentInput = z.object({
   id: z.number().int(),
-  name: z.string().min(1).optional(),
+  name: z.string().trim().min(1).optional(),
   description: z.string().nullish(),
   order: z.number().int().optional(),
   groupId: z.number().int().nullish(),

--- a/packages/services/src/private-location/schemas.ts
+++ b/packages/services/src/private-location/schemas.ts
@@ -18,7 +18,7 @@ export const PrivateLocationMetadata = z
 export type PrivateLocationMetadata = z.infer<typeof PrivateLocationMetadata>;
 
 export const CreatePrivateLocationInput = z.object({
-  name: z.string().min(1),
+  name: z.string().trim().min(1),
   token: z.string().min(1).optional(),
   monitors: monitorIds,
   metadata: PrivateLocationMetadata.optional(),
@@ -29,7 +29,7 @@ export type CreatePrivateLocationInput = z.infer<
 
 export const UpdatePrivateLocationInput = z.object({
   id: z.number().int(),
-  name: z.string().min(1).optional(),
+  name: z.string().trim().min(1).optional(),
   monitors: monitorIds.optional(),
   metadata: PrivateLocationMetadata.optional(),
 });

--- a/packages/services/src/status-report/schemas.ts
+++ b/packages/services/src/status-report/schemas.ts
@@ -27,7 +27,7 @@ export type StatusReportListPeriod = (typeof statusReportListPeriods)[number];
 export const statusReportListPeriodSchema = z.enum(statusReportListPeriods);
 
 export const CreateStatusReportInput = z.object({
-  title: z.string().min(1).max(256),
+  title: z.string().trim().min(1).max(256),
   status: statusReportStatusSchema,
   message: z.string(),
   date: z.coerce.date(),
@@ -40,7 +40,7 @@ export type CreateStatusReportInput = z.infer<typeof CreateStatusReportInput>;
 
 export const UpdateStatusReportInput = z.object({
   id: z.number().int(),
-  title: z.string().min(1).max(256).optional(),
+  title: z.string().trim().min(1).max(256).optional(),
   status: statusReportStatusSchema.optional(),
   /** When provided, replaces the full association set (empty array clears). */
   pageComponentIds: z.array(z.number().int()).optional(),

--- a/packages/services/src/workspace/schemas.ts
+++ b/packages/services/src/workspace/schemas.ts
@@ -19,7 +19,7 @@ export type GetWorkspaceByStripeIdInput = z.infer<
 >;
 
 export const UpdateWorkspaceNameInput = z.object({
-  name: z.string().min(1),
+  name: z.string().trim().min(1),
 });
 export type UpdateWorkspaceNameInput = z.infer<typeof UpdateWorkspaceNameInput>;
 


### PR DESCRIPTION
This PR fixes eight forms that accepted a whitespace-only name or title. In each case the client schema used `z.string().min(1)` without `.trim()`, so a value of only spaces passed validation and was either saved as a blank-looking record or rejected by the server with a raw Zod error string shown to the user.

### 1. API key name

Submitting spaces sent an empty name to the server, which surfaced the raw `ZodError` JSON in a toast. Now the field blocks it inline and no request is sent.

**Before**

<img width="973" height="713" alt="01-api-key" src="https://github.com/user-attachments/assets/1be4b351-0ebe-4059-9fa2-7c92c2fb868b" />

**After**

<img width="2560" height="1626" alt="01-api-key" src="https://github.com/user-attachments/assets/682b186f-dad6-4866-b3b6-28cb833f2d33" />

---

### 2. Private location name

The location saved with a blank Name, leaving an unidentifiable row in the table.

**Before**

<img width="2560" height="1514" alt="02-private-location" src="https://github.com/user-attachments/assets/f323b587-9fcc-483d-ba29-cd87957edde2" />


**After**

<img width="2560" height="1626" alt="02-private-location" src="https://github.com/user-attachments/assets/b997f666-bc1e-43ad-8b71-d4312c6f363a" />

---

### 3. Monitor tag name

The tag saved as "Tags saved successfully" with an empty label, and stayed empty after a reload.

**Before**

<img width="2560" height="1514" alt="03-monitor-tag" src="https://github.com/user-attachments/assets/85035092-6927-4981-ba57-985c97aa59d2" />



**After**

<img width="2560" height="1626" alt="03-monitor-tag" src="https://github.com/user-attachments/assets/d5463eb9-95f4-45f1-8985-4713898f0766" />

__

> Note: monitor-tag and page-component updateOrder previously had no length constraint, so this adds one. a workspace with a pre-existing blank tag or component name will need to rename it on the next save.

---

### 4. Status report title

The report was created and listed with an empty Title column.

**Before**

<img width="2560" height="1514" alt="04-status-report" src="https://github.com/user-attachments/assets/4a6c8807-8b86-4129-96c5-c100af23dcdb" />


**After**

<img width="2560" height="1626" alt="04-status-report" src="https://github.com/user-attachments/assets/eb895d83-db61-4466-9709-ca0f2d29a0df" />

---

### 5. Maintenance title

The maintenance saved with an empty Title while the message was kept, so the list row had nothing to identify it by.

**Before**

<img width="2560" height="1626" alt="05-maintenance" src="https://github.com/user-attachments/assets/95de82bf-07c8-49e8-8b2d-bf84fc89858e" />

**After**

<img width="2560" height="1626" alt="05-maintenance" src="https://github.com/user-attachments/assets/418bc388-d8ee-48b7-9926-1a366f509265" />

---

### 6. Page component name

The component name was replaced with spaces and saved, blanking the label on the status page preview.

**Before**

<img width="2560" height="1626" alt="06-page-component" src="https://github.com/user-attachments/assets/6e8a603d-33cd-48b3-a300-cde3b5e72ea1" />


**After**

<img width="2560" height="1626" alt="06-page-component" src="https://github.com/user-attachments/assets/1205cbe8-0943-4397-8dbc-995ad13de481" />
---

### 7. Feedback message

The widget accepted spaces and sent them to `feedback.submit`, which already trims server-side (#2618), so the request always failed with a raw error. The client schema was the missing half of that fix — the message is now blocked before any request is made.

**Before**

https://github.com/user-attachments/assets/b6506212-45a8-48a7-8bfa-4e4b6ca9a37e



---

### 8. Onboarding component name

A whitespace-only component name was silently discarded: the status page published successfully but the component was never created, leaving the new workspace with "No components selected".

**Before**

<img width="2560" height="1600" alt="08-onboarding" src="https://github.com/user-attachments/assets/48508349-d6ca-4525-9793-f547fd6ef12d" />


**After**

<img width="2560" height="1600" alt="08-onboarding" src="https://github.com/user-attachments/assets/0988d672-621a-448a-8b53-9199fc2f8ac5" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

