### PR TITLE
fix(notifications): keep chat titles within provider limits

### DIFF
--- a/packages/notifications/discord/src/embeds.ts
+++ b/packages/notifications/discord/src/embeds.ts
@@ -63,7 +63,7 @@ export function buildAlertEmbed(data: FormattedMessageData): DiscordEmbed {
       : data.monitorUrl;
 
   return {
-    title: `${data.monitorName} is failing`,
+    title: buildTitle(data.monitorName, " is failing"),
     description: `\`${description}\``,
     color: COLOR_DECIMALS.red,
     fields: [
@@ -172,7 +172,7 @@ export function buildRecoveryEmbed(data: FormattedMessageData): DiscordEmbed {
   );
 
   return {
-    title: `${data.monitorName} is recovered`,
+    title: buildTitle(data.monitorName, " is recovered"),
     description: `\`${description}\``,
     color: COLOR_DECIMALS.green,
     fields,
@@ -255,7 +255,7 @@ export function buildDegradedEmbed(data: FormattedMessageData): DiscordEmbed {
   );
 
   return {
-    title: `${data.monitorName} is degraded`,
+    title: buildTitle(data.monitorName, " is degraded"),
     description: `\`${description}\``,
     color: COLOR_DECIMALS.yellow,
     fields,
@@ -265,4 +265,12 @@ export function buildDegradedEmbed(data: FormattedMessageData): DiscordEmbed {
     },
     url: data.dashboardUrl,
   };
+}
+
+function buildTitle(name: string, suffix: string): string {
+  const shortenedName = name
+    .slice(0, 256 - suffix.length)
+    // Keep surrogate pairs complete at the title limit.
+    .replace(/[\uD800-\uDBFF]$/, "");
+  return `${shortenedName}${suffix}`;
 }

--- a/packages/notifications/discord/src/index.test.ts
+++ b/packages/notifications/discord/src/index.test.ts
@@ -5,6 +5,11 @@ import { afterEach, beforeEach, describe, test } from "@std/testing/bdd";
 import { assertSpyCalls, type Stub, stub } from "@std/testing/mock";
 
 import {
+  buildAlertEmbed,
+  buildDegradedEmbed,
+  buildRecoveryEmbed,
+} from "./embeds";
+import {
   sendAlert,
   sendDegraded,
   sendRecovery,
@@ -165,4 +170,45 @@ describe("Discord Notifications", () => {
       }),
     ).rejects.toThrow();
   });
+});
+
+describe("Discord title limits", () => {
+  for (const [build, suffix] of [
+    [buildAlertEmbed, " is failing"],
+    [buildRecoveryEmbed, " is recovered"],
+    [buildDegradedEmbed, " is degraded"],
+  ] as const) {
+    test(`${build.name} keeps the status and complete characters within 256 characters`, () => {
+      for (const monitorName of [
+        "API Health",
+        "A".repeat(256 - suffix.length),
+        "A".repeat(255),
+        "\u{1F680}".repeat(127),
+        `A${"\u{1F680}".repeat(127)}`,
+      ]) {
+        const data = Object.freeze({
+          monitorName,
+          monitorUrl: "https://example.com/health",
+          monitorJobType: "http",
+          statusCodeFormatted: "503 Service Unavailable",
+          errorMessage: "Connection timeout",
+          timestampFormatted: "Sep 9, 2026 at 00:00 UTC",
+          regionsDisplay: "iad",
+          latencyDisplay: "100ms",
+          dashboardUrl: "https://app.openstatus.dev/monitors/1",
+        });
+        const title = build(data).title;
+        expect(title.length).toBeLessThanOrEqual(256);
+        expect(title.endsWith(suffix)).toBe(true);
+        const name = title.slice(0, -suffix.length);
+        expect(name.isWellFormed()).toBe(true);
+        expect(name.length).toBeGreaterThan(0);
+        expect(monitorName.startsWith(name)).toBe(true);
+        if (monitorName.length <= 256 - suffix.length) {
+          expect(name).toBe(monitorName);
+        }
+        expect(data.monitorName).toBe(monitorName);
+      }
+    });
+  }
 });

--- a/packages/notifications/slack/src/blocks.ts
+++ b/packages/notifications/slack/src/blocks.ts
@@ -91,7 +91,6 @@ export function escapeSlackText(text: string): string {
  * });
  */
 export function buildAlertBlocks(data: FormattedMessageData): SlackBlock[] {
-  const escapedName = escapeSlackText(data.monitorName);
   const escapedError = escapeSlackText(data.errorMessage);
 
   // Format description as "METHOD URL" or just "URL" for non-HTTP
@@ -105,7 +104,7 @@ export function buildAlertBlocks(data: FormattedMessageData): SlackBlock[] {
       type: "header",
       text: {
         type: "plain_text",
-        text: `${escapedName} is failing`,
+        text: buildTitle(data.monitorName, " is failing"),
         emoji: false,
       },
     },
@@ -195,8 +194,6 @@ export function buildAlertBlocks(data: FormattedMessageData): SlackBlock[] {
  * });
  */
 export function buildRecoveryBlocks(data: FormattedMessageData): SlackBlock[] {
-  const escapedName = escapeSlackText(data.monitorName);
-
   // Format description as "METHOD URL" or just "URL" for non-HTTP
   const description =
     data.monitorMethod && data.monitorJobType === "http"
@@ -208,7 +205,7 @@ export function buildRecoveryBlocks(data: FormattedMessageData): SlackBlock[] {
       type: "header",
       text: {
         type: "plain_text",
-        text: `${escapedName} is recovered`,
+        text: buildTitle(data.monitorName, " is recovered"),
         emoji: false,
       },
     },
@@ -307,8 +304,6 @@ export function buildRecoveryBlocks(data: FormattedMessageData): SlackBlock[] {
  * });
  */
 export function buildDegradedBlocks(data: FormattedMessageData): SlackBlock[] {
-  const escapedName = escapeSlackText(data.monitorName);
-
   // Format description as "METHOD URL" or just "URL" for non-HTTP
   const description =
     data.monitorMethod && data.monitorJobType === "http"
@@ -320,7 +315,7 @@ export function buildDegradedBlocks(data: FormattedMessageData): SlackBlock[] {
       type: "header",
       text: {
         type: "plain_text",
-        text: `${escapedName} is degraded`,
+        text: buildTitle(data.monitorName, " is degraded"),
         emoji: false,
       },
     },
@@ -387,4 +382,12 @@ export function buildDegradedBlocks(data: FormattedMessageData): SlackBlock[] {
   );
 
   return blocks;
+}
+
+function buildTitle(name: string, suffix: string): string {
+  const shortenedName = escapeSlackText(name)
+    .slice(0, 150 - suffix.length)
+    // Keep escape sequences and surrogate pairs complete at the title limit.
+    .replace(/&[^;]*$|[\uD800-\uDBFF]$/g, "");
+  return `${shortenedName}${suffix}`;
 }

--- a/packages/notifications/slack/src/index.test.ts
+++ b/packages/notifications/slack/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   buildAlertBlocks,
   buildDegradedBlocks,
   buildRecoveryBlocks,
+  escapeSlackText,
 } from "./blocks";
 import {
   sendAlert,
@@ -208,6 +209,8 @@ describe("Slack title limits", () => {
         "API Health",
         "A".repeat(150 - suffix.length),
         "A".repeat(255),
+        "A & <B>",
+        "&<>".repeat(20),
         "&<>".repeat(85),
         "\u{1F680}".repeat(127),
         `A${"\u{1F680}".repeat(127)}`,
@@ -237,7 +240,7 @@ describe("Slack title limits", () => {
           .replace(/&amp;/g, "&");
         expect(decoded.length).toBeGreaterThan(0);
         expect(monitorName.startsWith(decoded)).toBe(true);
-        if (monitorName.length <= 150 - suffix.length) {
+        if (escapeSlackText(monitorName).length <= 150 - suffix.length) {
           expect(decoded).toBe(monitorName);
         }
         expect(data.monitorName).toBe(monitorName);

--- a/packages/notifications/slack/src/index.test.ts
+++ b/packages/notifications/slack/src/index.test.ts
@@ -2,8 +2,13 @@ import { selectNotificationSchema } from "@openstatus/db/src/schema";
 import { COLORS } from "@openstatus/notification-base";
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, test } from "@std/testing/bdd";
-import { assertSpyCalls, stub, type Stub } from "@std/testing/mock";
+import { assertSpyCalls, type Stub, stub } from "@std/testing/mock";
 
+import {
+  buildAlertBlocks,
+  buildDegradedBlocks,
+  buildRecoveryBlocks,
+} from "./blocks";
 import {
   sendAlert,
   sendDegraded,
@@ -190,4 +195,53 @@ describe("Slack Notifications", () => {
 
     assertSpyCalls(fetchMock, 1);
   });
+});
+
+describe("Slack title limits", () => {
+  for (const [build, suffix] of [
+    [buildAlertBlocks, " is failing"],
+    [buildRecoveryBlocks, " is recovered"],
+    [buildDegradedBlocks, " is degraded"],
+  ] as const) {
+    test(`${build.name} keeps the status and complete characters within 150 characters`, () => {
+      for (const monitorName of [
+        "API Health",
+        "A".repeat(150 - suffix.length),
+        "A".repeat(255),
+        "&<>".repeat(85),
+        "\u{1F680}".repeat(127),
+        `A${"\u{1F680}".repeat(127)}`,
+      ]) {
+        const data = Object.freeze({
+          monitorName,
+          monitorUrl: "https://example.com/health",
+          monitorJobType: "http",
+          statusCodeFormatted: "503 Service Unavailable",
+          errorMessage: "Connection timeout",
+          timestampFormatted: "Sep 9, 2026 at 00:00 UTC",
+          regionsDisplay: "iad",
+          latencyDisplay: "100ms",
+          dashboardUrl: "https://app.openstatus.dev/monitors/1",
+        });
+        const header = build(data).find((block) => block.type === "header");
+        if (header?.type !== "header") throw new Error("Missing Slack header");
+        const title = header.text.text;
+        expect(title.length).toBeLessThanOrEqual(150);
+        expect(title.endsWith(suffix)).toBe(true);
+        const name = title.slice(0, -suffix.length);
+        expect(name).not.toMatch(/&(?!amp;|lt;|gt;)/);
+        expect(name.isWellFormed()).toBe(true);
+        const decoded = name
+          .replace(/&lt;/g, "<")
+          .replace(/&gt;/g, ">")
+          .replace(/&amp;/g, "&");
+        expect(decoded.length).toBeGreaterThan(0);
+        expect(monitorName.startsWith(decoded)).toBe(true);
+        if (monitorName.length <= 150 - suffix.length) {
+          expect(decoded).toBe(monitorName);
+        }
+        expect(data.monitorName).toBe(monitorName);
+      }
+    });
+  }
 });


### PR DESCRIPTION
Valid 255-character monitor names could produce Slack and Discord notification titles longer than the provider limits. Titles now stay within those limits and keep the full status text. The shared monitor name stays unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

