### PR TITLE
fix: keep report metadata status consistent with update history

### DIFF
--- a/packages/services/src/status-report/__tests__/derive-status.test.ts
+++ b/packages/services/src/status-report/__tests__/derive-status.test.ts
@@ -18,7 +18,7 @@ import { addStatusReportUpdate } from "../add-update";
 import { deleteStatusReportUpdate } from "../delete";
 import { deriveReportStatus, recomputeReportStatus } from "../derive-status";
 import type { StatusReportStatus } from "../schemas";
-import { updateStatusReportUpdate } from "../update";
+import { updateStatusReport, updateStatusReportUpdate } from "../update";
 
 const TEST_PREFIX = "svc-derive-status-test";
 
@@ -201,6 +201,141 @@ const readStatus = async (tx: DB, id: number) =>
   (await readRow(tx, id))?.status;
 
 describe("recomputeReportStatus (DB)", () => {
+  test("metadata status survives message edits without adding an update", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const report = await seedReport(
+        tx,
+        teamCtx.workspace.id,
+        "investigating",
+      );
+      const tied = await addUpdate(tx, report.id, "identified", "2026-01-03");
+      const latest = await addUpdate(
+        tx,
+        report.id,
+        "investigating",
+        "2026-01-03",
+      );
+      const backdated = await addUpdate(
+        tx,
+        report.id,
+        "monitoring",
+        "2026-01-02",
+      );
+
+      const updated = await updateStatusReport({
+        ctx,
+        input: { id: report.id, status: "resolved" },
+      });
+      expect(updated.status).toBe("resolved");
+
+      await updateStatusReportUpdate({
+        ctx,
+        input: { id: latest.id, message: "typo fixed" },
+      });
+      expect(await readStatus(tx, report.id)).toBe("resolved");
+
+      const rows = await tx
+        .select()
+        .from(statusReportUpdate)
+        .where(eq(statusReportUpdate.statusReportId, report.id))
+        .all();
+      expect(
+        rows.map(({ id, status, message, date }) => ({
+          id,
+          status,
+          message,
+          date,
+        })),
+      ).toEqual(
+        expect.arrayContaining([
+          {
+            id: tied.id,
+            status: "identified",
+            message: "identified",
+            date: tied.date,
+          },
+          {
+            id: latest.id,
+            status: "resolved",
+            message: "typo fixed",
+            date: latest.date,
+          },
+          {
+            id: backdated.id,
+            status: "monitoring",
+            message: "monitoring",
+            date: backdated.date,
+          },
+        ]),
+      );
+      expect(rows).toHaveLength(3);
+      const audit = await readAuditLog({
+        workspaceId: teamCtx.workspace.id,
+        entityType: "status_report",
+        entityId: report.id,
+        db: tx,
+      });
+      expect(
+        audit.find((row) => row.action === "status_report.update")?.after
+          ?.status,
+      ).toBe("resolved");
+    });
+  });
+
+  test("metadata status works without update history", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const report = await seedReport(
+        tx,
+        teamCtx.workspace.id,
+        "investigating",
+      );
+      const updated = await updateStatusReport({
+        ctx,
+        input: { id: report.id, status: "resolved" },
+      });
+      expect(updated.status).toBe("resolved");
+      expect(await readStatus(tx, report.id)).toBe("resolved");
+      expect(
+        await tx
+          .select()
+          .from(statusReportUpdate)
+          .where(eq(statusReportUpdate.statusReportId, report.id))
+          .all(),
+      ).toEqual([]);
+    });
+  });
+
+  test("title and component metadata edits leave update history unchanged", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const report = await seedReport(
+        tx,
+        teamCtx.workspace.id,
+        "investigating",
+      );
+      const only = await addUpdate(
+        tx,
+        report.id,
+        "investigating",
+        "2026-01-02",
+      );
+      await updateStatusReport({
+        ctx,
+        input: { id: report.id, title: "New title", pageComponentIds: [] },
+      });
+      expect(
+        await tx
+          .select()
+          .from(statusReportUpdate)
+          .where(eq(statusReportUpdate.statusReportId, report.id))
+          .all(),
+      ).toEqual([only]);
+      expect(await readStatus(tx, report.id)).toBe("investigating");
+    });
+  });
+
   test("persists the latest update's status onto the report", async () => {
     await withTestTransaction(async (tx) => {
       const report = await seedReport(

--- a/packages/services/src/status-report/update.ts
+++ b/packages/services/src/status-report/update.ts
@@ -1,9 +1,9 @@
-import { eq } from "@openstatus/db";
+import { desc, eq } from "@openstatus/db";
 import {
   statusReport,
+  statusReportsToPageComponents,
   statusReportUpdate,
   statusReportUpdateToPageComponents,
-  statusReportsToPageComponents,
 } from "@openstatus/db/src/schema";
 
 import { emitAudit } from "../audit";
@@ -64,7 +64,24 @@ export async function updateStatusReport(args: {
 
     const updateValues: Record<string, unknown> = { updatedAt: new Date() };
     if (input.title !== undefined) updateValues.title = input.title;
-    if (input.status !== undefined) updateValues.status = input.status;
+    if (input.status !== undefined) {
+      const latest = await tx
+        .select({ id: statusReportUpdate.id })
+        .from(statusReportUpdate)
+        .where(eq(statusReportUpdate.statusReportId, report.id))
+        .orderBy(desc(statusReportUpdate.date), desc(statusReportUpdate.id))
+        .limit(1)
+        .get();
+
+      if (latest) {
+        await updateStatusReportUpdate({
+          ctx: { ...ctx, db: tx },
+          input: { id: latest.id, status: input.status },
+        });
+      } else {
+        updateValues.status = input.status;
+      }
+    }
 
     if (input.pageComponentIds !== undefined) {
       const validated = await validatePageComponentIds({


### PR DESCRIPTION
A message-only edit could reopen a report after a metadata edit set its status to resolved. The report now keeps that status because metadata status edits also change the latest existing update.

Metadata edits still add no public update and send no subscriber notifications. Reports without update history still accept status changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

