### PR TITLE
fix(dashboard): send state in generic OIDC authorization request

### DIFF
--- a/apps/dashboard/src/lib/auth/providers.ts
+++ b/apps/dashboard/src/lib/auth/providers.ts
@@ -28,6 +28,7 @@ export const OIDCProvider: OIDCConfig<Profile> = {
   issuer: process.env.AUTH_OIDC_ISSUER,
   clientId: process.env.AUTH_OIDC_ID,
   clientSecret: process.env.AUTH_OIDC_SECRET,
+  checks: ["pkce", "state"],
 };
 
 // The stock provider bakes an empty `connection=` into the authorize URL, and


### PR DESCRIPTION
# Summary
The self-hosted dashboard’s generic `OIDCProvider` (`apps/dashboard/src/lib/auth/providers.ts`) sets no checks, so Auth.js sends PKCE only — the authorization request carries `client_id`, `redirect_uri`, `scope`, `code_challenge`, but no `state`. Providers that require `state` (e.g. Cloudflare Access) reject it:

```
error=invalid_request
error_description=state is a required parameter
```

and the user lands on `/login?error=OAuthCallbackError`.

```typescript
 export const OIDCProvider: OIDCConfig<Profile> = {
   ...
   clientSecret: process.env.AUTH_OIDC_SECRET,
+  checks: ["pkce", "state"],
 };
```

Verified against Cloudflare Access: replaying the same authorization request with a `state` value proceeds to the provider’s login page; issuer discovery and the callback URL were already working.

`pnpm format:check` and `tsc --noEmit` for `apps/dashboard` pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

