### PR TITLE
fix: keep timeline events that overlap the lookback window

### DIFF
--- a/packages/services/src/status-timeline/__tests__/events.test.ts
+++ b/packages/services/src/status-timeline/__tests__/events.test.ts
@@ -1,19 +1,22 @@
 import { expect } from "@std/expect";
 import { describe, test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 
 import {
-  type Event,
-  type ImpactInterval,
-  type StatusData,
   activeReportStatus,
+  type Event,
   eventWorstImpact,
+  getEvents,
   getHighestPriorityStatus,
   getWorstVariant,
+  type ImpactInterval,
   isDateWithinEvent,
   reportEventDayImpact,
   reportEventDayStatus,
   resolveDayStatus,
+  type StatusData,
 } from "../events";
+import { durationDowntimeMs } from "../uptime";
 
 const day = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
 
@@ -40,6 +43,87 @@ function makeBucket(overrides: Partial<StatusData> = {}): StatusData {
     ...overrides,
   };
 }
+
+describe("getEvents lookback", () => {
+  test("keeps overlapping intervals and clips incident downtime to the window", () => {
+    const time = new FakeTime(day("2026-03-01"));
+    try {
+      const from = day("2025-12-01");
+      const threshold = day("2026-01-15");
+      const ends = [
+        day("2026-03-02"),
+        day("2026-02-01"),
+        threshold,
+        new Date(threshold.getTime() - 1),
+      ];
+      const events = getEvents({
+        reports: [],
+        maintenances: ends.map((to, id) => ({
+          id,
+          title: "Maintenance",
+          message: "",
+          from,
+          to,
+          workspaceId: 1,
+          pageId: 1,
+          createdAt: from,
+          updatedAt: from,
+          maintenancesToPageComponents: [],
+        })),
+        incidents: [null, ...ends].map((resolvedAt, id) => ({
+          id,
+          title: "Incident",
+          summary: "",
+          status: resolvedAt ? "resolved" : "investigating",
+          monitorId: 1,
+          workspaceId: 1,
+          startedAt: from,
+          acknowledgedAt: null,
+          acknowledgedBy: null,
+          resolvedAt,
+          resolvedBy: null,
+          incidentScreenshotUrl: null,
+          recoveryScreenshotUrl: null,
+          autoResolved: false,
+          createdAt: from,
+          updatedAt: from,
+        })),
+      });
+
+      expect(
+        events
+          .filter((event) => event.type === "maintenance")
+          .map((event) => event.id),
+      ).toEqual([0, 1, 2]);
+      expect(
+        events
+          .filter((event) => event.type === "incident")
+          .map((event) => event.id),
+      ).toEqual([0, 1, 2, 3]);
+      expect(
+        resolveDayStatus(
+          makeBucket({ day: "2026-02-28T00:00:00.000Z" }),
+          events,
+        ).status,
+      ).toBe("down");
+      expect(
+        durationDowntimeMs(events, {
+          start: threshold.getTime(),
+          end: time.now,
+          now: time.now,
+        }),
+      ).toBe(3_888_000_000);
+      expect(
+        resolveDayStatus(
+          makeBucket({ day: "2026-02-28T00:00:00.000Z" }),
+          events.filter((event) => event.type === "maintenance"),
+        ).status,
+      ).toBe("maintenance");
+    } finally {
+      time.restore();
+    }
+  });
+});
 
 describe("getWorstVariant", () => {
   test("empty input is operational (success)", () => {

--- a/packages/services/src/status-timeline/events.ts
+++ b/packages/services/src/status-timeline/events.ts
@@ -292,7 +292,7 @@ export function getEvents({
       return true;
     })
     .forEach((maintenance) => {
-      if (maintenance.from < pastThreshold) return;
+      if (maintenance.to < pastThreshold) return;
       events.push({
         id: maintenance.id,
         name: maintenance.title,
@@ -311,7 +311,12 @@ export function getEvents({
         monitorId ? incident.monitorId === monitorId : true,
       )
       .forEach((incident) => {
-        if (!incident.createdAt || incident.createdAt < pastThreshold) return;
+        if (
+          !incident.createdAt ||
+          (incident.resolvedAt && incident.resolvedAt < pastThreshold)
+        ) {
+          return;
+        }
         events.push({
           id: incident.id,
           name: "Downtime",


### PR DESCRIPTION
Status pages can show a healthy component when an active incident or maintenance started before the lookback window. These events now remain on the timeline, along with events that ended inside the window. Duration-based uptime includes incident downtime within the window.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

