### PR TITLE
fix: slack block updated scheduled label

### DIFF
--- a/packages/subscriptions/src/channels/slack-blocks.test.ts
+++ b/packages/subscriptions/src/channels/slack-blocks.test.ts
@@ -55,6 +55,26 @@ describe("buildRootMessage", () => {
     );
   });
 
+  test("context line says Updated for reports and Scheduled for maintenance", () => {
+    const contextText = (root: ReturnType<typeof buildRootMessage>) =>
+      JSON.stringify(root.attachments[0]?.blocks);
+    expect(contextText(buildRootMessage(makeUpdate(), makeSub()))).toContain(
+      "Updated 2026-01-01T10:00:00.000Z",
+    );
+    const maintenance = buildRootMessage(
+      makeUpdate({
+        status: "maintenance",
+        updateId: undefined,
+        date: "2026-01-01T10:00:00.000Z - 2026-01-02T10:00:00.000Z",
+      }),
+      makeSub(),
+    );
+    expect(contextText(maintenance)).toContain(
+      "Scheduled 2026-01-01T10:00:00.000Z - 2026-01-02T10:00:00.000Z",
+    );
+    expect(contextText(maintenance)).not.toContain("Updated");
+  });
+
   test("uses the custom domain origin when present", () => {
     const root = buildRootMessage(
       makeUpdate(),

--- a/packages/subscriptions/src/channels/slack-blocks.ts
+++ b/packages/subscriptions/src/channels/slack-blocks.ts
@@ -95,12 +95,15 @@ export function buildRootMessage(
     });
   }
 
+  // Maintenance carries a scheduled window, not an update timestamp.
+  const dateLabel =
+    pageUpdate.status === "maintenance" ? "Scheduled" : "Updated";
   blocks.push({
     type: "context",
     elements: [
       {
         type: "mrkdwn",
-        text: `Updated ${pageUpdate.date} · <${eventUrl(pageUpdate, subscription)}|View details> · Manage with \`/openstatus unsubscribe\``,
+        text: `${dateLabel} ${pageUpdate.date} · <${eventUrl(pageUpdate, subscription)}|View details> · Manage with \`/openstatus unsubscribe\``,
       },
     ],
   });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

