### PR TITLE
fix(dashboard): show choosing state only on clicked plan

### DIFF
--- a/apps/dashboard/src/components/data-table/billing/data-table.tsx
+++ b/apps/dashboard/src/components/data-table/billing/data-table.tsx
@@ -40,6 +40,7 @@ export function DataTable({ restrictTo }: { restrictTo?: WorkspacePlan[] }) {
   const trpc = useTRPC();
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [pendingPlan, setPendingPlan] = useState<WorkspacePlan | null>(null);
   const { data: workspace } = useQuery(trpc.workspace.get.queryOptions());
 
   const checkoutSessionMutation = useMutation(
@@ -131,6 +132,7 @@ export function DataTable({ restrictTo }: { restrictTo?: WorkspacePlan[] }) {
                       type="button"
                       variant={id === "starter" ? "default" : "outline"}
                       onClick={() => {
+                        setPendingPlan(id);
                         startTransition(async () => {
                           if (id === "free") {
                             await customerPortalMutation.mutateAsync({
@@ -153,7 +155,7 @@ export function DataTable({ restrictTo }: { restrictTo?: WorkspacePlan[] }) {
                     >
                       {isCurrentPlan
                         ? "Current Plan"
-                        : isPending
+                        : isPending && pendingPlan === id
                           ? "Choosing..."
                           : "Choose"}
                     </Button>


### PR DESCRIPTION
This PR fixes the billing plan buttons all showing Choosing... at once. The clicked plan is now tracked in state, so only that button shows Choosing....


## Before

https://github.com/user-attachments/assets/c0b846da-4fff-45e2-804f-536be686b9ab


## After

https://github.com/user-attachments/assets/742f912b-6bd9-4bb5-805d-6d0e8c01bd50


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

