### PR TITLE
fix(invitation): record acceptance in invited workspace

### DIFF
--- a/packages/services/src/invitation/__tests__/invitation.test.ts
+++ b/packages/services/src/invitation/__tests__/invitation.test.ts
@@ -9,6 +9,7 @@ import {
   expectAuditRow,
   makeApiKeyCtx,
   makeUserCtx,
+  readAuditLog,
   withTestTransaction,
 } from "../../../test/helpers";
 import type { ServiceContext } from "../../context";
@@ -222,6 +223,37 @@ describe("acceptInvitation", () => {
         .where(eq(usersToWorkspaces.userId, acceptingUserId))
         .get();
       expect(membership?.workspaceId).toBe(teamCtx.workspace.id);
+    });
+  });
+
+  test("records acceptance only in the invited workspace", async () => {
+    await withTestTransaction(async (tx) => {
+      const email = `${TEST_PREFIX}-audit-${Date.now()}@example.com`;
+      const created = await createInvitation({
+        ctx: { ...teamCtx, db: tx },
+        input: { email },
+      });
+
+      await acceptInvitation({
+        ctx: { ...freeCtx, db: tx },
+        input: { id: created.id, email },
+      });
+
+      await expectAuditRow({
+        workspaceId: teamCtx.workspace.id,
+        action: "invitation.update",
+        entityType: "invitation",
+        entityId: created.id,
+        actorType: "user",
+        db: tx,
+      });
+      const activeWorkspaceRows = await readAuditLog({
+        workspaceId: freeCtx.workspace.id,
+        entityType: "invitation",
+        entityId: created.id,
+        db: tx,
+      });
+      expect(activeWorkspaceRows).toEqual([]);
     });
   });
 

--- a/packages/services/src/invitation/accept.ts
+++ b/packages/services/src/invitation/accept.ts
@@ -110,18 +110,23 @@ export async function acceptInvitation(args: {
     if (!existing.workspace) {
       throw new NotFoundError("workspace", existing.workspaceId);
     }
+    const workspace = selectWorkspaceSchema.parse(existing.workspace);
 
     // Strip `token` (email-link capability) from the snapshot; construct the snapshots from the pre-fetched row
     // to avoid a second SELECT after the UPDATE.
     const { token: _token, ...before } = existing;
-    await emitAudit(tx, ctx, {
-      action: "invitation.update",
-      entityType: "invitation",
-      entityId: input.id,
-      before,
-      after: { ...before, acceptedAt },
-    });
+    await emitAudit(
+      tx,
+      { ...ctx, workspace },
+      {
+        action: "invitation.update",
+        entityType: "invitation",
+        entityId: input.id,
+        before,
+        after: { ...before, acceptedAt },
+      },
+    );
 
-    return selectWorkspaceSchema.parse(existing.workspace);
+    return workspace;
   });
 }


### PR DESCRIPTION
- Invitation acceptance appears in the invited workspace's audit history, not the user's active workspace.
- Previously, the invited workspace had no acceptance record, and the active workspace showed an unrelated invitation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

