### PR TITLE
fix(opsgenie): close recovered alerts by alias

### DIFF
--- a/packages/notifications/opsgenie/src/index.test.ts
+++ b/packages/notifications/opsgenie/src/index.test.ts
@@ -1,9 +1,9 @@
 import { selectNotificationSchema } from "@openstatus/db/src/schema";
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, test } from "@std/testing/bdd";
-import { assertSpyCalls, stub, type Stub } from "@std/testing/mock";
+import { assertSpyCalls, type Stub, stub } from "@std/testing/mock";
 
-import { sendAlert, sendDegraded, sendTest } from "./index";
+import { sendAlert, sendDegraded, sendRecovery, sendTest } from "./index";
 
 describe("OpsGenie Notifications", () => {
   let fetchMock: Stub<typeof globalThis>;
@@ -132,6 +132,80 @@ describe("OpsGenie Notifications", () => {
     const body = JSON.parse(callArgs[1].body);
     expect(body.details.severity).toBe("degraded");
     expect(body.message).toBe("API Health Check is degraded");
+  });
+
+  for (const { region, message, url } of [
+    {
+      region: "us",
+      message: "Service recovered",
+      url: "https://api.opsgenie.com/v2/alerts/monitor-1/close?identifierType=alias",
+    },
+    {
+      region: "eu",
+      message: undefined,
+      url: "https://api.eu.opsgenie.com/v2/alerts/monitor-1/close?identifierType=alias",
+    },
+  ] as const) {
+    test(`Recovery closes the monitor alias in ${region}`, async () => {
+      fetchMock.restore();
+      fetchMock = stub(globalThis, "fetch", () =>
+        Promise.resolve(new Response(null, { status: 202 })),
+      );
+
+      await sendRecovery({
+        // @ts-expect-error
+        monitor: createMockMonitor(),
+        notification: selectNotificationSchema.parse(
+          createMockNotification(region),
+        ),
+        statusCode: 200,
+        message,
+        cronTimestamp: Date.now(),
+      });
+
+      assertSpyCalls(fetchMock, 1);
+      const [requestUrl, options] = fetchMock.calls[0].args;
+      expect(requestUrl).toBe(url);
+      expect(options.method).toBe("POST");
+      expect(options.headers["Content-Type"]).toBe("application/json");
+      expect(options.headers.Authorization).toBe("GenieKey test-api-key-123");
+      expect(JSON.parse(options.body)).toEqual({ source: "OpenStatus" });
+    });
+  }
+
+  test("Recovery rejects an unsuccessful close response", async () => {
+    fetchMock.restore();
+    fetchMock = stub(globalThis, "fetch", () =>
+      Promise.resolve(new Response(null, { status: 503 })),
+    );
+
+    await expect(
+      sendRecovery({
+        // @ts-expect-error
+        monitor: createMockMonitor(),
+        notification: selectNotificationSchema.parse(createMockNotification()),
+        message: "Service recovered",
+        cronTimestamp: Date.now(),
+      }),
+    ).rejects.toThrow("503");
+    assertSpyCalls(fetchMock, 1);
+  });
+
+  test("Recovery propagates a rejected close request", async () => {
+    const error = new Error("Connection reset");
+    fetchMock.restore();
+    fetchMock = stub(globalThis, "fetch", () => Promise.reject(error));
+
+    await expect(
+      sendRecovery({
+        // @ts-expect-error
+        monitor: createMockMonitor(),
+        notification: selectNotificationSchema.parse(createMockNotification()),
+        message: "Service recovered",
+        cronTimestamp: Date.now(),
+      }),
+    ).rejects.toBe(error);
+    assertSpyCalls(fetchMock, 1);
   });
 
   test("Handle fetch error gracefully", async () => {

--- a/packages/notifications/opsgenie/src/index.ts
+++ b/packages/notifications/opsgenie/src/index.ts
@@ -1,6 +1,10 @@
 import type { NotificationContext } from "@openstatus/notification-base";
 
-import { OpsGeniePayloadAlert, OpsGenieSchema } from "./schema";
+import {
+  OpsGenieCloseAlert,
+  OpsGeniePayloadAlert,
+  OpsGenieSchema,
+} from "./schema";
 
 export const sendAlert = async ({
   monitor,
@@ -84,37 +88,27 @@ export const sendDegraded = async ({
 export const sendRecovery = async ({
   monitor,
   notification,
-  statusCode,
-  message,
 }: NotificationContext) => {
   const { opsgenie } = OpsGenieSchema.parse(JSON.parse(notification.data));
 
   const url =
     opsgenie.region === "eu"
-      ? `https://api.eu.opsgenie.com/v2/alerts/${monitor.id}/close`
-      : `https://api.opsgenie.com/v2/alerts/${monitor.id}/close`;
+      ? `https://api.eu.opsgenie.com/v2/alerts/${monitor.id}/close?identifierType=alias`
+      : `https://api.opsgenie.com/v2/alerts/${monitor.id}/close?identifierType=alias`;
 
-  const event = OpsGeniePayloadAlert.parse({
-    alias: `${monitor.id}`,
-    message: `${monitor.name} has recovered`,
-    description: message,
-    details: {
-      message,
-      status: statusCode,
+  const event = OpsGenieCloseAlert.parse({});
+  const res = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(event),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `GenieKey ${opsgenie.apiKey}`,
     },
   });
-  try {
-    await fetch(url, {
-      method: "POST",
-      body: JSON.stringify(event),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `GenieKey ${opsgenie.apiKey}`,
-      },
-    });
-  } catch (err) {
-    console.log(err);
-    // Do something
+  if (!res.ok) {
+    throw new Error(
+      `Failed to close OpsGenie alert: ${res.status} ${res.statusText}`,
+    );
   }
 };
 export const sendTest = async (props: {


### PR DESCRIPTION
Opsgenie alerts stayed open after monitor recovery because local validation rejected every close request. Recovery sends a valid close request for the monitor alias.

HTTP and network errors also reach the existing retry handlers instead of a false success result.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

