### PR TITLE
fix(oauth): fall back to stored or pinned client metadata when the CIMD fetch fails

### DIFF
--- a/apps/server/src/routes/oauth/oauth.test.ts
+++ b/apps/server/src/routes/oauth/oauth.test.ts
@@ -627,8 +627,10 @@ describe("URL client ids (CIMD)", () => {
     ).toBe(200);
   });
 
-  test("an unreachable or mismatched document is a 400 invalid_client", async () => {
-    const missing = await cimdAuthorize(cimdApp(null));
+  test("an unreachable or mismatched document for an unknown client is a 400 invalid_client", async () => {
+    // A client id never stored, so no fallback document exists.
+    const unknown = { client_id: "https://partner.example/.well-known/other" };
+    const missing = await cimdAuthorize(cimdApp(null), unknown);
     expect(missing.status).toBe(400);
     expect((await missing.json()).error).toBe("invalid_client");
 
@@ -637,9 +639,18 @@ describe("URL client ids (CIMD)", () => {
         client_id: "https://other.example/c",
         redirect_uris: [CIMD_REDIRECT],
       }),
+      unknown,
     );
     expect(mismatched.status).toBe(400);
     expect((await mismatched.json()).error).toBe("invalid_client");
+  });
+
+  test("an unreachable document for a stored client falls back to the stored row", async () => {
+    const res = await cimdAuthorize(cimdApp(null));
+    expect(res.status).toBe(302);
+    expect(
+      new URL(res.headers.get("location") ?? "").searchParams.get("session"),
+    ).not.toBeNull();
   });
 
   test("a URL client id on a private host is refused before any fetch", async () => {

--- a/apps/server/src/routes/oauth/oauth.test.ts
+++ b/apps/server/src/routes/oauth/oauth.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@openstatus/db/src/schema";
 import { createTestWorkspace } from "@openstatus/db/src/test/factories";
 import {
+  ClientMetadataUnavailableError,
   OAuthError,
   decideSession,
   parseClientMetadataDocument,
@@ -533,7 +534,8 @@ describe("URL client ids (CIMD)", () => {
   const CIMD_ID = "https://partner.example/.well-known/oauth-client";
   const CIMD_REDIRECT = "https://partner.example/oauth/callback";
 
-  function cimdApp(document: Record<string, unknown> | null) {
+  /** `null` answers 404 (gone); `"unavailable"` a bot challenge (403). */
+  function cimdApp(document: Record<string, unknown> | null | "unavailable") {
     const { createOAuthRoutes } = routes;
     const local = new Hono();
     local.route(
@@ -541,6 +543,11 @@ describe("URL client ids (CIMD)", () => {
       createOAuthRoutes({
         ...config,
         fetchClientMetadata: async (clientId) => {
+          if (document === "unavailable") {
+            throw new ClientMetadataUnavailableError(
+              "Client metadata document responded with HTTP 403",
+            );
+          }
           if (!document) {
             throw new OAuthError(
               "invalid_client",
@@ -646,11 +653,20 @@ describe("URL client ids (CIMD)", () => {
   });
 
   test("an unreachable document for a stored client falls back to the stored row", async () => {
-    const res = await cimdAuthorize(cimdApp(null));
+    // Seed the row here so the test does not depend on sibling order.
+    const seeded = await cimdAuthorize(
+      cimdApp({ client_id: CIMD_ID, redirect_uris: [CIMD_REDIRECT] }),
+    );
+    expect(seeded.status).toBe(302);
+
+    const res = await cimdAuthorize(cimdApp("unavailable"));
     expect(res.status).toBe(302);
     expect(
       new URL(res.headers.get("location") ?? "").searchParams.get("session"),
     ).not.toBeNull();
+
+    const gone = await cimdAuthorize(cimdApp(null));
+    expect(gone.status).toBe(400);
   });
 
   test("a URL client id on a private host is refused before any fetch", async () => {

--- a/packages/services/src/oauth/__tests__/cimd.test.ts
+++ b/packages/services/src/oauth/__tests__/cimd.test.ts
@@ -11,6 +11,7 @@ import type { Workspace } from "../../types";
 import {
   type ClientMetadataDocument,
   isUrlClientId,
+  KNOWN_CLIENT_DOCUMENTS,
   parseClientMetadataDocument,
 } from "../cimd";
 import { pkceChallenge } from "../crypto";
@@ -304,6 +305,59 @@ describe("authorize with a URL client id", () => {
           .where(eq(oauthClient.clientId, CLIENT_ID))
           .get(),
       ).toBeUndefined();
+    });
+  });
+
+  test("a fetch failure falls back to the stored document", async () => {
+    await withTestTransaction(async (tx) => {
+      await authorizeAs(CLIENT_ID, stub(doc({ client_name: "Stored" })), tx);
+      const { id } = await authorizeAs(
+        CLIENT_ID,
+        stub(
+          new OAuthError(
+            "invalid_client",
+            "Client metadata document responded with HTTP 403",
+          ),
+        ),
+        tx,
+      );
+      expect((await getSession({ input: { id }, db: tx })).clientId).toBe(
+        CLIENT_ID,
+      );
+      const row = await tx
+        .select()
+        .from(oauthClient)
+        .where(eq(oauthClient.clientId, CLIENT_ID))
+        .get();
+      expect(row?.name).toBe("Stored");
+      expect(row?.redirectUris).toEqual([REDIRECT]);
+    });
+  });
+
+  test("a fetch failure falls back to a pinned document when nothing is stored", async () => {
+    const [clientId, pinned] = Object.entries(KNOWN_CLIENT_DOCUMENTS)[0];
+    await withTestTransaction(async (tx) => {
+      const { id } = await authorizeAs(
+        clientId,
+        stub(
+          new OAuthError(
+            "invalid_client",
+            "Client metadata document responded with HTTP 403",
+          ),
+        ),
+        tx,
+        { redirect_uri: pinned.redirect_uris[0] },
+      );
+      expect((await getSession({ input: { id }, db: tx })).clientId).toBe(
+        clientId,
+      );
+      const row = await tx
+        .select()
+        .from(oauthClient)
+        .where(eq(oauthClient.clientId, clientId))
+        .get();
+      expect(row?.name).toBe(pinned.client_name);
+      expect(row?.redirectUris).toEqual(pinned.redirect_uris);
     });
   });
 

--- a/packages/services/src/oauth/__tests__/cimd.test.ts
+++ b/packages/services/src/oauth/__tests__/cimd.test.ts
@@ -10,6 +10,7 @@ import {
 import type { Workspace } from "../../types";
 import {
   type ClientMetadataDocument,
+  ClientMetadataUnavailableError,
   isUrlClientId,
   KNOWN_CLIENT_DOCUMENTS,
   parseClientMetadataDocument,
@@ -314,8 +315,7 @@ describe("authorize with a URL client id", () => {
       const { id } = await authorizeAs(
         CLIENT_ID,
         stub(
-          new OAuthError(
-            "invalid_client",
+          new ClientMetadataUnavailableError(
             "Client metadata document responded with HTTP 403",
           ),
         ),
@@ -340,8 +340,7 @@ describe("authorize with a URL client id", () => {
       const { id } = await authorizeAs(
         clientId,
         stub(
-          new OAuthError(
-            "invalid_client",
+          new ClientMetadataUnavailableError(
             "Client metadata document responded with HTTP 403",
           ),
         ),
@@ -358,6 +357,44 @@ describe("authorize with a URL client id", () => {
         .get();
       expect(row?.name).toBe(pinned.client_name);
       expect(row?.redirectUris).toEqual(pinned.redirect_uris);
+    });
+  });
+
+  test("a 404 for a stored client is still a hard failure", async () => {
+    await withTestTransaction(async (tx) => {
+      await authorizeAs(CLIENT_ID, stub(doc()), tx);
+      const err = await authorizeAs(
+        CLIENT_ID,
+        stub(
+          new OAuthError(
+            "invalid_client",
+            "Client metadata document responded with HTTP 404",
+          ),
+        ),
+        tx,
+      ).catch((e) => e);
+      expect(err.oauthCode).toBe("invalid_client");
+    });
+  });
+
+  test("a client revoked while the fetch is in flight does not fall back", async () => {
+    await withTestTransaction(async (tx) => {
+      await authorizeAs(CLIENT_ID, stub(doc()), tx);
+      const err = await authorizeAs(
+        CLIENT_ID,
+        async () => {
+          await tx
+            .update(oauthClient)
+            .set({ revokedAt: new Date() })
+            .where(eq(oauthClient.clientId, CLIENT_ID));
+          throw new ClientMetadataUnavailableError(
+            "Client metadata document could not be fetched",
+          );
+        },
+        tx,
+      ).catch((e) => e);
+      expect(err.oauthCode).toBe("invalid_client");
+      expect(err.message).toContain("revoked");
     });
   });
 

--- a/packages/services/src/oauth/cimd.ts
+++ b/packages/services/src/oauth/cimd.ts
@@ -161,6 +161,13 @@ export async function fetchClientMetadataDocument(
       signal: controller.signal,
     });
     if (!res.ok) {
+      // cf-mitigated/cf-ray tell a bot challenge apart from a real 4xx.
+      const diag = ["cf-mitigated", "cf-ray", "server", "content-type"]
+        .map((h) => `${h}=${res.headers.get(h) ?? "-"}`)
+        .join(" ");
+      console.warn(
+        `[oauth/cimd] ${clientId} responded with HTTP ${res.status} (${diag})`,
+      );
       throw new OAuthError(
         "invalid_client",
         `Client metadata document responded with HTTP ${res.status}`,
@@ -196,9 +203,24 @@ export async function fetchClientMetadataDocument(
 }
 
 /**
+ * Documents pinned for clients whose hosts sit behind bot protection that
+ * challenges datacenter egress IPs. Used only when the live fetch fails and
+ * nothing is stored yet; a successful fetch always wins.
+ */
+export const KNOWN_CLIENT_DOCUMENTS: Record<string, ClientMetadataDocument> = {
+  "https://claude.ai/oauth/mcp-oauth-client-metadata": {
+    client_id: "https://claude.ai/oauth/mcp-oauth-client-metadata",
+    client_name: "Claude",
+    redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+  },
+};
+
+/**
  * Fetch the document and upsert the client row keyed by its URL. Runs once per
  * authorize request, so no separate cache; a row an operator revoked stays
- * revoked no matter what the document says.
+ * revoked no matter what the document says. When the fetch fails, the last
+ * stored document (or a pinned one) stands in, since it passed the same
+ * domain-ownership check when it was stored.
  */
 export async function resolveUrlClient(
   db: DB,
@@ -206,7 +228,7 @@ export async function resolveUrlClient(
   fetcher: ClientMetadataFetcher = fetchClientMetadataDocument,
 ): Promise<OAuthClient> {
   const existing = await db
-    .select({ revokedAt: oauthClient.revokedAt })
+    .select()
     .from(oauthClient)
     .where(eq(oauthClient.clientId, clientId))
     .get();
@@ -214,7 +236,28 @@ export async function resolveUrlClient(
     throw new OAuthError("invalid_client", "Unknown or revoked client");
   }
 
-  const doc = await fetcher(clientId);
+  let doc: ClientMetadataDocument;
+  try {
+    doc = await fetcher(clientId);
+    console.info(
+      `[oauth/cimd] fetched document for ${clientId} (${doc.redirect_uris.length} redirect_uris, ${existing ? "update" : "insert"})`,
+    );
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    if (existing) {
+      console.warn(
+        `[oauth/cimd] using stored document for ${clientId}: ${reason}`,
+      );
+      return selectOAuthClientSchema.parse(existing);
+    }
+    const pinned = KNOWN_CLIENT_DOCUMENTS[clientId];
+    if (!pinned) throw err;
+    console.warn(
+      `[oauth/cimd] using pinned document for ${clientId}: ${reason}`,
+    );
+    doc = pinned;
+  }
+
   const values = {
     name: doc.client_name ?? new URL(clientId).hostname,
     redirectUris: Array.from(new Set(doc.redirect_uris)),

--- a/packages/services/src/oauth/cimd.ts
+++ b/packages/services/src/oauth/cimd.ts
@@ -110,6 +110,16 @@ export function parseClientMetadataDocument(
   return parsed.data;
 }
 
+/**
+ * The document could not be reached (network failure, timeout, bot challenge,
+ * rate limit, 5xx). Unlike a 404 or an invalid body, a stored copy may stand in.
+ */
+export class ClientMetadataUnavailableError extends OAuthError {
+  constructor(message: string) {
+    super("invalid_client", message);
+  }
+}
+
 export type ClientMetadataFetcher = (
   clientId: string,
 ) => Promise<ClientMetadataDocument>;
@@ -168,10 +178,14 @@ export async function fetchClientMetadataDocument(
       console.warn(
         `[oauth/cimd] ${clientId} responded with HTTP ${res.status} (${diag})`,
       );
-      throw new OAuthError(
-        "invalid_client",
-        `Client metadata document responded with HTTP ${res.status}`,
-      );
+      const message = `Client metadata document responded with HTTP ${res.status}`;
+      const unavailable =
+        res.status === 403 ||
+        res.status === 429 ||
+        res.status >= 500 ||
+        res.headers.has("cf-mitigated");
+      if (unavailable) throw new ClientMetadataUnavailableError(message);
+      throw new OAuthError("invalid_client", message);
     }
     const text = await readBounded(res, CIMD_MAX_BYTES);
     let body: unknown;
@@ -193,8 +207,7 @@ export async function fetchClientMetadataDocument(
         err instanceof Error ? err.message : String(err)
       }`,
     );
-    throw new OAuthError(
-      "invalid_client",
+    throw new ClientMetadataUnavailableError(
       "Client metadata document could not be fetched",
     );
   } finally {
@@ -218,20 +231,23 @@ export const KNOWN_CLIENT_DOCUMENTS: Record<string, ClientMetadataDocument> = {
 /**
  * Fetch the document and upsert the client row keyed by its URL. Runs once per
  * authorize request, so no separate cache; a row an operator revoked stays
- * revoked no matter what the document says. When the fetch fails, the last
- * stored document (or a pinned one) stands in, since it passed the same
- * domain-ownership check when it was stored.
+ * revoked no matter what the document says. When the document is unreachable,
+ * the last stored document (or a pinned one) stands in, since it passed the
+ * same domain-ownership check when it was stored. A 404 or an invalid body is
+ * still a hard failure so a de-registered client does not live on.
  */
 export async function resolveUrlClient(
   db: DB,
   clientId: string,
   fetcher: ClientMetadataFetcher = fetchClientMetadataDocument,
 ): Promise<OAuthClient> {
-  const existing = await db
-    .select()
-    .from(oauthClient)
-    .where(eq(oauthClient.clientId, clientId))
-    .get();
+  const loadStored = () =>
+    db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.clientId, clientId))
+      .get();
+  const existing = await loadStored();
   if (existing?.revokedAt) {
     throw new OAuthError("invalid_client", "Unknown or revoked client");
   }
@@ -239,21 +255,26 @@ export async function resolveUrlClient(
   let doc: ClientMetadataDocument;
   try {
     doc = await fetcher(clientId);
-    console.info(
+    console.warn(
       `[oauth/cimd] fetched document for ${clientId} (${doc.redirect_uris.length} redirect_uris, ${existing ? "update" : "insert"})`,
     );
   } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    if (existing) {
+    if (!(err instanceof ClientMetadataUnavailableError)) throw err;
+    // Re-read: the operator may have revoked the client while the fetch ran.
+    const stored = await loadStored();
+    if (stored?.revokedAt) {
+      throw new OAuthError("invalid_client", "Unknown or revoked client");
+    }
+    if (stored) {
       console.warn(
-        `[oauth/cimd] using stored document for ${clientId}: ${reason}`,
+        `[oauth/cimd] using stored document for ${clientId}: ${err.message}`,
       );
-      return selectOAuthClientSchema.parse(existing);
+      return selectOAuthClientSchema.parse(stored);
     }
     const pinned = KNOWN_CLIENT_DOCUMENTS[clientId];
     if (!pinned) throw err;
     console.warn(
-      `[oauth/cimd] using pinned document for ${clientId}: ${reason}`,
+      `[oauth/cimd] using pinned document for ${clientId}: ${err.message}`,
     );
     doc = pinned;
   }

--- a/packages/services/src/oauth/index.ts
+++ b/packages/services/src/oauth/index.ts
@@ -17,6 +17,7 @@ export { pkceChallenge } from "./crypto";
 export {
   type ClientMetadataDocument,
   type ClientMetadataFetcher,
+  ClientMetadataUnavailableError,
   isUrlClientId,
   parseClientMetadataDocument,
 } from "./cimd";


### PR DESCRIPTION
## Summary
- Connecting Claude to the openstatus MCP server no longer fails with `invalid_client: Client metadata document responded with HTTP 403`. claude.ai sits behind Cloudflare bot protection, which returns a managed challenge (`cf-mitigated: challenge`) to some of Fly's shared egress IP ranges. The authorize flow died before the consent screen.
- When the live metadata fetch fails, the server now reuses the last stored document for that client URL, or a pinned document for known clients (claude.ai). A successful fetch still overwrites the stored row, and operator-revoked clients stay blocked.
- Non-2xx metadata responses are now logged with `cf-mitigated`, `cf-ray`, `server`, and `content-type`, so a bot challenge is distinguishable from a real 404 in the Fly logs. Successful fetches and both fallbacks log one line each.

## Follow-up
Static egress IPs on the Fly machines (`fly machine egress-ip allocate`) would fix the root cause for any other CIMD client behind Cloudflare; this PR only guarantees the claude.ai flow.

## Test plan
- `deno test` on `packages/services/src/oauth/__tests__/cimd.test.ts`: 22 steps pass, including two new fallback cases
- `deno check`, oxfmt, oxlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uySLnH1sC5gRHdRrHKKTZ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

