### PR TITLE
fix: order equal-date report updates by descending id

### DIFF
--- a/packages/services/src/status-report/__tests__/status-report.test.ts
+++ b/packages/services/src/status-report/__tests__/status-report.test.ts
@@ -4,9 +4,9 @@ import {
   pageComponent,
   pageSubscriber,
   statusReport,
+  statusReportsToPageComponents,
   statusReportUpdate,
   statusReportUpdateToPageComponents,
-  statusReportsToPageComponents,
 } from "@openstatus/db/src/schema";
 import { expect } from "@std/expect";
 import {
@@ -18,8 +18,8 @@ import {
 } from "@std/testing/bdd";
 
 import {
-  expectAuditRow,
   createWorkspaceFixture,
+  expectAuditRow,
   makeApiKeyCtx,
   makeSlackCtx,
   makeUserCtx,
@@ -535,6 +535,69 @@ describe("updateStatusReportUpdate", () => {
 });
 
 describe("listStatusReports / getStatusReport", () => {
+  test("returns equal-date updates by descending id after sorting by date", async () => {
+    await withTestTransaction(async (tx) => {
+      const ctx = { ...teamCtx, db: tx };
+      const date = new Date("2026-01-02T00:00:00Z");
+      const { statusReport: report, initialUpdate } = await createStatusReport({
+        ctx,
+        input: {
+          title: `${TEST_PREFIX}-equal-date`,
+          status: "investigating",
+          message: "investigating",
+          date,
+          pageId: testPageId,
+          pageComponentIds: [],
+        },
+      });
+      const { statusReportUpdate: resolved } = await addStatusReportUpdate({
+        ctx,
+        input: {
+          statusReportId: report.id,
+          status: "resolved",
+          message: "all clear",
+          date,
+        },
+      });
+      const { statusReportUpdate: older } = await addStatusReportUpdate({
+        ctx,
+        input: {
+          statusReportId: report.id,
+          status: "identified",
+          message: "backfilled update",
+          date: new Date("2026-01-01T00:00:00Z"),
+        },
+      });
+
+      const full = await getStatusReport({ ctx, input: { id: report.id } });
+      const { items } = await listStatusReports({
+        ctx,
+        input: {
+          limit: 100,
+          offset: 0,
+          statuses: [],
+          order: "desc",
+          pageId: testPageId,
+        },
+      });
+      for (const result of [
+        full,
+        items.find((item) => item.id === report.id),
+      ]) {
+        expect(result?.updates.map((update) => update.id)).toEqual([
+          resolved.id,
+          initialUpdate.id,
+          older.id,
+        ]);
+        expect(result?.status).toBe("resolved");
+        expect(result?.updates[0]).toMatchObject({
+          status: "resolved",
+          message: "all clear",
+        });
+      }
+    });
+  });
+
   test("respects workspace isolation", async () => {
     await withTestTransaction(async (tx) => {
       const teamCtxTx = { ...teamCtx, db: tx };

--- a/packages/services/src/status-report/internal.ts
+++ b/packages/services/src/status-report/internal.ts
@@ -1,11 +1,11 @@
 import { and, asc, desc, eq, inArray, notInArray } from "@openstatus/db";
 import {
-  type PageComponentImpact,
   pageComponent,
+  type PageComponentImpact,
   statusReport,
+  statusReportsToPageComponents,
   statusReportUpdate,
   statusReportUpdateToPageComponents,
-  statusReportsToPageComponents,
 } from "@openstatus/db/src/schema";
 
 import type { DB } from "../context";
@@ -181,7 +181,7 @@ export async function getUpdatesForReport(tx: DB, statusReportId: number) {
     .select()
     .from(statusReportUpdate)
     .where(eq(statusReportUpdate.statusReportId, statusReportId))
-    .orderBy(desc(statusReportUpdate.date))
+    .orderBy(desc(statusReportUpdate.date), desc(statusReportUpdate.id))
     .all();
 }
 

--- a/packages/services/src/status-report/list.ts
+++ b/packages/services/src/status-report/list.ts
@@ -1,5 +1,4 @@
 import {
-  type SQL,
   and,
   asc,
   db as defaultDb,
@@ -7,21 +6,22 @@ import {
   eq,
   gte,
   inArray,
+  type SQL,
   sql,
 } from "@openstatus/db";
 import {
-  type PageComponentImpact,
-  pageComponent,
   page as pageTable,
+  pageComponent,
+  type PageComponentImpact,
   selectPageComponentSchema,
   selectPageSchema,
   statusReport,
+  statusReportsToPageComponents,
   statusReportUpdate,
   statusReportUpdateToPageComponents,
-  statusReportsToPageComponents,
 } from "@openstatus/db/src/schema";
 
-import { type DB, type ServiceContext, batchReads } from "../context";
+import { batchReads, type DB, type ServiceContext } from "../context";
 import type {
   Page,
   PageComponent,
@@ -99,7 +99,7 @@ async function enrichReportsBatch(
       .select()
       .from(statusReportUpdate)
       .where(inArray(statusReportUpdate.statusReportId, reportIds))
-      .orderBy(desc(statusReportUpdate.date)),
+      .orderBy(desc(statusReportUpdate.date), desc(statusReportUpdate.id)),
     // Explicit column selection with aliases avoids depending on drizzle's
     // auto-derived `row.<object_name>` keys — those are named after the
     // exported JS variable, so a rename in the schema silently breaks the


### PR DESCRIPTION
When report updates share a date, report reads return the update with the highest ID first. This prevents `list_status_reports` from showing an earlier message and status after a resolving update with the same date. Updates with different dates keep their newest-first order.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

