### PR TITLE
fix(header-analysis): report the last cache-status member

### DIFF
--- a/packages/header-analysis/src/cdn/normalize-cache-status.test.ts
+++ b/packages/header-analysis/src/cdn/normalize-cache-status.test.ts
@@ -47,6 +47,7 @@ describe("cloudfront / fastly / akamai (x-cache)", () => {
     ["RefreshHit from cloudfront", "EXPIRED"],
     ["HIT", "HIT"],
     ["MISS, HIT", "HIT"],
+    ["HIT, MISS", "HIT"],
     [
       "TCP_HIT from a23-45-67-89.deploy.akamaitechnologies.com (AkamaiGHost)",
       "HIT",
@@ -70,13 +71,31 @@ describe("rfc 9211 cache-status", () => {
     ["ExampleCache; fwd=miss; stored", "MISS"],
     ["ExampleCache; fwd=stale", "EXPIRED"],
     ["ExampleCache; fwd=bypass", "BYPASS"],
+    ["OriginCache; hit, EdgeCache; fwd=miss", "MISS"],
+    ["OriginCache; fwd=miss, EdgeCache; hit", "HIT"],
+    ["OriginCache; fwd=bypass, EdgeCache; fwd=stale", "EXPIRED"],
+    ['OriginCache; hit, "Edge, Cache"; fwd=miss', "MISS"],
+    ['OriginCache; hit, EdgeCache; fwd=miss; detail="a,b; hit"', "MISS"],
+    [
+      String.raw`OriginCache; hit, EdgeCache; fwd=miss; detail="a\",b; hit"`,
+      "MISS",
+    ],
+    [String.raw`OriginCache; detail="a\\"; hit, EdgeCache; fwd=miss`, "MISS"],
   ] as const) {
     test(`cache-status: ${raw} -> ${status}`, () => {
       const result = normalizeCacheStatus({ "Cache-Status": raw });
       expect(result.status).toBe(status);
       expect(result.source).toBe("cache-status");
+      expect(result.raw).toBe(raw);
     });
   }
+
+  test("does not use an upstream hit when the last cache has no status", () => {
+    expect(
+      normalizeCacheStatus({ "Cache-Status": "OriginCache; hit, EdgeCache" })
+        .status,
+    ).toBe("UNKNOWN");
+  });
 });
 
 describe("vendor header priority", () => {

--- a/packages/header-analysis/src/cdn/normalize-cache-status.ts
+++ b/packages/header-analysis/src/cdn/normalize-cache-status.ts
@@ -38,9 +38,11 @@ function fromToken(value: string): CacheStatus | null {
   return null;
 }
 
-// RFC 9211, e.g. `"Netlify Edge"; hit` or `ExampleCache; fwd=miss; stored`
+// RFC 9211 lists the cache closest to the user last.
 function fromCacheStatusHeader(value: string): CacheStatus | null {
-  const lower = value.toLowerCase();
+  // Quoted strings can contain commas and text that resembles parameters.
+  const unquoted = value.replace(/"(?:[^"\\]|\\.)*"/g, '""');
+  const lower = unquoted.slice(unquoted.lastIndexOf(",") + 1).toLowerCase();
   if (/;\s*hit/.test(lower)) return "HIT";
   const fwd = lower.match(/fwd=([a-z-]+)/)?.[1];
   if (!fwd) return null;


### PR DESCRIPTION
The CDN report no longer counts an upstream cache hit as an edge hit when the edge reports a miss. `Cache-Status` uses the last member, as RFC 9211 specifies, and ignores commas inside quoted strings. Other vendor headers keep their existing behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

