### PR TITLE
fix: external status provider switches

### DIFF
--- a/apps/workflows/src/cron/external-status-detect.test.ts
+++ b/apps/workflows/src/cron/external-status-detect.test.ts
@@ -6,6 +6,7 @@ import {
   PROBE_TTL_MS,
   clearProbeStamp,
   decideDetectionAction,
+  isBlocked,
   isSuspicious,
   shouldProbe,
 } from "./external-status-detect";
@@ -13,7 +14,7 @@ import {
 const URL = "https://status.example.com";
 
 const fetchError = (init: {
-  kind?: "http" | "parse" | "network" | "timeout";
+  kind?: "http" | "parse" | "schema" | "network" | "timeout";
   httpStatus?: number;
 }) => new FetchError({ url: URL, ...init });
 
@@ -43,10 +44,22 @@ describe("shouldProbe", () => {
 });
 
 describe("isSuspicious", () => {
-  test("parse and 4xx are suspicious", () => {
+  test("parse, schema and 4xx are suspicious", () => {
     expect(isSuspicious(fetchError({ kind: "parse" }))).toBe(true);
+    expect(isSuspicious(fetchError({ kind: "schema" }))).toBe(true);
     expect(isSuspicious(fetchError({ kind: "http", httpStatus: 404 }))).toBe(
       true,
+    );
+  });
+
+  test("bot challenges and rate limits are blocked, not suspicious", () => {
+    for (const httpStatus of [401, 403, 429]) {
+      const err = fetchError({ kind: "http", httpStatus });
+      expect(isBlocked(err)).toBe(true);
+      expect(isSuspicious(err)).toBe(false);
+    }
+    expect(isBlocked(fetchError({ kind: "http", httpStatus: 404 }))).toBe(
+      false,
     );
   });
 
@@ -107,6 +120,31 @@ describe("decideDetectionAction", () => {
     expect(action).toMatchObject({
       kind: "suggest",
       suggestion: "atlassian-statuspage|incidentio",
+    });
+  });
+
+  test("suggests the new base when the page moved", () => {
+    const action = decideDetectionAction(
+      result({
+        movedTo: {
+          base: "https://example.status.atlassian.com",
+          matches: [
+            {
+              type: "atlassian",
+              provider: "atlassian-statuspage",
+              endpoint:
+                "https://example.status.atlassian.com/api/v2/summary.json",
+            },
+          ],
+        },
+        hostnameSuggestions: ["uptime-robot"],
+      }),
+      row(null),
+    );
+    expect(action).toMatchObject({
+      kind: "suggest",
+      suggestion:
+        "atlassian-statuspage at https://example.status.atlassian.com",
     });
   });
 

--- a/apps/workflows/src/cron/external-status-detect.ts
+++ b/apps/workflows/src/cron/external-status-detect.ts
@@ -29,10 +29,25 @@ export function clearProbeStamp(
   map.delete(slug);
 }
 
-export function isSuspicious(err: FetchError): boolean {
-  if (err.kind === "parse") return true;
+const BLOCKED_STATUSES = new Set([401, 403, 429]);
+
+// Bot challenges and rate limits say nothing about the provider; probing them
+// daily only adds noise.
+export function isBlocked(err: FetchError): boolean {
   return (
-    err.kind === "http" && err.httpStatus !== undefined && err.httpStatus < 500
+    err.kind === "http" &&
+    err.httpStatus !== undefined &&
+    BLOCKED_STATUSES.has(err.httpStatus)
+  );
+}
+
+export function isSuspicious(err: FetchError): boolean {
+  if (err.kind === "parse" || err.kind === "schema") return true;
+  return (
+    err.kind === "http" &&
+    err.httpStatus !== undefined &&
+    err.httpStatus < 500 &&
+    !isBlocked(err)
   );
 }
 
@@ -63,6 +78,18 @@ export function decideDetectionAction(
         .map((m) => m.provider)
         .sort()
         .join("|"),
+      evidence,
+    };
+  }
+  // A move needs a status_page_url edit, which stays manual.
+  if (result.movedTo) {
+    const providers = result.movedTo.matches
+      .map((m) => m.provider)
+      .sort()
+      .join("|");
+    return {
+      kind: "suggest",
+      suggestion: `${providers} at ${result.movedTo.base}`,
       evidence,
     };
   }

--- a/apps/workflows/src/cron/external-status.ts
+++ b/apps/workflows/src/cron/external-status.ts
@@ -38,6 +38,7 @@ import {
 import {
   clearProbeStamp,
   decideDetectionAction,
+  isBlocked,
   isSuspicious,
   shouldProbe,
 } from "./external-status-detect";
@@ -243,6 +244,7 @@ function runIncidentPhase(
               phase: "incidents",
               slug: entry.id,
               error: err,
+              level: isBlocked(err) ? "warning" : undefined,
             });
             return { kind: "fail", slug: entry.id, reason: err.message };
           }),
@@ -313,6 +315,7 @@ function runComponentPhase(
               phase: "components",
               slug: entry.id,
               error: err,
+              level: isBlocked(err) ? "warning" : undefined,
             });
             return { kind: "fail", slug: entry.id, reason: err.message };
           }),
@@ -479,6 +482,7 @@ function collectDetectItems(
         phase: "status",
         slug: outcome.slug,
         error: outcome.error,
+        level: isBlocked(outcome.error) ? "warning" : undefined,
       });
     }
   });
@@ -595,11 +599,16 @@ function detectAndAct(
         case "noop":
           return Effect.sync((): DetectOutcome => {
             if (action.reason === "no-evidence") {
+              // Valid JSON our schema rejects means our schema is stale, not
+              // that the page moved.
               reportDetectionStory({
                 slug: entry.id,
                 currentProvider: row.provider,
                 fetchError: error,
-                outcome: { kind: "none" },
+                outcome:
+                  error?.kind === "schema"
+                    ? { kind: "schema-mismatch" }
+                    : { kind: "none" },
                 evidence: action.evidence,
               });
               return { kind: "none", slug: entry.id };

--- a/apps/workflows/src/lib/sentry.ts
+++ b/apps/workflows/src/lib/sentry.ts
@@ -1,5 +1,6 @@
 import { FetchError } from "@openstatus/status-fetcher";
 import * as Sentry from "@sentry/deno";
+import type { SeverityLevel } from "@sentry/deno";
 
 import { env } from "../env";
 
@@ -38,11 +39,13 @@ export type DetectionOutcome =
   | { kind: "applied"; provider: string }
   | { kind: "config-cleared" }
   | { kind: "suggest"; suggestion: string }
+  | { kind: "schema-mismatch" }
   | { kind: "none" };
 
 // One event tells the whole story of a probed tick: the fetch failure plus
 // what detection concluded. Fingerprinted per (slug, outcome) so repeats
-// collapse into a single issue.
+// collapse into a single issue; a schema mismatch is our bug, so it groups
+// per provider instead.
 export function reportDetectionStory(args: {
   slug: string;
   currentProvider: string;
@@ -55,33 +58,43 @@ export function reportDetectionStory(args: {
     switch (outcome.kind) {
       case "applied":
         return {
-          key: `applied:${outcome.provider}`,
+          fingerprint: [
+            "external-status-detect",
+            slug,
+            `applied:${outcome.provider}`,
+          ],
           level: "info" as const,
           message: `provider auto-updated ${currentProvider} → ${outcome.provider}`,
         };
       case "config-cleared":
         return {
-          key: "config-cleared",
+          fingerprint: ["external-status-detect", slug, "config-cleared"],
           level: "info" as const,
           message: `stale api_config cleared (provider ${currentProvider})`,
         };
       case "suggest":
         return {
-          key: outcome.suggestion,
+          fingerprint: ["external-status-detect", slug, outcome.suggestion],
           level: "warning" as const,
           message: `provider suggestion: ${outcome.suggestion} (currently ${currentProvider})`,
         };
+      case "schema-mismatch":
+        return {
+          fingerprint: ["external-status-detect", "schema", currentProvider],
+          level: "error" as const,
+          message: `JSON did not match the ${currentProvider} schema`,
+        };
       case "none":
         return {
-          key: "none",
-          level: "error" as const,
+          fingerprint: ["external-status-detect", slug, "none"],
+          level: "warning" as const,
           message: `failing, no provider detected (currently ${currentProvider})`,
         };
     }
   })();
   Sentry.captureMessage(`external-status: ${slug} ${story.message}`, {
     level: story.level,
-    fingerprint: ["external-status-detect", slug, story.key],
+    fingerprint: story.fingerprint,
     tags: {
       cron: "external-status",
       phase: "detect",
@@ -112,9 +125,18 @@ export function reportFetchFailure(args: {
   phase: "status" | "incidents" | "components";
   slug: string;
   error: FetchError;
+  level?: SeverityLevel;
 }): void {
-  const { phase, slug, error } = args;
+  const { phase, slug, error, level } = args;
   Sentry.captureException(error, {
+    level,
+    fingerprint: [
+      "external-status-fetch",
+      slug,
+      phase,
+      error.kind ?? "unknown",
+      String(error.httpStatus ?? ""),
+    ],
     tags: {
       cron: "external-status",
       phase,

--- a/packages/status-fetcher/README.md
+++ b/packages/status-fetcher/README.md
@@ -105,13 +105,19 @@ class FetchError extends Error {
   readonly fetcherName?: string;
   readonly entryId?: string;
   readonly httpStatus?: number;
+  readonly kind?: "http" | "parse" | "schema" | "network" | "timeout";
   // `.cause: unknown` (inherited from Error)
 }
 ```
 
-The computed `.message` is `[<fetcherName> (<entryId>)] HTTP <status>: <url>`
-or `[<fetcherName> (<entryId>)] fetch failed: <url>` when no HTTP status is
-available.
+`kind` classifies the failure: `http` (non-2xx), `parse` (body is not JSON),
+`schema` (JSON that the fetcher's zod schema rejects), `network` (fetch threw)
+or `timeout`.
+
+The computed `.message` is `[<fetcherName> (<entryId>)] <label>: <url>` where
+`<label>` is `HTTP <status>` when a status is available, otherwise
+`non-JSON body`, `schema mismatch`, `network error` or `timeout` by `kind`,
+and `fetch failed` when neither is set.
 
 ## Retry & timeout
 

--- a/packages/status-fetcher/__tests__/detect.test.ts
+++ b/packages/status-fetcher/__tests__/detect.test.ts
@@ -245,6 +245,27 @@ describe("detectProvider", () => {
     expect(fetchMock.calls.length).toBe(7);
   });
 
+  it("probes the new origin root when the redirect lands on a subpath", async () => {
+    const MOVED = "https://example.status.atlassian.com";
+    installMockFetch((url) => {
+      const { origin, pathname } = new URL(url);
+      if (origin === MOVED && pathname === "/api/v2/summary.json") {
+        return Promise.resolve(json(atlassianBody));
+      }
+      if (origin === PAGE_URL && pathname === "/") {
+        return Promise.resolve(html("<html>moved</html>", `${MOVED}/en/`));
+      }
+      return Promise.resolve(notFound());
+    });
+    const result = await Effect.runPromise(
+      detectProvider({ statusPageUrl: PAGE_URL, currentProvider: "unknown" }),
+    );
+    expect(result.movedTo?.base).toBe(MOVED);
+    expect(result.movedTo?.matches.map((m) => m.provider)).toEqual([
+      "atlassian-statuspage",
+    ]);
+  });
+
   it("does not re-probe when the redirect stays on the same origin", async () => {
     const fetchMock = route({
       "/": () => html("<html>page</html>", `${PAGE_URL}/en/`),

--- a/packages/status-fetcher/__tests__/detect.test.ts
+++ b/packages/status-fetcher/__tests__/detect.test.ts
@@ -47,14 +47,7 @@ const atlassianBody = {
 };
 
 const instatusBody = {
-  activeIncidents: [],
-  activeMaintenances: [],
-  status: { text: "All systems operational", type: "UP" },
-  page: {
-    name: "Example",
-    url: "https://status.example.com",
-    updated: "2024-01-01T00:00:00Z",
-  },
+  page: { name: "Example", url: "https://status.example.com", status: "UP" },
 };
 
 const route = (routes: Record<string, () => Response>) =>
@@ -218,6 +211,64 @@ describe("detectProvider", () => {
     expect(result.evidence).toContain(
       "final url https://stats.uptimerobot.com/xyz",
     );
+  });
+
+  it("reports a move when the page redirects to an origin whose probes validate", async () => {
+    const MOVED = "https://example.status.atlassian.com";
+    const fetchMock = installMockFetch((url) => {
+      const { origin, pathname } = new URL(url);
+      if (origin === MOVED && pathname === "/api/v2/summary.json") {
+        return Promise.resolve(json(atlassianBody));
+      }
+      if (origin === PAGE_URL && pathname === "/") {
+        return Promise.resolve(html("<html>moved</html>", `${MOVED}/`));
+      }
+      return Promise.resolve(notFound());
+    });
+    const result = await Effect.runPromise(
+      detectProvider({
+        statusPageUrl: PAGE_URL,
+        currentProvider: "atlassian-statuspage",
+      }),
+    );
+    expect(result.currentProviderValidated).toBe(false);
+    expect(result.matches).toEqual([]);
+    expect(result.movedTo?.base).toBe(MOVED);
+    expect(result.movedTo?.matches.map((m) => m.provider)).toEqual([
+      "atlassian-statuspage",
+    ]);
+    expect(result.evidence).toContain(`final url ${MOVED}/`);
+    expect(result.evidence).toContain(
+      "hostname tiebreak: atlassian-statuspage",
+    );
+    // 3 probes at the old base, the html fetch, 3 probes at the new base
+    expect(fetchMock.calls.length).toBe(7);
+  });
+
+  it("does not re-probe when the redirect stays on the same origin", async () => {
+    const fetchMock = route({
+      "/": () => html("<html>page</html>", `${PAGE_URL}/en/`),
+    });
+    const result = await Effect.runPromise(
+      detectProvider({ statusPageUrl: PAGE_URL, currentProvider: "unknown" }),
+    );
+    expect(result.movedTo).toBeUndefined();
+    expect(fetchMock.calls.length).toBe(4);
+  });
+
+  it("suggests instatus from an html marker when nothing validates", async () => {
+    route({
+      "/": () => html('<img src="https://instatus.com/user-content/logo.png">'),
+    });
+    const result = await Effect.runPromise(
+      detectProvider({
+        statusPageUrl: PAGE_URL,
+        currentProvider: "uptime-robot",
+      }),
+    );
+    expect(result.matches).toEqual([]);
+    expect(result.hostnameSuggestions).toEqual(["instatus"]);
+    expect(result.evidence).toContain("html marker: instatus.com");
   });
 
   it("never suggests the current provider from hostname evidence", async () => {

--- a/packages/status-fetcher/__tests__/fetch.test.ts
+++ b/packages/status-fetcher/__tests__/fetch.test.ts
@@ -126,7 +126,8 @@ describe("fetchJson", () => {
     );
     const err = expectFailure(exit);
     expect(err.cause).toBeInstanceOf(Error);
-    expect(err.kind).toBe("parse");
+    expect(err.kind).toBe("schema");
+    expect(err.message).toBe(`[FetchError] schema mismatch: ${TEST_URL}`);
     expect(fetchMock.calls.length).toBe(1);
   });
 

--- a/packages/status-fetcher/__tests__/fetchers/atlassian.test.ts
+++ b/packages/status-fetcher/__tests__/fetchers/atlassian.test.ts
@@ -391,3 +391,41 @@ describe("AtlassianFetcher", () => {
     });
   });
 });
+
+describe("AtlassianFetcher maintenance indicator", () => {
+  it("maps the maintenance indicator to severity none and under_maintenance", async () => {
+    const fetcher = new AtlassianFetcher();
+    const entry: StatusPageEntry = {
+      id: "test",
+      name: "Test",
+      url: "https://test.com",
+      status_page_url: "https://test.statuspage.io",
+      provider: "atlassian-statuspage",
+      industry: ["saas"],
+    };
+    installMockFetch(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({
+          page: {
+            id: "123",
+            name: "Test",
+            url: "https://test.statuspage.io",
+            timezone: "Europe/Berlin",
+            updated_at: "2026-09-10T13:01:07.723+02:00",
+          },
+          status: {
+            indicator: "maintenance",
+            description: "Service Under Maintenance",
+          },
+        }),
+      } as Response),
+    );
+
+    const result = await runFetcher(fetcher, entry);
+
+    expect(result.severity).toBe("none");
+    expect(result.status).toBe("under_maintenance");
+    expect(result.description).toBe("Service Under Maintenance");
+  });
+});

--- a/packages/status-fetcher/__tests__/fetchers/edge-cases.test.ts
+++ b/packages/status-fetcher/__tests__/fetchers/edge-cases.test.ts
@@ -186,16 +186,10 @@ describe("Fetcher Edge Cases", () => {
       };
 
       const mockResponse = {
-        activeIncidents: [],
-        activeMaintenances: [],
-        status: {
-          text: "Unknown",
-          type: "UNKNOWN",
-        },
         page: {
           name: "Test",
           url: "https://test.instatus.com",
-          updated: "2024-02-16T12:00:00.000Z",
+          status: "UNKNOWN",
         },
       };
 

--- a/packages/status-fetcher/__tests__/fetchers/instatus.test.ts
+++ b/packages/status-fetcher/__tests__/fetchers/instatus.test.ts
@@ -151,7 +151,7 @@ describe("InstatusFetcher", () => {
       expect(result.updated_at).toBe(Date.parse("2024-02-16T13:00:00.000Z"));
     });
 
-    it("should map HASISSUES without impact to degraded", async () => {
+    it("should map HASISSUES without impact to minor/degraded", async () => {
       mockJson({
         page: {
           name: "Test",
@@ -163,9 +163,31 @@ describe("InstatusFetcher", () => {
 
       const result = await runFetcher(fetcher, entry);
 
-      expect(result.severity).toBe("major");
+      expect(result.severity).toBe("minor");
       expect(result.status).toBe("degraded");
       expect(result.description).toBe("Something");
+    });
+
+    it("should ignore scheduled maintenance when deriving updated_at", async () => {
+      const before = Date.now();
+      mockJson({
+        page: { name: "Test", url: "https://test.instatus.com", status: "UP" },
+        activeMaintenances: [
+          {
+            name: "Upcoming DB upgrade",
+            start: "2999-01-01T00:00:00.000Z",
+            status: "NOTSTARTEDYET",
+            duration: "120",
+            url: "https://test.instatus.com/m",
+          },
+        ],
+      });
+
+      const result = await runFetcher(fetcher, entry);
+
+      expect(result.status).toBe("operational");
+      expect(result.updated_at).toBeGreaterThanOrEqual(before);
+      expect(result.updated_at).toBeLessThanOrEqual(Date.now());
     });
 
     it("should map UNDERMAINTENANCE to under_maintenance", async () => {

--- a/packages/status-fetcher/__tests__/fetchers/instatus.test.ts
+++ b/packages/status-fetcher/__tests__/fetchers/instatus.test.ts
@@ -73,40 +73,36 @@ describe("InstatusFetcher", () => {
   });
 
   describe("fetch", () => {
-    it("should fetch and parse UP status", async () => {
-      const entry: StatusPageEntry = {
-        id: "test",
-        name: "Test Service",
-        url: "https://test.com",
-        status_page_url: "https://test.instatus.com",
-        provider: "instatus",
-        industry: ["saas"],
-      };
+    const entry: StatusPageEntry = {
+      id: "test",
+      name: "Test Service",
+      url: "https://test.com",
+      status_page_url: "https://test.instatus.com",
+      provider: "instatus",
+      industry: ["saas"],
+    };
 
-      const mockResponse = {
-        activeIncidents: [],
-        activeMaintenances: [],
-        status: {
-          text: "All Systems Operational",
-          type: "UP",
-        },
+    const mockJson = (body: unknown) =>
+      installMockFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: async () => body,
+        } as Response),
+      );
+
+    it("should fetch and parse UP status (arrays omitted when empty)", async () => {
+      const fetchMock = mockJson({
         page: {
           name: "Test Service",
           url: "https://test.instatus.com",
-          updated: "2024-02-16T12:00:00.000Z",
+          status: "UP",
         },
-      };
-
-      const fetchMock = installMockFetch(() =>
-        Promise.resolve({
-          ok: true,
-          json: async () => mockResponse,
-        } as Response),
-      );
+      });
 
       const result = await runFetcher(fetcher, entry);
 
       expect(result.severity).toBe("none");
+      expect(result.status).toBe("operational");
       expect(result.description).toBe("All Systems Operational");
       expect(result.timezone).toBe("UTC");
       expect(typeof result.updated_at).toBe("number");
@@ -121,116 +117,95 @@ describe("InstatusFetcher", () => {
       );
     });
 
-    it("should map HASISSUES to major indicator", async () => {
-      const entry: StatusPageEntry = {
-        id: "test",
-        name: "Test",
-        url: "https://test.com",
-        status_page_url: "https://test.instatus.com",
-        provider: "instatus",
-        industry: ["saas"],
-      };
-
-      const mockResponse = {
-        activeIncidents: [{ id: 1, name: "API Errors" }],
-        activeMaintenances: [],
-        status: {
-          text: "Service Degraded",
-          type: "HASISSUES",
-        },
+    it("should map HASISSUES to the worst active incident impact", async () => {
+      mockJson({
         page: {
           name: "Test",
           url: "https://test.instatus.com",
-          updated: "2024-02-16T12:00:00.000Z",
+          status: "HASISSUES",
         },
-      };
-
-      installMockFetch(() =>
-        Promise.resolve({
-          ok: true,
-          json: async () => mockResponse,
-        } as Response),
-      );
+        activeIncidents: [
+          {
+            name: "API Errors",
+            started: "2024-02-16T12:00:00.000Z",
+            status: "INVESTIGATING",
+            impact: "DEGRADEDPERFORMANCE",
+            url: "https://test.instatus.com/abc",
+          },
+          {
+            name: "Dashboard Down",
+            started: "2024-02-16T13:00:00.000Z",
+            status: "IDENTIFIED",
+            impact: "PARTIALOUTAGE",
+            url: "https://test.instatus.com/def",
+          },
+        ],
+        activeMaintenances: [],
+      });
 
       const result = await runFetcher(fetcher, entry);
 
       expect(result.severity).toBe("major");
-      expect(result.description).toBe("Service Degraded");
+      expect(result.status).toBe("partial_outage");
+      expect(result.description).toBe("API Errors, Dashboard Down");
+      expect(result.updated_at).toBe(Date.parse("2024-02-16T13:00:00.000Z"));
     });
 
-    it("should map UNDERMAINTENANCE to minor indicator", async () => {
-      const entry: StatusPageEntry = {
-        id: "test",
-        name: "Test",
-        url: "https://test.com",
-        status_page_url: "https://test.instatus.com",
-        provider: "instatus",
-        industry: ["saas"],
-      };
-
-      const mockResponse = {
-        activeIncidents: [],
-        activeMaintenances: [{ id: 1, name: "Scheduled Maintenance" }],
-        status: {
-          text: "Under Maintenance",
-          type: "UNDERMAINTENANCE",
-        },
+    it("should map HASISSUES without impact to degraded", async () => {
+      mockJson({
         page: {
           name: "Test",
           url: "https://test.instatus.com",
-          updated: "2024-02-16T12:00:00.000Z",
+          status: "HASISSUES",
         },
-      };
+        activeIncidents: [{ name: "Something" }],
+      });
 
-      installMockFetch(() =>
-        Promise.resolve({
-          ok: true,
-          json: async () => mockResponse,
-        } as Response),
-      );
+      const result = await runFetcher(fetcher, entry);
+
+      expect(result.severity).toBe("major");
+      expect(result.status).toBe("degraded");
+      expect(result.description).toBe("Something");
+    });
+
+    it("should map UNDERMAINTENANCE to under_maintenance", async () => {
+      mockJson({
+        page: {
+          name: "Test",
+          url: "https://test.instatus.com",
+          status: "UNDERMAINTENANCE",
+        },
+        activeIncidents: [],
+        activeMaintenances: [
+          {
+            name: "Scheduled Maintenance",
+            start: "2024-02-16T12:00:00.000Z",
+            status: "INPROGRESS",
+            duration: "60",
+            url: "https://test.instatus.com/m",
+          },
+        ],
+      });
 
       const result = await runFetcher(fetcher, entry);
 
       expect(result.severity).toBe("none");
-      expect(result.description).toBe("Under Maintenance");
+      expect(result.status).toBe("under_maintenance");
+      expect(result.description).toBe("Scheduled Maintenance");
     });
 
     it("should use custom endpoint if provided", async () => {
-      const entry: StatusPageEntry = {
-        id: "test",
-        name: "Test",
-        url: "https://test.com",
-        status_page_url: "https://test.instatus.com",
-        provider: "instatus",
-        industry: ["saas"],
+      const fetchMock = mockJson({
+        page: { name: "Test", url: "https://test.instatus.com", status: "UP" },
+      });
+
+      await runFetcher(fetcher, {
+        ...entry,
         api_config: {
           type: "instatus",
           endpoint: "https://custom.endpoint.com/status.json",
         },
-      };
-
-      const mockResponse = {
-        activeIncidents: [],
-        activeMaintenances: [],
-        status: {
-          text: "Operational",
-          type: "UP",
-        },
-        page: {
-          name: "Test",
-          url: "https://test.instatus.com",
-          updated: "2024-02-16T12:00:00.000Z",
-        },
-      };
-
-      const fetchMock = installMockFetch(() =>
-        Promise.resolve({
-          ok: true,
-          json: async () => mockResponse,
-        } as Response),
-      );
-
-      await runFetcher(fetcher, entry);
+      });
 
       const call = fetchMock.calls[fetchMock.calls.length - 1];
       expect(call.args[0]).toBe("https://custom.endpoint.com/status.json");
@@ -238,15 +213,6 @@ describe("InstatusFetcher", () => {
     });
 
     it("should fail with FetchError on non-200 response (after retries)", async () => {
-      const entry: StatusPageEntry = {
-        id: "test",
-        name: "Test",
-        url: "https://test.com",
-        status_page_url: "https://test.instatus.com",
-        provider: "instatus",
-        industry: ["saas"],
-      };
-
       installMockFetch(() =>
         Promise.resolve({
           ok: false,
@@ -261,24 +227,11 @@ describe("InstatusFetcher", () => {
     });
 
     it("should fail with FetchError on invalid JSON schema", async () => {
-      const entry: StatusPageEntry = {
-        id: "test",
-        name: "Test",
-        url: "https://test.com",
-        status_page_url: "https://test.instatus.com",
-        provider: "instatus",
-        industry: ["saas"],
-      };
-
-      installMockFetch(() =>
-        Promise.resolve({
-          ok: true,
-          json: async () => ({ invalid: "data" }),
-        } as Response),
-      );
+      mockJson({ invalid: "data" });
 
       const exit = await runFetcherExit(fetcher, entry);
       const err = expectFetchError(exit);
+      expect(err.kind).toBe("schema");
       expect(err.cause).toBeInstanceOf(Error);
     });
   });

--- a/packages/status-fetcher/__tests__/integration.test.ts
+++ b/packages/status-fetcher/__tests__/integration.test.ts
@@ -225,13 +225,10 @@ describe("Integration Tests", () => {
         {
           fetcher: "instatus",
           mockResponse: {
-            activeIncidents: [],
-            activeMaintenances: [],
-            status: { text: "All Good", type: "UP" },
             page: {
               name: "Test",
               url: "https://test.instatus.com",
-              updated: "2024-02-16T12:00:00.000Z",
+              status: "UP",
             },
           },
         },

--- a/packages/status-fetcher/src/detect.ts
+++ b/packages/status-fetcher/src/detect.ts
@@ -23,6 +23,9 @@ export type DetectionResult = {
   currentProviderValidated: boolean;
   matches: ProviderMatch[];
   hostnameSuggestions: StatusPageProvider[];
+  // Set when the page redirects to another origin whose probes validate: the
+  // stored status_page_url is stale, not (necessarily) the provider.
+  movedTo?: { base: string; matches: ProviderMatch[] };
   evidence: string[];
 };
 
@@ -75,8 +78,11 @@ const PROBES: Probe[] = [
   },
 ];
 
-const HOSTNAME_EVIDENCE: { domain: string; provider: StatusPageProvider }[] = [
+type HostnameHit = { domain: string; provider: StatusPageProvider };
+
+const HOSTNAME_EVIDENCE: HostnameHit[] = [
   { domain: "statuspage.io", provider: "atlassian-statuspage" },
+  { domain: "status.atlassian.com", provider: "atlassian-statuspage" },
   { domain: "incident.io", provider: "incidentio" },
   { domain: "incidentio.com", provider: "incidentio" },
   { domain: "instatus.com", provider: "instatus" },
@@ -88,13 +94,20 @@ const HOSTNAME_EVIDENCE: { domain: string; provider: StatusPageProvider }[] = [
 const HTML_MARKERS: { provider: StatusPageProvider; needle: string }[] = [
   { provider: "incidentio", needle: "incident.io" },
   { provider: "atlassian-statuspage", needle: "statuspage.io" },
+  { provider: "instatus", needle: "instatus.com" },
+  { provider: "better-uptime", needle: "betteruptime.com" },
 ];
 
 const describeError = (err: FetchError): string =>
   `${err.kind ?? "error"}${err.httpStatus ? ` ${err.httpStatus}` : ""}`;
 
-const hostnameHits = (url: string) =>
+const hostnameHits = (url: string): HostnameHit[] =>
   HOSTNAME_EVIDENCE.filter((h) => urlHostnameEndsWith(url, h.domain));
+
+const htmlMarkerHits = (html: string) => {
+  const lower = html.toLowerCase();
+  return HTML_MARKERS.filter((m) => lower.includes(m.needle));
+};
 
 const trimTrailingSlash = (value: string): string => {
   let end = value.length;
@@ -121,6 +134,77 @@ const canonicalHref = (value: string): string => {
   }
 };
 
+const originOf = (value: string): string | null => {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+};
+
+const isPair = (candidates: ProviderMatch[]): boolean =>
+  candidates.length === 2 &&
+  candidates.every((c) => c.type === "atlassian" || c.type === "incidentio");
+
+const runProbes = (
+  base: string,
+  entryId: string | undefined,
+  evidence: string[],
+): Effect.Effect<ProviderMatch[]> =>
+  Effect.forEach(
+    PROBES,
+    (probe) => {
+      const endpoint = `${base}${probe.path}`;
+      return probe.validate(endpoint, entryId).pipe(
+        Effect.match({
+          onSuccess: () => ({ probe, endpoint, ok: true }),
+          onFailure: (err: FetchError) => {
+            evidence.push(`${endpoint}: ${describeError(err)}`);
+            return { probe, endpoint, ok: false };
+          },
+        }),
+      );
+    },
+    { concurrency: 3 },
+  ).pipe(
+    Effect.map((probed) =>
+      probed
+        .filter((r) => r.ok)
+        .flatMap((r) => {
+          evidence.push(`validated ${r.endpoint}`);
+          return r.probe.candidates.map((c) => ({
+            ...c,
+            endpoint: r.endpoint,
+          }));
+        }),
+    ),
+  );
+
+// Hostname evidence outranks html markers: a page hosted on a provider domain
+// is unambiguous, while markers can name a competitor in prose.
+const tiebreakPair = (
+  candidates: ProviderMatch[],
+  hits: HostnameHit[],
+  html: string | undefined,
+  evidence: string[],
+): ProviderMatch[] => {
+  const hitProviders = new Set(hits.map((h) => h.provider));
+  const pairHits = candidates.filter((c) => hitProviders.has(c.provider));
+  if (pairHits.length === 1) {
+    evidence.push(`hostname tiebreak: ${pairHits[0].provider}`);
+    return pairHits;
+  }
+  if (html === undefined) return candidates;
+  const markerHits = htmlMarkerHits(html).filter((m) =>
+    candidates.some((c) => c.provider === m.provider),
+  );
+  const markerProviders = new Set(markerHits.map((m) => m.provider));
+  if (markerProviders.size !== 1) return candidates;
+  const pick = markerHits[0];
+  evidence.push(`html marker: ${pick.needle}`);
+  return candidates.filter((c) => c.provider === pick.provider);
+};
+
 export const detectProvider = (args: {
   statusPageUrl: string;
   currentProvider: StatusPageProvider;
@@ -130,29 +214,7 @@ export const detectProvider = (args: {
     const base = probeBase(args.statusPageUrl);
     const evidence: string[] = [];
 
-    const probed = yield* Effect.forEach(
-      PROBES,
-      (probe) => {
-        const endpoint = `${base}${probe.path}`;
-        return probe.validate(endpoint, args.entryId).pipe(
-          Effect.match({
-            onSuccess: () => ({ probe, endpoint, ok: true }),
-            onFailure: (err: FetchError) => {
-              evidence.push(`${endpoint}: ${describeError(err)}`);
-              return { probe, endpoint, ok: false };
-            },
-          }),
-        );
-      },
-      { concurrency: 3 },
-    );
-
-    const candidates: ProviderMatch[] = probed
-      .filter((r) => r.ok)
-      .flatMap((r) => {
-        evidence.push(`validated ${r.endpoint}`);
-        return r.probe.candidates.map((c) => ({ ...c, endpoint: r.endpoint }));
-      });
+    const candidates = yield* runProbes(base, args.entryId, evidence);
 
     // Deliberate trade-off: a validating current provider ends detection, so
     // atlassian↔incidentio label drift goes unflagged — the APIs are identical
@@ -169,17 +231,14 @@ export const detectProvider = (args: {
     const staticHits = hostnameHits(args.statusPageUrl);
     for (const h of staticHits) evidence.push(`hostname matches ${h.domain}`);
 
-    const isPair =
-      candidates.length === 2 &&
-      candidates.every(
-        (c) => c.type === "atlassian" || c.type === "incidentio",
-      );
-
-    let finalUrlHits: typeof staticHits = [];
+    const ambiguous = isPair(candidates);
+    let finalUrlHits: HostnameHit[] = [];
     let matches = candidates;
+    let movedTo: DetectionResult["movedTo"];
+    let page: { text: string; finalUrl: string } | null = null;
 
-    if (isPair || candidates.length === 0) {
-      const page = yield* fetchTextWithUrl({
+    if (ambiguous || candidates.length === 0) {
+      page = yield* fetchTextWithUrl({
         url: args.statusPageUrl,
         fetcherName: "detect",
         entryId: args.entryId,
@@ -193,10 +252,10 @@ export const detectProvider = (args: {
         }),
       );
 
-      if (
+      const redirected =
         page?.finalUrl &&
-        canonicalHref(page.finalUrl) !== canonicalHref(args.statusPageUrl)
-      ) {
+        canonicalHref(page.finalUrl) !== canonicalHref(args.statusPageUrl);
+      if (page && redirected) {
         evidence.push(`final url ${page.finalUrl}`);
         finalUrlHits = hostnameHits(page.finalUrl);
         for (const h of finalUrlHits) {
@@ -204,49 +263,58 @@ export const detectProvider = (args: {
         }
       }
 
-      if (isPair) {
-        const hitProviders = new Set(
-          [...staticHits, ...finalUrlHits].map((h) => h.provider),
+      if (ambiguous) {
+        matches = tiebreakPair(
+          candidates,
+          [...staticHits, ...finalUrlHits],
+          page?.text,
+          evidence,
         );
-        const pairHits = candidates.filter((c) => hitProviders.has(c.provider));
-        const hostnamePick = pairHits.length === 1 ? pairHits[0] : undefined;
-        if (hostnamePick) {
-          matches = [hostnamePick];
-          evidence.push(`hostname tiebreak: ${hostnamePick.provider}`);
-        } else if (page) {
-          const html = page.text.toLowerCase();
-          const markerHits = HTML_MARKERS.filter((m) =>
-            html.includes(m.needle),
-          );
-          const markerPick =
-            new Set(markerHits.map((m) => m.provider)).size === 1
-              ? markerHits[0]
-              : undefined;
-          if (markerPick) {
-            matches = candidates.filter(
-              (c) => c.provider === markerPick.provider,
-            );
-            evidence.push(`html marker: ${markerPick.needle}`);
-          }
+      }
+
+      // Nothing validates here but the page lives elsewhere now: probe the
+      // new origin so a stale status_page_url surfaces as a concrete move.
+      const originMoved =
+        page &&
+        redirected &&
+        originOf(page.finalUrl) !== null &&
+        originOf(page.finalUrl) !== originOf(args.statusPageUrl);
+      if (page && candidates.length === 0 && originMoved) {
+        const movedBase = probeBase(page.finalUrl);
+        const movedCandidates = yield* runProbes(
+          movedBase,
+          args.entryId,
+          evidence,
+        );
+        if (movedCandidates.length > 0) {
+          movedTo = {
+            base: movedBase,
+            matches: isPair(movedCandidates)
+              ? tiebreakPair(movedCandidates, finalUrlHits, page.text, evidence)
+              : movedCandidates,
+          };
         }
       }
     }
 
-    const hostnameSuggestions =
-      candidates.length === 0
-        ? [
-            ...new Set(
-              [...staticHits, ...finalUrlHits]
-                .map((h) => h.provider)
-                .filter((p) => p !== args.currentProvider),
-            ),
-          ]
-        : [];
+    let hostnameSuggestions: StatusPageProvider[] = [];
+    if (candidates.length === 0) {
+      const markerHits = page && !movedTo ? htmlMarkerHits(page.text) : [];
+      for (const m of markerHits) evidence.push(`html marker: ${m.needle}`);
+      hostnameSuggestions = [
+        ...new Set(
+          [...staticHits, ...finalUrlHits, ...markerHits]
+            .map((h) => h.provider)
+            .filter((p) => p !== args.currentProvider),
+        ),
+      ];
+    }
 
     return {
       currentProviderValidated: false,
       matches,
       hostnameSuggestions,
+      ...(movedTo ? { movedTo } : {}),
       evidence,
     };
   });

--- a/packages/status-fetcher/src/detect.ts
+++ b/packages/status-fetcher/src/detect.ts
@@ -280,7 +280,9 @@ export const detectProvider = (args: {
         originOf(page.finalUrl) !== null &&
         originOf(page.finalUrl) !== originOf(args.statusPageUrl);
       if (page && candidates.length === 0 && originMoved) {
-        const movedBase = probeBase(page.finalUrl);
+        // Providers serve their API at the root, so a redirect landing on a
+        // subpath must not carry that path into the probes.
+        const movedBase = originOf(page.finalUrl) ?? probeBase(page.finalUrl);
         const movedCandidates = yield* runProbes(
           movedBase,
           args.entryId,

--- a/packages/status-fetcher/src/fetch.ts
+++ b/packages/status-fetcher/src/fetch.ts
@@ -3,7 +3,22 @@ import type { z } from "zod";
 
 import type { JsonValue } from "./types";
 
-export type FetchErrorKind = "http" | "parse" | "network" | "timeout";
+// "parse": body is not JSON (html, challenge page); "schema": valid JSON our
+// zod schema rejects — the split separates "page moved" from "our schema is stale".
+export type FetchErrorKind =
+  | "http"
+  | "parse"
+  | "schema"
+  | "network"
+  | "timeout";
+
+const KIND_LABELS: Record<FetchErrorKind, string> = {
+  http: "fetch failed",
+  parse: "non-JSON body",
+  schema: "schema mismatch",
+  network: "network error",
+  timeout: "timeout",
+};
 
 type FetchErrorInit = {
   url: string;
@@ -26,7 +41,11 @@ export class FetchError extends Error {
       [init.fetcherName, init.entryId && `(${init.entryId})`]
         .filter(Boolean)
         .join(" ") || "FetchError";
-    const status = init.httpStatus ? `HTTP ${init.httpStatus}` : "fetch failed";
+    const status = init.httpStatus
+      ? `HTTP ${init.httpStatus}`
+      : init.kind
+        ? KIND_LABELS[init.kind]
+        : "fetch failed";
     super(`[${ctx}] ${status}: ${init.url}`, { cause: init.cause });
     this.name = "FetchError";
     this.url = init.url;
@@ -166,7 +185,7 @@ export const fetchJson = <T>(
       Effect.flatMap((json) =>
         Effect.try({
           try: () => opts.schema.parse(json),
-          catch: failWith(opts, "parse"),
+          catch: failWith(opts, "schema"),
         }),
       ),
     ),
@@ -185,7 +204,7 @@ export const fetchJsonWithRaw = <T>(
       Effect.flatMap((raw) =>
         Effect.try({
           try: () => ({ parsed: opts.schema.parse(raw), raw }),
-          catch: failWith(opts, "parse"),
+          catch: failWith(opts, "schema"),
         }),
       ),
     ),

--- a/packages/status-fetcher/src/fetchers/atlassian.ts
+++ b/packages/status-fetcher/src/fetchers/atlassian.ts
@@ -14,6 +14,8 @@ import type {
 import { SEVERITY_LEVELS } from "../types";
 import { inferStatus, urlHostnameEndsWith } from "../utils";
 
+// Statuspage reports "maintenance" as a fifth indicator while a scheduled
+// maintenance is in progress; it is not a severity, so it maps to none.
 export const atlassianResponseSchema = z.object({
   page: z.object({
     id: z.string(),
@@ -23,10 +25,30 @@ export const atlassianResponseSchema = z.object({
     updated_at: z.string().datetime({ offset: true }),
   }),
   status: z.object({
-    indicator: z.enum(SEVERITY_LEVELS),
+    indicator: z.enum([...SEVERITY_LEVELS, "maintenance"]),
     description: z.string(),
   }),
 });
+
+export type AtlassianSummary = z.infer<typeof atlassianResponseSchema>;
+
+export const normalizeAtlassianSummary = (
+  data: AtlassianSummary,
+): StatusResult => {
+  const description = data.status.description;
+  const indicator = data.status.indicator;
+  const severity = indicator === "maintenance" ? "none" : indicator;
+  return {
+    severity,
+    status:
+      indicator === "maintenance"
+        ? "under_maintenance"
+        : inferStatus(description, severity),
+    description,
+    updated_at: new Date(data.page.updated_at).getTime(),
+    timezone: data.page.timezone,
+  };
+};
 
 export class AtlassianFetcher implements StatusFetcher {
   name = "atlassian";
@@ -49,19 +71,7 @@ export class AtlassianFetcher implements StatusFetcher {
       schema: atlassianResponseSchema,
       fetcherName: this.name,
       entryId: entry.id,
-    }).pipe(
-      Effect.map((data) => {
-        const severity = data.status.indicator;
-        const description = data.status.description;
-        return {
-          severity,
-          status: inferStatus(description, severity),
-          description,
-          updated_at: new Date(data.page.updated_at).getTime(),
-          timezone: data.page.timezone,
-        };
-      }),
-    );
+    }).pipe(Effect.map(normalizeAtlassianSummary));
   }
 
   fetchIncidents(

--- a/packages/status-fetcher/src/fetchers/incidentio.ts
+++ b/packages/status-fetcher/src/fetchers/incidentio.ts
@@ -12,10 +12,12 @@ import type {
   StatusResult,
 } from "../types";
 import { SEVERITY_LEVELS } from "../types";
-import { inferStatus, urlHostnameEndsWith } from "../utils";
+import { urlHostnameEndsWith } from "../utils";
+import { normalizeAtlassianSummary } from "./atlassian";
 
 // incident.io status pages expose an Atlassian Statuspage-compatible API, so the
-// summary endpoint returns the same shape AtlassianFetcher consumes.
+// summary endpoint returns the same shape AtlassianFetcher consumes. Kept as
+// its own schema so the two can drift independently.
 const incidentioResponseSchema = z.object({
   page: z.object({
     id: z.string(),
@@ -25,7 +27,7 @@ const incidentioResponseSchema = z.object({
     updated_at: z.string().datetime({ offset: true }),
   }),
   status: z.object({
-    indicator: z.enum(SEVERITY_LEVELS),
+    indicator: z.enum([...SEVERITY_LEVELS, "maintenance"]),
     description: z.string(),
   }),
 });
@@ -52,19 +54,7 @@ export class IncidentioFetcher implements StatusFetcher {
       schema: incidentioResponseSchema,
       fetcherName: this.name,
       entryId: entry.id,
-    }).pipe(
-      Effect.map((data) => {
-        const severity = data.status.indicator;
-        const description = data.status.description;
-        return {
-          severity,
-          status: inferStatus(description, severity),
-          description,
-          updated_at: new Date(data.page.updated_at).getTime(),
-          timezone: data.page.timezone,
-        };
-      }),
-    );
+    }).pipe(Effect.map(normalizeAtlassianSummary));
   }
 
   fetchIncidents(

--- a/packages/status-fetcher/src/fetchers/instatus.ts
+++ b/packages/status-fetcher/src/fetchers/instatus.ts
@@ -84,7 +84,12 @@ export class InstatusFetcher implements StatusFetcher {
   }
 
   private normalize(data: InstatusResponse): StatusResult {
-    const { activeIncidents, activeMaintenances } = data;
+    const { activeIncidents } = data;
+    // Scheduled maintenances ride along in activeMaintenances; their future
+    // start must not become the page's last update.
+    const activeMaintenances = data.activeMaintenances.filter(
+      (m) => m.status !== "NOTSTARTEDYET",
+    );
     const updated_at = latestTimestamp([
       ...activeIncidents.map((i) => i.started),
       ...activeMaintenances.map((m) => m.start),
@@ -102,8 +107,9 @@ export class InstatusFetcher implements StatusFetcher {
           timezone: "UTC",
         };
       case "HASISSUES": {
-        // Worst active incident impact wins; unknown impacts fold to degraded.
-        let worst = { rank: 0, severity: "major", status: "degraded" } as {
+        // Worst active incident impact wins; the fallback is the least severe
+        // so a known impact can only escalate it.
+        let worst = { rank: 0, severity: "minor", status: "degraded" } as {
           rank: number;
           severity: SeverityLevel;
           status: StatusType;

--- a/packages/status-fetcher/src/fetchers/instatus.ts
+++ b/packages/status-fetcher/src/fetchers/instatus.ts
@@ -2,22 +2,63 @@ import { Effect } from "effect";
 import { z } from "zod";
 
 import { type FetchError, fetchJson } from "../fetch";
-import type { StatusFetcher, StatusPageEntry, StatusResult } from "../types";
+import type {
+  SeverityLevel,
+  StatusFetcher,
+  StatusPageEntry,
+  StatusResult,
+  StatusType,
+} from "../types";
 import { urlHostnameEndsWith } from "../utils";
 
+// Public summary.json per https://instatus.com/help/api/public-data. The two
+// arrays are omitted entirely when empty.
+const instatusIncidentSchema = z.object({
+  name: z.string(),
+  started: z.string().optional(),
+  status: z.string().optional(),
+  impact: z.string().optional(),
+  url: z.string().optional(),
+});
+
+const instatusMaintenanceSchema = z.object({
+  name: z.string(),
+  start: z.string().optional(),
+  status: z.string().optional(),
+  duration: z.string().optional(),
+  url: z.string().optional(),
+});
+
 export const instatusResponseSchema = z.object({
-  activeIncidents: z.array(z.unknown()),
-  activeMaintenances: z.array(z.unknown()),
-  status: z.object({
-    text: z.string(),
-    type: z.enum(["UP", "HASISSUES", "UNDERMAINTENANCE"]),
-  }),
   page: z.object({
     name: z.string(),
     url: z.string(),
-    updated: z.string(),
+    status: z.enum(["UP", "HASISSUES", "UNDERMAINTENANCE"]),
   }),
+  activeIncidents: z.array(instatusIncidentSchema).optional().default([]),
+  activeMaintenances: z.array(instatusMaintenanceSchema).optional().default([]),
 });
+
+type InstatusResponse = z.infer<typeof instatusResponseSchema>;
+
+const IMPACT_RANK: Record<
+  string,
+  { rank: number; severity: SeverityLevel; status: StatusType }
+> = {
+  MAJOROUTAGE: { rank: 3, severity: "critical", status: "major_outage" },
+  PARTIALOUTAGE: { rank: 2, severity: "major", status: "partial_outage" },
+  DEGRADEDPERFORMANCE: { rank: 1, severity: "minor", status: "degraded" },
+};
+
+const latestTimestamp = (values: (string | undefined)[]): number => {
+  let latest = 0;
+  for (const value of values) {
+    if (!value) continue;
+    const ms = new Date(value).getTime();
+    if (Number.isFinite(ms) && ms > latest) latest = ms;
+  }
+  return latest || Date.now();
+};
 
 export class InstatusFetcher implements StatusFetcher {
   name = "instatus";
@@ -39,33 +80,56 @@ export class InstatusFetcher implements StatusFetcher {
       schema: instatusResponseSchema,
       fetcherName: this.name,
       entryId: entry.id,
-    }).pipe(
-      Effect.map((data) => {
-        const mapping = this.mapInstatusType(data.status.type);
-        return {
-          severity: mapping.severity,
-          status: mapping.status,
-          description: data.status.text,
-          updated_at: new Date(data.page.updated).getTime(),
-          timezone: "UTC",
-        };
-      }),
-    );
+    }).pipe(Effect.map((data) => this.normalize(data)));
   }
 
-  private mapInstatusType(type: "UP" | "HASISSUES" | "UNDERMAINTENANCE"): {
-    severity: "none" | "minor" | "major";
-    status: "operational" | "degraded" | "under_maintenance";
-  } {
-    switch (type) {
-      case "UP":
-        return { severity: "none", status: "operational" };
-      case "HASISSUES":
-        return { severity: "major", status: "degraded" };
+  private normalize(data: InstatusResponse): StatusResult {
+    const { activeIncidents, activeMaintenances } = data;
+    const updated_at = latestTimestamp([
+      ...activeIncidents.map((i) => i.started),
+      ...activeMaintenances.map((m) => m.start),
+    ]);
+
+    switch (data.page.status) {
       case "UNDERMAINTENANCE":
-        return { severity: "none", status: "under_maintenance" };
+        return {
+          severity: "none",
+          status: "under_maintenance",
+          description:
+            activeMaintenances.map((m) => m.name).join(", ") ||
+            "Under Maintenance",
+          updated_at,
+          timezone: "UTC",
+        };
+      case "HASISSUES": {
+        // Worst active incident impact wins; unknown impacts fold to degraded.
+        let worst = { rank: 0, severity: "major", status: "degraded" } as {
+          rank: number;
+          severity: SeverityLevel;
+          status: StatusType;
+        };
+        for (const incident of activeIncidents) {
+          const mapped = IMPACT_RANK[incident.impact ?? ""];
+          if (mapped && mapped.rank > worst.rank) worst = mapped;
+        }
+        return {
+          severity: worst.severity,
+          status: worst.status,
+          description:
+            activeIncidents.map((i) => i.name).join(", ") ||
+            "Experiencing issues",
+          updated_at,
+          timezone: "UTC",
+        };
+      }
       default:
-        return { severity: "none", status: "operational" };
+        return {
+          severity: "none",
+          status: "operational",
+          description: "All Systems Operational",
+          updated_at,
+          timezone: "UTC",
+        };
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

