### PR TITLE
fix(utils): send binary bodies in copied curl commands

### DIFF
--- a/packages/utils/src/curl.test.ts
+++ b/packages/utils/src/curl.test.ts
@@ -30,6 +30,34 @@ describe("buildCurlCommand", () => {
     expect(command).toContain(`--data-raw '{"a":1}'`);
   });
 
+  it("sends decoded binary POST bytes without shell or text conversion", async () => {
+    const server = Deno.serve(
+      { hostname: "127.0.0.1", port: 0 },
+      async (request) => new Response(await request.arrayBuffer()),
+    );
+    try {
+      const command = buildCurlCommand({
+        url: `http://127.0.0.1:${server.addr.port}/upload`,
+        method: "POST",
+        body: "data:application/octet-stream;base64,AP8nJFwNCgA=",
+        headers: [{ key: "Content-Type", value: "application/octet-stream" }],
+        timeout: 5000,
+      });
+      const result = await new Deno.Command("sh", {
+        args: ["-c", command],
+        env: { NO_PROXY: "*" },
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      expect(result.code).toBe(0);
+      expect(result.stdout).toEqual(
+        new Uint8Array([0, 255, 39, 36, 92, 13, 10, 0]),
+      );
+    } finally {
+      await server.shutdown();
+    }
+  });
+
   it("does not override a custom content type or user agent", () => {
     const command = buildCurlCommand({
       url: "https://example.com",

--- a/packages/utils/src/curl.test.ts
+++ b/packages/utils/src/curl.test.ts
@@ -36,23 +36,69 @@ describe("buildCurlCommand", () => {
       async (request) => new Response(await request.arrayBuffer()),
     );
     try {
-      const command = buildCurlCommand({
-        url: `http://127.0.0.1:${server.addr.port}/upload`,
-        method: "POST",
-        body: "data:application/octet-stream;base64,AP8nJFwNCgA=",
-        headers: [{ key: "Content-Type", value: "application/octet-stream" }],
-        timeout: 5000,
-      });
-      const result = await new Deno.Command("sh", {
-        args: ["-c", command],
-        env: { NO_PROXY: "*" },
-        stdout: "piped",
-        stderr: "piped",
-      }).output();
-      expect(result.code).toBe(0);
-      expect(result.stdout).toEqual(
-        new Uint8Array([0, 255, 39, 36, 92, 13, 10, 0]),
-      );
+      for (const { body, bytes } of [
+        {
+          body: "data:application/octet-stream;base64,AP8nJFwNCgA=",
+          bytes: [0, 255, 39, 36, 92, 13, 10, 0],
+        },
+        { body: "data:application/octet-stream;base64,", bytes: [] },
+        {
+          body: "data:application/octet-stream;base64,aGVs\r\nbG8=",
+          bytes: [104, 101, 108, 108, 111],
+        },
+      ]) {
+        const command = buildCurlCommand({
+          url: `http://127.0.0.1:${server.addr.port}/upload`,
+          method: "POST",
+          body,
+          headers: [{ key: "Content-Type", value: "application/octet-stream" }],
+          timeout: 5000,
+        });
+        const result = await new Deno.Command("sh", {
+          args: ["-c", command],
+          env: { NO_PROXY: "*" },
+          stdout: "piped",
+          stderr: "piped",
+        }).output();
+        expect(result.code).toBe(0);
+        expect(result.stdout).toEqual(new Uint8Array(bytes));
+      }
+    } finally {
+      await server.shutdown();
+    }
+  });
+
+  it("rejects malformed binary bodies before sending a request", async () => {
+    let requests = 0;
+    const server = Deno.serve({ hostname: "127.0.0.1", port: 0 }, () => {
+      requests++;
+      return new Response("received");
+    });
+    try {
+      for (const body of [
+        "",
+        "not a data URL",
+        "data:application/octet-stream;base64,aGVsbG8=,extra",
+        "data:application/octet-stream;base64,aGVsbG8=!",
+        "data:application/octet-stream;base64,aGVsbG8",
+        "data:application/octet-stream;base64,aGVsbG8=\u2028",
+      ]) {
+        const command = buildCurlCommand({
+          url: `http://127.0.0.1:${server.addr.port}/upload`,
+          method: "POST",
+          body,
+          headers: [{ key: "Content-Type", value: "application/octet-stream" }],
+          timeout: 5000,
+        });
+        const result = await new Deno.Command("sh", {
+          args: ["-c", command],
+          env: { NO_PROXY: "*" },
+          stdout: "piped",
+          stderr: "piped",
+        }).output();
+        expect(requests).toBe(0);
+        expect(result.code).not.toBe(0);
+      }
     } finally {
       await server.shutdown();
     }

--- a/packages/utils/src/curl.ts
+++ b/packages/utils/src/curl.ts
@@ -47,17 +47,30 @@ export function buildCurlCommand(request: CurlRequest): string {
   }
 
   let command = "curl";
-  if (body) {
+  if (
+    method === "POST" &&
+    headers.find((h) => h.key === "Content-Type")?.value ===
+      "application/octet-stream"
+  ) {
+    const parts = body.split(",");
+    const encoded = parts[1]?.replace(/[\r\n]/g, "");
     if (
-      method === "POST" &&
-      headers.find((h) => h.key === "Content-Type")?.value ===
-        "application/octet-stream"
+      parts.length !== 2 ||
+      encoded === undefined ||
+      !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?(?![\s\S])/.test(
+        encoded,
+      )
     ) {
-      command = `printf %s ${quote(body.split(",")[1] ?? "")} | base64 -d | curl`;
-      args.push("--data-binary @-");
-    } else {
-      args.push(`--data-raw ${quote(body)}`);
+      return "printf '%s\\n' 'Invalid base64 data URL body' >&2; false";
     }
+    const octal = atob(encoded).replace(
+      /./gs,
+      (byte) => `\\0${byte.charCodeAt(0).toString(8).padStart(3, "0")}`,
+    );
+    command = `printf %b ${quote(octal)} | curl`;
+    args.push("--data-binary @-");
+  } else if (body) {
+    args.push(`--data-raw ${quote(body)}`);
   }
   if (request.followRedirects) args.push("-L");
   if (request.timeout) args.push(`--max-time ${seconds(request.timeout)}`);

--- a/packages/utils/src/curl.ts
+++ b/packages/utils/src/curl.ts
@@ -46,9 +46,21 @@ export function buildCurlCommand(request: CurlRequest): string {
     args.push(`-H ${quote("Content-Type: application/json")}`);
   }
 
-  if (body) args.push(`--data-raw ${quote(body)}`);
+  let command = "curl";
+  if (body) {
+    if (
+      method === "POST" &&
+      headers.find((h) => h.key === "Content-Type")?.value ===
+        "application/octet-stream"
+    ) {
+      command = `printf %s ${quote(body.split(",")[1] ?? "")} | base64 -d | curl`;
+      args.push("--data-binary @-");
+    } else {
+      args.push(`--data-raw ${quote(body)}`);
+    }
+  }
   if (request.followRedirects) args.push("-L");
   if (request.timeout) args.push(`--max-time ${seconds(request.timeout)}`);
 
-  return ["curl", ...args].join(" \\\n  ");
+  return [command, ...args].join(" \\\n  ");
 }


### PR DESCRIPTION
Copied curl commands for binary POST monitors sent the stored data URL as text instead of the uploaded bytes. The commands now decode the base64 payload and send the bytes through curl's binary input to match the monitor request.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

