### PR TITLE
fix: accept OAuth clients that can fall back to public auth

### DIFF
--- a/packages/services/src/oauth/__tests__/cimd.test.ts
+++ b/packages/services/src/oauth/__tests__/cimd.test.ts
@@ -133,6 +133,29 @@ describe("parseClientMetadataDocument", () => {
     expect(parsed.client_name).toBe("Partner App");
   });
 
+  test("accepts a client that prefers private_key_jwt but also supports none", () => {
+    const parsed = parseClientMetadataDocument(
+      CLIENT_ID,
+      doc({
+        token_endpoint_auth_method: "private_key_jwt",
+        token_endpoint_auth_methods_supported: ["none", "private_key_jwt"],
+      }),
+    );
+    expect(parsed.client_name).toBe("Partner App");
+  });
+
+  test("rejects a confidential client that cannot fall back to none", () => {
+    expect(() =>
+      parseClientMetadataDocument(
+        CLIENT_ID,
+        doc({
+          token_endpoint_auth_method: "private_key_jwt",
+          token_endpoint_auth_methods_supported: ["private_key_jwt"],
+        }),
+      ),
+    ).toThrow(OAuthError);
+  });
+
   test("rejects a document whose client_id differs from its URL", () => {
     expect(() =>
       parseClientMetadataDocument(

--- a/packages/services/src/oauth/__tests__/cimd.test.ts
+++ b/packages/services/src/oauth/__tests__/cimd.test.ts
@@ -156,6 +156,15 @@ describe("parseClientMetadataDocument", () => {
     ).toThrow(OAuthError);
   });
 
+  test("a supported-methods list without none is rejected even if the method is omitted", () => {
+    expect(() =>
+      parseClientMetadataDocument(
+        CLIENT_ID,
+        doc({ token_endpoint_auth_methods_supported: ["private_key_jwt"] }),
+      ),
+    ).toThrow(OAuthError);
+  });
+
   test("rejects a document whose client_id differs from its URL", () => {
     expect(() =>
       parseClientMetadataDocument(

--- a/packages/services/src/oauth/cimd.ts
+++ b/packages/services/src/oauth/cimd.ts
@@ -91,8 +91,9 @@ export const ClientMetadataDocument = z
   })
   .refine(
     (doc) =>
-      (doc.token_endpoint_auth_method ?? "none") === "none" ||
-      doc.token_endpoint_auth_methods_supported?.includes("none") === true,
+      doc.token_endpoint_auth_methods_supported
+        ? doc.token_endpoint_auth_methods_supported.includes("none")
+        : (doc.token_endpoint_auth_method ?? "none") === "none",
     {
       path: ["token_endpoint_auth_method"],
       message:

--- a/packages/services/src/oauth/cimd.ts
+++ b/packages/services/src/oauth/cimd.ts
@@ -79,12 +79,26 @@ const redirectUriSchema = z.string().refine((value) => {
   }
 }, "redirect_uris must be https or loopback, without fragment or credentials");
 
-export const ClientMetadataDocument = z.object({
-  client_id: z.string().url(),
-  client_name: z.string().trim().min(1).max(120).optional(),
-  redirect_uris: z.array(redirectUriSchema).min(1).max(20),
-  token_endpoint_auth_method: z.literal("none").optional(),
-});
+export const ClientMetadataDocument = z
+  .object({
+    client_id: z.string().url(),
+    client_name: z.string().trim().min(1).max(120).optional(),
+    redirect_uris: z.array(redirectUriSchema).min(1).max(20),
+    token_endpoint_auth_method: z.string().optional(),
+    // Non-standard but published by e.g. ChatGPT: the client prefers
+    // private_key_jwt yet can fall back to `none` when the server only offers that.
+    token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
+  })
+  .refine(
+    (doc) =>
+      (doc.token_endpoint_auth_method ?? "none") === "none" ||
+      doc.token_endpoint_auth_methods_supported?.includes("none") === true,
+    {
+      path: ["token_endpoint_auth_method"],
+      message:
+        'Only public clients are supported: expected "none", or "none" listed in token_endpoint_auth_methods_supported',
+    },
+  );
 export type ClientMetadataDocument = z.infer<typeof ClientMetadataDocument>;
 
 /** Validates the body and pins `client_id` to the URL it was fetched from. */


### PR DESCRIPTION
## Summary
- The ChatGPT MCP connector can now complete the OAuth login. Its client metadata document prefers `private_key_jwt` but lists `none` in `token_endpoint_auth_methods_supported`; the parser required the literal `none` and rejected the document with `invalid_client`.
- Any URL client that can use `none` is now accepted. Clients that only support confidential auth methods are still rejected, with a clearer error message.
- Token exchange is unchanged: URL clients stay public and are verified by `client_id` plus PKCE.

## Test plan
- [x] Added CIMD parser tests for the ChatGPT-shaped document and for a confidential-only client
- [x] `cimd.test.ts` suite passes under devbox (22 steps)
- [ ] Retry the ChatGPT connector login against production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uySLnH1sC5gRHdRrHKKTZ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

