### PR TITLE
fix(oauth): reject access tokens and consent at expiration

### DIFF
--- a/packages/services/src/oauth/__tests__/oauth.test.ts
+++ b/packages/services/src/oauth/__tests__/oauth.test.ts
@@ -282,6 +282,41 @@ describe("createSession", () => {
 });
 
 describe("getSession", () => {
+  test("rejects reads and decisions at the expiration instant", async () => {
+    await withTestTransaction(async (tx) => {
+      const client = await register(tx);
+      const { id } = await start(tx, client.client_id);
+      const { expiresAt } = await getSession({ input: { id }, db: tx });
+      expect(
+        (
+          await getSession({
+            input: { id },
+            db: tx,
+            now: new Date(expiresAt.getTime() - 1),
+          })
+        ).id,
+      ).toBe(id);
+      for (const delta of [0, 1]) {
+        const now = new Date(expiresAt.getTime() + delta);
+        await expect(
+          getSession({ input: { id }, db: tx, now }),
+        ).rejects.toBeInstanceOf(PreconditionFailedError);
+        await expect(
+          decideSession({
+            input: {
+              id,
+              approved: true,
+              userId: ownerId,
+              workspaceId: team.id,
+            },
+            db: tx,
+            now,
+          }),
+        ).rejects.toBeInstanceOf(PreconditionFailedError);
+      }
+    });
+  });
+
   test("returns client name and requested scope while pending", async () => {
     await withTestTransaction(async (tx) => {
       const client = await register(tx, "Cursor");
@@ -800,6 +835,40 @@ describe("exchangeCode", () => {
 });
 
 describe("verifyAccessToken", () => {
+  test("rejects access tokens at the expiration instant", async () => {
+    await withTestTransaction(async (tx) => {
+      const client = await register(tx);
+      const tokens = await mintGrant(tx, {
+        clientId: client.client_id,
+        userId: ownerId,
+        workspaceId: team.id,
+      });
+      const grantId = await grantIdOf(tx, tokens.access_token);
+      const grant = await tx
+        .select()
+        .from(oauthGrant)
+        .where(eq(oauthGrant.id, grantId))
+        .get();
+      if (!grant) throw new Error("grant missing");
+      expect(
+        (
+          await verifyAccessToken(tokens.access_token, {
+            db: tx,
+            now: new Date(grant.accessTokenExpiresAt.getTime() - 1),
+          })
+        )?.grantId,
+      ).toBe(grantId);
+      for (const delta of [0, 1]) {
+        expect(
+          await verifyAccessToken(tokens.access_token, {
+            db: tx,
+            now: new Date(grant.accessTokenExpiresAt.getTime() + delta),
+          }),
+        ).toBeNull();
+      }
+    });
+  });
+
   test("resolves workspace, user and scopes and bumps last_used_at", async () => {
     await withTestTransaction(async (tx) => {
       const client = await register(tx);

--- a/packages/services/src/oauth/session.ts
+++ b/packages/services/src/oauth/session.ts
@@ -1,7 +1,7 @@
 import { db as defaultDb, eq } from "@openstatus/db";
 import {
-  type OAuthSession,
   oauthClient,
+  type OAuthSession,
   oauthSession,
   selectOAuthSessionSchema,
 } from "@openstatus/db/src/schema";
@@ -154,7 +154,7 @@ export async function loadPendingSession(
       "This authorization request was already answered",
     );
   }
-  if (session.expiresAt < now) {
+  if (session.expiresAt <= now) {
     throw new PreconditionFailedError("This authorization request expired");
   }
   return session;

--- a/packages/services/src/oauth/verify.ts
+++ b/packages/services/src/oauth/verify.ts
@@ -37,7 +37,7 @@ export async function verifyAccessToken(
     .where(eq(oauthGrant.accessTokenHash, await sha256Hex(token)))
     .get();
   if (!grant || grant.revokedAt) return null;
-  if (grant.accessTokenExpiresAt < now) return null;
+  if (grant.accessTokenExpiresAt <= now) return null;
 
   if (shouldUpdateLastUsed(grant.lastUsedAt, undefined, now)) {
     await db


### PR DESCRIPTION
- Access tokens and pending consent requests no longer remain valid at their exact expiration timestamp.
- Requests before the deadline remain valid. At the deadline, token authentication and consent reads or decisions reject the expired credential or request.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

