### PR TITLE
fix: exclude deleted monitors from private location reads

### DIFF
--- a/packages/services/src/private-location/__tests__/private-location.test.ts
+++ b/packages/services/src/private-location/__tests__/private-location.test.ts
@@ -11,8 +11,8 @@ import { expect } from "@std/expect";
 import { afterAll, beforeAll, describe, test } from "@std/testing/bdd";
 
 import {
-  expectAuditRow,
   createWorkspaceFixture,
+  expectAuditRow,
   makeApiKeyCtx,
   makeUserCtx,
   readAuditLog,
@@ -643,6 +643,35 @@ describe("getPrivateLocation", () => {
       expect(found.id).toBe(created.id);
       expect(found.token).toBe(created.token);
       expect(found.monitors.map((m) => m.id)).toEqual([teamMonitorId]);
+    });
+  });
+
+  test("excludes soft-deleted monitors from get and list without losing healthy monitors", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const created = await createPrivateLocation({
+        ctx,
+        input: {
+          name: `${TEST_PREFIX}-deleted-attachment`,
+          monitors: [teamMonitorId, secondMonitorId],
+        },
+      });
+      await tx
+        .update(monitor)
+        .set({ active: false, deletedAt: new Date() })
+        .where(eq(monitor.id, secondMonitorId));
+
+      const found = await getPrivateLocation({
+        ctx,
+        input: { id: created.id },
+      });
+      const listed = await listPrivateLocations({ ctx });
+      expect({
+        get: found.monitors.map((m) => m.id),
+        list: listed.items
+          .find((item) => item.id === created.id)
+          ?.monitors.map((m) => m.id),
+      }).toEqual({ get: [teamMonitorId], list: [teamMonitorId] });
     });
   });
 

--- a/packages/services/src/private-location/get.ts
+++ b/packages/services/src/private-location/get.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "@openstatus/db";
 import { privateLocation } from "@openstatus/db/src/schema";
 
-import { type ServiceContext, getReadDb } from "../context";
+import { getReadDb, type ServiceContext } from "../context";
 import { NotFoundError } from "../errors";
 import { GetPrivateLocationInput } from "./schemas";
 
@@ -36,6 +36,8 @@ export async function getPrivateLocation(args: {
     ...row,
     monitors: row.privateLocationToMonitors
       .map((link) => link.monitor)
-      .filter((m) => m !== null),
+      .filter(
+        (m): m is NonNullable<typeof m> => m !== null && m.deletedAt === null,
+      ),
   };
 }

--- a/packages/services/src/private-location/list.ts
+++ b/packages/services/src/private-location/list.ts
@@ -1,7 +1,7 @@
 import { count, desc, eq } from "@openstatus/db";
 import { privateLocation } from "@openstatus/db/src/schema";
 
-import { type ServiceContext, getReadDb } from "../context";
+import { getReadDb, type ServiceContext } from "../context";
 import { ListPrivateLocationsInput } from "./schemas";
 
 const LIMIT_DEFAULT = 50;
@@ -9,7 +9,7 @@ const LIMIT_DEFAULT = 50;
 /**
  * List private locations in the caller's workspace, each one flattened to
  * include the monitors it's attached to (the relational join's `monitor`
- * link lifted onto `monitors`, filtered to non-null).
+ * link lifted onto `monitors`, excluding deleted monitors).
  *
  * Return type is deliberately inferred from drizzle's relational query
  * rather than annotated: pulling the shape out of `@openstatus/db`'s
@@ -46,7 +46,9 @@ export async function listPrivateLocations(args: {
       ...row,
       monitors: row.privateLocationToMonitors
         .map((link) => link.monitor)
-        .filter((m) => m !== null),
+        .filter(
+          (m): m is NonNullable<typeof m> => m !== null && m.deletedAt === null,
+        ),
     })),
     totalSize: total?.count ?? 0,
   };


### PR DESCRIPTION
- Private-location reads no longer return deleted monitors or include them in monitor counts. Healthy attached monitors remain in the results.
- This also covers monitors whose database links remain after deletion through the legacy API.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

