### PR TITLE
chore: upgrade deno to 2.9.6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 🦕 Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.9.4
+          deno-version: 2.9.6
 
       - name: 📥 Download deps
         run: pnpm install

--- a/.github/workflows/dx.yml
+++ b/.github/workflows/dx.yml
@@ -44,7 +44,7 @@ jobs:
       - name: 🦕 Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.9.4
+          deno-version: 2.9.6
 
       - name: 🔥  DX task
         run: pnpm dx

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -29,7 +29,7 @@ jobs:
       - name: 🦕 Install deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.9.4
+          deno-version: 2.9.6
 
       - name: 📥 Download deps
         run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: 🦕 Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.9.4
+          deno-version: 2.9.6
 
       - name: 📥 Download deps
         run: pnpm install

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -3,9 +3,9 @@
 # See https://github.com/lenra-io/dofigen
 
 # install
-FROM node@sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc AS install
+FROM node@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS install
 LABEL \
-    org.opencontainers.image.base.digest="sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc" \
+    org.opencontainers.image.base.digest="sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553" \
     org.opencontainers.image.base.name="docker.io/node:24-slim" \
     org.opencontainers.image.stage="install"
 WORKDIR /app/
@@ -52,10 +52,10 @@ pnpm install --prod --frozen-lockfile --filter=@openstatus/server... --loglevel 
 EOF
 
 # build
-FROM denoland/deno@sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62 AS build
+FROM denoland/deno@sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d AS build
 LABEL \
-    org.opencontainers.image.base.digest="sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62" \
-    org.opencontainers.image.base.name="docker.io/denoland/deno:2.9.2" \
+    org.opencontainers.image.base.digest="sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d" \
+    org.opencontainers.image.base.name="docker.io/denoland/deno:2.9.6" \
     org.opencontainers.image.stage="build"
 ENV NODE_ENV="production"
 WORKDIR /app/apps/server

--- a/apps/server/dofigen.lock
+++ b/apps/server/dofigen.lock
@@ -13,11 +13,11 @@ effective: |
     build:
       fromImage:
         path: denoland/deno
-        digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
+        digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
       label:
-        org.opencontainers.image.base.name: docker.io/denoland/deno:2.9.2
-        org.opencontainers.image.base.digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
+        org.opencontainers.image.base.name: docker.io/denoland/deno:2.9.6
         org.opencontainers.image.stage: build
+        org.opencontainers.image.base.digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
       workdir: /app/apps/server
       env:
         NODE_ENV: production
@@ -43,9 +43,9 @@ effective: |
     install:
       fromImage:
         path: node
-        digest: sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
+        digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
       label:
-        org.opencontainers.image.base.digest: sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
+        org.opencontainers.image.base.digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
         org.opencontainers.image.stage: install
         org.opencontainers.image.base.name: docker.io/node:24-slim
       workdir: /app/
@@ -131,13 +131,13 @@ effective: |
     path: hi/curl
     digest: sha256:848b81ab5d5e55371d7193fd4f1ea7b605d14dbb039344ffad34a4c1f0d880f4
   label:
-    org.opencontainers.image.title: OpenStatus Server
+    org.opencontainers.image.base.digest: sha256:848b81ab5d5e55371d7193fd4f1ea7b605d14dbb039344ffad34a4c1f0d880f4
     io.dofigen.version: 2.8.0
-    org.opencontainers.image.authors: OpenStatus Team
     org.opencontainers.image.description: REST API server with Hono framework for OpenStatus
+    org.opencontainers.image.authors: OpenStatus Team
+    org.opencontainers.image.title: OpenStatus Server
     org.opencontainers.image.vendor: OpenStatus
     org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
-    org.opencontainers.image.base.digest: sha256:848b81ab5d5e55371d7193fd4f1ea7b605d14dbb039344ffad34a4c1f0d880f4
   user:
     user: '1000'
     group: '1000'
@@ -162,14 +162,14 @@ images:
     library:
       node:
         24-slim:
-          digest: sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
+          digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
     denoland:
       deno:
-        2.9.2:
-          digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
+        2.9.6:
+          digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
 resources:
   dofigen.yml:
-    hash: 95e3bf743a7d33783733fdb18f4bc95dff243d10cfa99f99ad7a2ee464ffc9bf
+    hash: 154835eeea31d4f8058dfc7438b87e2ac4321f15c20201c46ebd6a14878c0172
     content: |
       # Files to exclude from Docker context
       ignore:
@@ -234,7 +234,7 @@ resources:
 
         # Stage 2: Build application (compile to binary with Deno)
         build:
-          fromImage: denoland/deno:2.9.2
+          fromImage: denoland/deno:2.9.6
           workdir: /app/apps/server
           labels:
             org.opencontainers.image.stage: build

--- a/apps/server/dofigen.yml
+++ b/apps/server/dofigen.yml
@@ -61,7 +61,7 @@ builders:
 
   # Stage 2: Build application (compile to binary with Deno)
   build:
-    fromImage: denoland/deno:2.9.2
+    fromImage: denoland/deno:2.9.6
     workdir: /app/apps/server
     labels:
       org.opencontainers.image.stage: build

--- a/apps/workflows/Dockerfile
+++ b/apps/workflows/Dockerfile
@@ -3,9 +3,9 @@
 # See https://github.com/lenra-io/dofigen
 
 # install
-FROM node@sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc AS install
+FROM node@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS install
 LABEL \
-    org.opencontainers.image.base.digest="sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc" \
+    org.opencontainers.image.base.digest="sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553" \
     org.opencontainers.image.base.name="docker.io/node:24-slim" \
     org.opencontainers.image.stage="install"
 WORKDIR /app/
@@ -49,10 +49,10 @@ pnpm install --prod --frozen-lockfile --filter=@openstatus/workflows... --loglev
 EOF
 
 # build
-FROM denoland/deno@sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62 AS build
+FROM denoland/deno@sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d AS build
 LABEL \
-    org.opencontainers.image.base.digest="sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62" \
-    org.opencontainers.image.base.name="docker.io/denoland/deno:2.9.2" \
+    org.opencontainers.image.base.digest="sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d" \
+    org.opencontainers.image.base.name="docker.io/denoland/deno:2.9.6" \
     org.opencontainers.image.stage="build"
 ENV NODE_ENV="production"
 WORKDIR /app/apps/workflows

--- a/apps/workflows/dofigen.lock
+++ b/apps/workflows/dofigen.lock
@@ -15,11 +15,11 @@ effective: |
     install:
       fromImage:
         path: node
-        digest: sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
+        digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
       label:
-        org.opencontainers.image.base.digest: sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
-        org.opencontainers.image.stage: install
         org.opencontainers.image.base.name: docker.io/node:24-slim
+        org.opencontainers.image.base.digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
+        org.opencontainers.image.stage: install
       workdir: /app/
       run:
       - corepack enable pnpm
@@ -94,11 +94,11 @@ effective: |
     build:
       fromImage:
         path: denoland/deno
-        digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
+        digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
       label:
-        org.opencontainers.image.base.name: docker.io/denoland/deno:2.9.2
+        org.opencontainers.image.base.name: docker.io/denoland/deno:2.9.6
+        org.opencontainers.image.base.digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
         org.opencontainers.image.stage: build
-        org.opencontainers.image.base.digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
       workdir: /app/apps/workflows
       env:
         NODE_ENV: production
@@ -131,13 +131,13 @@ effective: |
     path: hi/curl
     digest: sha256:848b81ab5d5e55371d7193fd4f1ea7b605d14dbb039344ffad34a4c1f0d880f4
   label:
-    org.opencontainers.image.base.digest: sha256:848b81ab5d5e55371d7193fd4f1ea7b605d14dbb039344ffad34a4c1f0d880f4
-    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
-    org.opencontainers.image.authors: OpenStatus Team
     org.opencontainers.image.vendor: OpenStatus
     org.opencontainers.image.title: OpenStatus Workflows
     org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
+    org.opencontainers.image.description: Background job processing and probe scheduling for OpenStatus
     io.dofigen.version: 2.8.0
+    org.opencontainers.image.authors: OpenStatus Team
+    org.opencontainers.image.base.digest: sha256:848b81ab5d5e55371d7193fd4f1ea7b605d14dbb039344ffad34a4c1f0d880f4
   user:
     user: '1000'
     group: '1000'
@@ -164,17 +164,17 @@ effective: |
     retries: 3
 images:
   docker.io:
-    denoland:
-      deno:
-        2.9.2:
-          digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
     library:
       node:
         24-slim:
-          digest: sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
+          digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
+    denoland:
+      deno:
+        2.9.6:
+          digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
 resources:
   dofigen.yml:
-    hash: 614452ec2a7099d450629d841ea4c89e5b10bef8776c82581d57e7b7354fc2bd
+    hash: 1ff9b3016cac0c9d641f1365e1e9cd0ea262691c32b90ba54dfe46a5eed64c5c
     content: |
       ignore:
         - node_modules
@@ -237,7 +237,7 @@ resources:
 
         # Stage 4: Build application (compile to binary with Deno)
         build:
-          fromImage: denoland/deno:2.9.2
+          fromImage: denoland/deno:2.9.6
           workdir: /app/apps/workflows
           labels:
             org.opencontainers.image.stage: build

--- a/apps/workflows/dofigen.yml
+++ b/apps/workflows/dofigen.yml
@@ -59,7 +59,7 @@ builders:
 
   # Stage 4: Build application (compile to binary with Deno)
   build:
-    fromImage: denoland/deno:2.9.2
+    fromImage: denoland/deno:2.9.6
     workdir: /app/apps/workflows
     labels:
       org.opencontainers.image.stage: build

--- a/devbox.json
+++ b/devbox.json
@@ -3,7 +3,7 @@
   "packages": [
     "turso-cli@1.0.15",
     "nodejs@24.12.0",
-    "deno@2.9.4",
+    "deno@2.9.5",
     "bun@1.3.13",
     "sqld@0.24.32"
   ],

--- a/devbox.lock
+++ b/devbox.lock
@@ -49,53 +49,65 @@
         }
       }
     },
-    "deno@2.9.4": {
-      "last_modified": "2026-08-01T16:34:20Z",
-      "resolved": "github:NixOS/nixpkgs/a5cbcfe954791221bfffe2307f7d1a1bf61a871e#deno",
+    "deno@2.9.5": {
+      "last_modified": "2026-08-27T07:16:00Z",
+      "resolved": "github:NixOS/nixpkgs/c27cdad491a991b11ed731760aa2ef8db0cb0410#deno",
       "source": "devbox-search",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/lmqwp7gr0hapgh48vwfkvzd9as1qzsp2-deno-2.9.4",
+              "path": "/nix/store/94pdxnq7cfdymzmr19144spl0rp34mjg-deno-2.9.5",
               "default": true
             },
             {
               "name": "denort",
-              "path": "/nix/store/g0yd5grzazxkfgclcfbqxvqy1b8c6jy8-deno-2.9.4-denort"
+              "path": "/nix/store/ci5jh3b5yr2dz36q8qb9qs4za2nkkgz3-deno-2.9.5-denort"
+            },
+            {
+              "name": "libdenort",
+              "path": "/nix/store/lcxc1mm8hz5i9jhdpv0cb233nxf9r64g-deno-2.9.5-libdenort"
             }
           ],
-          "store_path": "/nix/store/lmqwp7gr0hapgh48vwfkvzd9as1qzsp2-deno-2.9.4"
+          "store_path": "/nix/store/94pdxnq7cfdymzmr19144spl0rp34mjg-deno-2.9.5"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/gskl25gjd0aqrz432ahapzyq45mfim0l-deno-2.9.4",
+              "path": "/nix/store/8rzh2fpa3lwqzx9iiz07qbk3b7lsjniw-deno-2.9.5",
               "default": true
             },
             {
               "name": "denort",
-              "path": "/nix/store/dm9j5iismy4bm9vch0z4g0ir6yg3k9bl-deno-2.9.4-denort"
+              "path": "/nix/store/2h16nirjr5ddd2bz7vxd19q0lawl5cd3-deno-2.9.5-denort"
+            },
+            {
+              "name": "libdenort",
+              "path": "/nix/store/8hn63ayil0mk81a7mim21qh4155n3r6j-deno-2.9.5-libdenort"
             }
           ],
-          "store_path": "/nix/store/gskl25gjd0aqrz432ahapzyq45mfim0l-deno-2.9.4"
+          "store_path": "/nix/store/8rzh2fpa3lwqzx9iiz07qbk3b7lsjniw-deno-2.9.5"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4",
+              "path": "/nix/store/7hk2ax3hgs4152cdqsqcq4lfq1a2kla6-deno-2.9.5",
               "default": true
             },
             {
+              "name": "libdenort",
+              "path": "/nix/store/3m3rdq6vl231165fycmk5rjc48anrzxi-deno-2.9.5-libdenort"
+            },
+            {
               "name": "denort",
-              "path": "/nix/store/0bgyyi7jcjlbjmf55if1xv7dk64qq2vr-deno-2.9.4-denort"
+              "path": "/nix/store/180ds5dqaynm1k7c1j6s5lwlak943z9k-deno-2.9.5-denort"
             }
           ],
-          "store_path": "/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4"
+          "store_path": "/nix/store/7hk2ax3hgs4152cdqsqcq4lfq1a2kla6-deno-2.9.5"
         }
       }
     },

--- a/packages/db/Dockerfile
+++ b/packages/db/Dockerfile
@@ -3,9 +3,9 @@
 # See https://github.com/lenra-io/dofigen
 
 # install
-FROM node@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS install
+FROM node@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS install
 LABEL \
-    org.opencontainers.image.base.digest="sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d" \
+    org.opencontainers.image.base.digest="sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553" \
     org.opencontainers.image.base.name="docker.io/node:24-slim" \
     org.opencontainers.image.stage="install"
 WORKDIR /app/
@@ -26,12 +26,12 @@ pnpm install --prod --frozen-lockfile --filter=@openstatus/db... --loglevel debu
 EOF
 
 # runtime
-FROM denoland/deno@sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62 AS runtime
+FROM denoland/deno@sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d AS runtime
 LABEL \
     io.dofigen.version="2.8.0" \
     org.opencontainers.image.authors="OpenStatus Team" \
-    org.opencontainers.image.base.digest="sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62" \
-    org.opencontainers.image.base.name="docker.io/denoland/deno:2.9.2" \
+    org.opencontainers.image.base.digest="sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d" \
+    org.opencontainers.image.base.name="docker.io/denoland/deno:2.9.6" \
     org.opencontainers.image.description="One-shot database migration runner for OpenStatus" \
     org.opencontainers.image.source="https://github.com/openstatusHQ/openstatus" \
     org.opencontainers.image.title="OpenStatus DB Migrate" \

--- a/packages/db/dofigen.lock
+++ b/packages/db/dofigen.lock
@@ -5,11 +5,11 @@ effective: |
     install:
       fromImage:
         path: node
-        digest: sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d
+        digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
       label:
+        org.opencontainers.image.base.digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
         org.opencontainers.image.base.name: docker.io/node:24-slim
         org.opencontainers.image.stage: install
-        org.opencontainers.image.base.digest: sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d
       workdir: /app/
       run:
       - corepack enable pnpm
@@ -37,16 +37,16 @@ effective: |
         source: packages/utils/package.json
   fromImage:
     path: denoland/deno
-    digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
+    digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
   label:
     org.opencontainers.image.vendor: OpenStatus
-    org.opencontainers.image.title: OpenStatus DB Migrate
-    org.opencontainers.image.base.digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
-    org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
     org.opencontainers.image.description: One-shot database migration runner for OpenStatus
-    org.opencontainers.image.base.name: docker.io/denoland/deno:2.9.2
-    io.dofigen.version: 2.8.0
+    org.opencontainers.image.title: OpenStatus DB Migrate
+    org.opencontainers.image.source: https://github.com/openstatusHQ/openstatus
     org.opencontainers.image.authors: OpenStatus Team
+    org.opencontainers.image.base.digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
+    org.opencontainers.image.base.name: docker.io/denoland/deno:2.9.6
+    io.dofigen.version: 2.8.0
   workdir: /app/packages/db
   env:
     DENO_DIR: /tmp/deno-dir
@@ -85,15 +85,15 @@ images:
   docker.io:
     denoland:
       deno:
-        2.9.2:
-          digest: sha256:69a9f3033e3f381770452648b1cbf4ae96ea409f7ef24f30afeff3d380705f62
+        2.9.6:
+          digest: sha256:2014dc167ece617ef7e7ba40631ac2234c59e75ce693e7cc2dc2602b3c87859d
     library:
       node:
         24-slim:
-          digest: sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d
+          digest: sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
 resources:
   dofigen.yml:
-    hash: cccac38ef65a7631285c314a64bd31a90785166f5305f5860e092f89d3fa6880
+    hash: b1986271c968bdb2d3e6a3a72b718f67e15c83f2230e4094c8454dba5acb8203
     content: |
       ignore:
         - node_modules
@@ -121,7 +121,7 @@ resources:
 
       # One-shot migration runner: drizzle's migrator reads drizzle/ from disk at
       # runtime, so the image ships source + node_modules instead of a compiled binary.
-      fromImage: denoland/deno:2.9.2
+      fromImage: denoland/deno:2.9.6
       workdir: /app/packages/db
 
       labels:

--- a/packages/db/dofigen.yml
+++ b/packages/db/dofigen.yml
@@ -24,7 +24,7 @@ builders:
 
 # One-shot migration runner: drizzle's migrator reads drizzle/ from disk at
 # runtime, so the image ships source + node_modules instead of a compiled binary.
-fromImage: denoland/deno:2.9.2
+fromImage: denoland/deno:2.9.6
 workdir: /app/packages/db
 
 labels:


### PR DESCRIPTION
Bump the CI toolchain (denoland/setup-deno) and the container base images from 2.9.4/2.9.2 to 2.9.6. devbox stays one patch behind at 2.9.5 because nixpkgs has not packaged 2.9.6 yet.




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/openstatusHQ/openstatus/pull/2695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

