### PR TITLE
fix(page): enforce component limit on full creation

### DIFF
--- a/packages/services/src/page/__tests__/page.test.ts
+++ b/packages/services/src/page/__tests__/page.test.ts
@@ -12,8 +12,8 @@ import { expect } from "@std/expect";
 import { afterAll, beforeAll, describe, test } from "@std/testing/bdd";
 
 import {
-  expectAuditRow,
   createWorkspaceFixture,
+  expectAuditRow,
   makeApiKeyCtx,
   makeUserCtx,
   withTestTransaction,
@@ -167,6 +167,115 @@ describe("createPage (full form)", () => {
         .where(eq(pageComponent.pageId, row.id))
         .all();
       expect(components.map((c) => c.monitorId)).toEqual([teamMonitorId]);
+    });
+  });
+
+  test("counts components on other pages and the full monitor batch", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      await tx
+        .update(workspace)
+        .set({
+          limits: JSON.stringify({
+            ...teamCtx.workspace.limits,
+            "status-pages": 10,
+            "page-components": 2,
+          }),
+        })
+        .where(eq(workspace.id, ctx.workspace.id));
+      const existing = await newPage({
+        ctx,
+        input: { title: "Existing", slug: uniqueSlug("component-existing") },
+      });
+      await tx.insert(pageComponent).values({
+        workspaceId: ctx.workspace.id,
+        pageId: existing.id,
+        type: "static",
+        name: "Existing component",
+      });
+      const secondMonitor = await tx
+        .insert(monitor)
+        .values({
+          workspaceId: ctx.workspace.id,
+          active: true,
+          url: "https://example.com",
+          name: "Second monitor",
+          method: "GET",
+          periodicity: "10m",
+          regions: "ams",
+        })
+        .returning()
+        .get();
+      await expect(
+        createPage({
+          ctx,
+          input: {
+            workspaceId: ctx.workspace.id,
+            description: "",
+            title: "Over limit",
+            slug: uniqueSlug("component-batch"),
+            monitors: [
+              { monitorId: teamMonitorId },
+              { monitorId: secondMonitor.id },
+            ],
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "LIMIT_EXCEEDED",
+        max: 2,
+        current: 1,
+      });
+      const allowed = await createPage({
+        ctx,
+        input: {
+          workspaceId: ctx.workspace.id,
+          description: "",
+          title: "At limit",
+          slug: uniqueSlug("component-allowed"),
+          monitors: [{ monitorId: teamMonitorId }],
+        },
+      });
+      const components = await tx
+        .select()
+        .from(pageComponent)
+        .where(eq(pageComponent.workspaceId, ctx.workspace.id))
+        .all();
+      expect(components.map((c) => c.pageId).sort()).toEqual(
+        [existing.id, allowed.id].sort(),
+      );
+      await expect(
+        createPage({
+          ctx,
+          input: {
+            workspaceId: ctx.workspace.id,
+            description: "",
+            title: "Cap spent",
+            slug: uniqueSlug("component-spent"),
+            monitors: [{ monitorId: secondMonitor.id }],
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "LIMIT_EXCEEDED",
+        max: 2,
+        current: 2,
+      });
+      const empty = await createPage({
+        ctx,
+        input: {
+          workspaceId: ctx.workspace.id,
+          description: "",
+          title: "No components",
+          slug: uniqueSlug("component-empty"),
+          monitors: [],
+        },
+      });
+      expect(
+        await tx
+          .select()
+          .from(pageComponent)
+          .where(eq(pageComponent.pageId, empty.id))
+          .all(),
+      ).toEqual([]);
     });
   });
 

--- a/packages/services/src/page/create.ts
+++ b/packages/services/src/page/create.ts
@@ -88,6 +88,12 @@ export async function createPage(args: {
         })
         .filter((v): v is NonNullable<typeof v> => v !== null);
       if (pageComponentValues.length > 0) {
+        await assertWithinLimit({
+          tx,
+          workspaceId: ctx.workspace.id,
+          limit: "page-components",
+          delta: pageComponentValues.length,
+        });
         await tx.insert(pageComponent).values(pageComponentValues).run();
       }
     }


### PR DESCRIPTION
- Full page creation rejects monitor selections that exceed the workspace component limit. Previously, a new page could bypass that limit.
- Components on other pages count toward the limit. Pages with no components remain possible when the component limit is spent.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

